### PR TITLE
Refuse monitor() of non-monitorable query

### DIFF
--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -360,6 +360,9 @@ function typeCheckMonitor(ast) {
                 throw new TypeError('Invalid field name ' + arg);
         });
     }
+    if (!ast.schema.is_monitorable)
+        throw new TypeError('monitor() applied to a non-monitorable query');
+
     return Promise.resolve();
 }
 

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1154,3 +1154,16 @@ now => p1(p_foo = "two");
 // monitor of non-monitorable query
 
 monitor (@com.thecatapi.get()) => notify;
+
+====
+
+// ** typecheck: expect TypeError **
+// propagating monitorable bit from table joins
+
+monitor (@com.bing.web_search() join @com.thecatapi.get()) => notify;
+
+====
+
+// propagating monitorable bit from table joins, part 2
+
+monitor (@com.bing.web_search() join @com.twitter.search()) => notify;

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1147,3 +1147,10 @@ let procedure p1(p_foo : String) := {
 };
 now => p1(p_foo = "one");
 now => p1(p_foo = "two");
+
+====
+
+// ** typecheck: expect TypeError **
+// monitor of non-monitorable query
+
+monitor (@com.thecatapi.get()) => notify;

--- a/test/test_compiler.js
+++ b/test/test_compiler.js
@@ -1364,7 +1364,7 @@ const TEST_CASES = [
 
   [`executor = "1234"^^tt:contact : {
     class @__dyn_0 extends @org.thingpedia.builtin.thingengine.remote {
-        query receive (in req __principal : Entity(tt:contact), in req __program_id : Entity(tt:program_id), in req __flow : Number, out __kindChannel : Entity(tt:function), out interval : Measure(ms));
+        monitorable list query receive (in req __principal : Entity(tt:contact), in req __program_id : Entity(tt:program_id), in req __flow : Number, out __kindChannel : Entity(tt:function), out interval : Measure(ms));
     }
     monitor @__dyn_0.receive(__principal="mock-account:12345678"^^tt:contact("me"), __program_id=$event.program_id, __flow=0)  => @security-camera.set_power(power=enum(on)) ;
 }`, [`"use strict";

--- a/test/thingpedia.json
+++ b/test/thingpedia.json
@@ -1861,7 +1861,7 @@
                         false
                     ],
                     "is_list": true,
-                    "is_monitorable": true,
+                    "is_monitorable": false,
                     "confirmation": "cat pictures",
                     "confirmation_remote": "cat pictures",
                     "doc": "get `count` many cat pictures",


### PR DESCRIPTION
I think at some point we were not doing this for compatibility, because Thingpedia's monitorable bit was not always correct. Nowadays it is correct though (except for thingtalk's own thingpedia.json, which is an old snapshot), so we can enable this check.

Fixes #66 