### PR TITLE
Test and fix AST cloning

### DIFF
--- a/lib/ast/class_def.js
+++ b/lib/ast/class_def.js
@@ -74,9 +74,12 @@ class ClassDef extends Statement {
         Object.assign(annotations, this.annotations);
         const imports = this.imports.map((i) => i.clone());
 
-        const classDef = new ClassDef(this.kind, this.extends, queries, actions, imports, metadata, annotations);
+        const classDef = new ClassDef(this.kind, this.extends, queries, actions, imports, metadata, annotations,
+            this.is_abstract);
         // adjust parent pointers to point to the clone, not the original class
         classDef._adjustParentPointers();
+
+        return classDef;
     }
 
     get loader() {

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -311,7 +311,12 @@ class Declaration extends Statement {
     clone() {
         const newArgs = {};
         Object.assign(newArgs, this.args);
-        return new Declaration(this.name, this.type, newArgs, this.value.clone());
+
+        const newMetadata = {};
+        Object.assign(newMetadata, this.metadata);
+        const newAnnotations = {};
+        Object.assign(newAnnotations, this.annotations);
+        return new Declaration(this.name, this.type, newArgs, this.value.clone(), newMetadata, newAnnotations);
     }
 }
 Declaration.prototype.isDeclaration = true;

--- a/test/test_grammar.js
+++ b/test/test_grammar.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const assert = require('assert');
 const fs = require('fs');
 
 const AppGrammar = require('../lib/grammar_api');
@@ -14,8 +15,9 @@ function main() {
         console.log('# Test Case ' + (i+1));
 
         code = code.trim();
+        let ast;
         try {
-            var ast = AppGrammar.parse(code);
+            ast = AppGrammar.parse(code);
             //console.log(String(ast.statements));
         } catch(e) {
             console.error('Parsing failed');
@@ -24,8 +26,9 @@ function main() {
             return;
         }
 
+        let codegenned;
         try {
-            var codegenned = prettyprint(ast, true);
+            codegenned = prettyprint(ast, true);
             AppGrammar.parse(codegenned);
 
             if (debug) {
@@ -36,10 +39,15 @@ function main() {
                 console.log('====');
                 console.log();
             }
+
+            const ast2 = ast.clone();
+            const codegenned2 = prettyprint(ast2, true);
+            assert(ast !== ast2);
+            assert.strictEqual(codegenned2, codegenned);
         } catch(e) {
             console.error('Codegen failed');
             console.error('AST:');
-            console.error(String(ast));
+            console.error(ast);
             console.error('Codegenned:');
             console.error(codegenned);
             console.error('====\nCode:');


### PR DESCRIPTION
Cloning of AST node is used by Genie's construct templates when they mutate an AST, as a quick way to produce a new AST with small changes.

Cloning is usually implemented by `adt`, but for native classes we do it by hand, and of course bugs.

Fixes #63 