### PR TITLE
RFC: Add the bookkeeping language to ThingTalk

### DIFF
--- a/lib/ast/api.js
+++ b/lib/ast/api.js
@@ -21,7 +21,12 @@ const { isUnaryStreamToStreamOp,
         isUnaryStreamToTableOp,
         isUnaryTableToStreamOp } = require('../utils');
 const { optimizeFilter, optimizeProgram } = require('../optimize');
-let { typeCheckFilter, typeCheckProgram, typeCheckExample, typeCheckPermissionRule, typeCheckMeta } = require('../typecheck');
+let { typeCheckFilter,
+      typeCheckProgram,
+      typeCheckExample,
+      typeCheckPermissionRule,
+      typeCheckMeta,
+      typeCheckBookkeeping } = require('../typecheck');
 
 const InvocationProto = Object.getPrototypeOf(new Ast.Invocation(Ast.Selector.Builtin, 'notify', [], null));
 const DeclarationProto = Ast.Statement.Declaration.prototype;
@@ -110,6 +115,8 @@ Ast.BooleanExpression.prototype.typecheck = function(schema, scope, schemas, cla
 };
 
 Ast.Input.prototype.typecheck = function(schemas, getMeta = false) {
+    if (this.isBookkeeping)
+        return typeCheckBookkeeping(this.intent).then(() => this);
     if (this.isProgram)
         return typeCheckProgram(this, schemas, getMeta).then(() => this);
     else if (this.isPermissionRule)

--- a/lib/ast/bookkeeping.js
+++ b/lib/ast/bookkeeping.js
@@ -27,6 +27,8 @@ Input.Bookkeeping = BookkeepingInput;
 BookkeepingInput.prototype.isBookkeeping = true;
 
 const BookkeepingSpecialTypes = [
+    'yes',
+    'no',
     'failed',
     'train',
     'back', // go back / go to the previous page

--- a/lib/ast/bookkeeping.js
+++ b/lib/ast/bookkeeping.js
@@ -1,0 +1,50 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingTalk
+//
+// Copyright 2015-2016 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const adt = require('adt');
+
+const { Input, BooleanExpression } = require('./program');
+const { Value } = require('./values');
+
+class BookkeepingInput extends Input {
+    constructor(intent) {
+        super();
+        this.intent = intent;
+    }
+}
+Input.Bookkeeping = BookkeepingInput;
+BookkeepingInput.prototype.isBookkeeping = true;
+
+const BookkeepingIntent = adt.data({
+    Failed: { command: adt.only(Object, null) },
+    Train: { command: adt.only(Object, null), fallbacks: adt.only(Array, null) },
+    Back: null, // go back / go to the previous page
+    More: null, // show more results / go to the next page
+    Empty: null, // default trigger/action, in make dialog
+    Debug: null,
+    Maybe: null, // "yes with filters", for permission grant
+    NeverMind: null, // cancel the current task
+    Stop: null, // cancel the current task, quietly
+    Help: null, // ask for contextual help, or start a new task
+    Make: null, // reset and start a new task
+    WakeUp: null, // do nothing and wake up the screen
+
+    Example: { utterance: adt.only(String), targetCode: adt.only(String) },
+    CommandList: { device: adt.only(String, null), category: adt.only(String) },
+
+    // on the chopping block after the contextual work is done...
+    Answer: { value: adt.only(Value, Number) },
+    Predicate: { predicate: adt.only(BooleanExpression) },
+});
+
+module.exports = {
+    BookkeepingIntent
+};

--- a/lib/ast/bookkeeping.js
+++ b/lib/ast/bookkeeping.js
@@ -19,32 +19,42 @@ class BookkeepingInput extends Input {
         super();
         this.intent = intent;
     }
+
+    *iteratePrimitives() {}
+    *iterateSlots(scope) {}
 }
 Input.Bookkeeping = BookkeepingInput;
 BookkeepingInput.prototype.isBookkeeping = true;
 
-const BookkeepingIntent = adt.data({
-    Failed: { command: adt.only(Object, null) },
-    Train: { command: adt.only(Object, null), fallbacks: adt.only(Array, null) },
-    Back: null, // go back / go to the previous page
-    More: null, // show more results / go to the next page
-    Empty: null, // default trigger/action, in make dialog
-    Debug: null,
-    Maybe: null, // "yes with filters", for permission grant
-    NeverMind: null, // cancel the current task
-    Stop: null, // cancel the current task, quietly
-    Help: null, // ask for contextual help, or start a new task
-    Make: null, // reset and start a new task
-    WakeUp: null, // do nothing and wake up the screen
+const BookkeepingSpecialTypes = [
+    'failed',
+    'train',
+    'back', // go back / go to the previous page
+    'more', // show more results / go to the next page
+    'empty', // default trigger/action, in make dialog
+    'debug',
+    'maybe', // "yes with filters", for permission grant
+    'nevermind', // cancel the current task
+    'stop', // cancel the current task, quietly
+    'help', // ask for contextual help, or start a new task
+    'makerule', // reset and start a new task
+    'wakeup', // do nothing and wake up the screen
+];
 
-    Example: { utterance: adt.only(String), targetCode: adt.only(String) },
-    CommandList: { device: adt.only(String, null), category: adt.only(String) },
+const BookkeepingIntent = adt.data({
+    Special: {
+        type: adt.only(String)
+    },
+    Choice: { value: adt.only(Number) },
+
+    CommandList: { device: adt.only(Value), category: adt.only(String) },
 
     // on the chopping block after the contextual work is done...
-    Answer: { value: adt.only(Value, Number) },
+    Answer: { value: adt.only(Value) },
     Predicate: { predicate: adt.only(BooleanExpression) },
 });
 
 module.exports = {
+    BookkeepingSpecialTypes,
     BookkeepingIntent
 };

--- a/lib/ast/bookkeeping.js
+++ b/lib/ast/bookkeeping.js
@@ -20,6 +20,10 @@ class BookkeepingInput extends Input {
         this.intent = intent;
     }
 
+    clone() {
+        return new BookkeepingInput(this.intent.clone());
+    }
+
     *iteratePrimitives() {}
     *iterateSlots(scope) {}
 }

--- a/lib/ast/index.js
+++ b/lib/ast/index.js
@@ -15,6 +15,7 @@ const FunctionDefs = require('./function_def');
 const ClassDefs = require('./class_def');
 const Values = require('./values');
 const Programs = require('./program');
+const Bookkeepings = require('./bookkeeping');
 
 adt.nativeClone = function nativeClone(x) {
     if (x === null || x === undefined)
@@ -33,5 +34,5 @@ adt.nativeClone = function nativeClone(x) {
     return x;
 };
 
-Object.assign(module.exports, FunctionDefs, ClassDefs, Values, Programs);
+Object.assign(module.exports, FunctionDefs, ClassDefs, Values, Programs, Bookkeepings);
 require('./api');

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -846,6 +846,68 @@ class Describer {
             }
         }
     }
+
+    _describeSpecial(specialType) {
+        switch (specialType) {
+            case 'yes':
+                return this._("yes");
+            case 'no':
+                return this._("no");
+            case 'failed':
+                return this._("I did not understand");
+            case 'train':
+                return this._("train me again");
+            case 'back':
+                return this._("go back");
+            case 'more':
+                return this._("show more results");
+            case 'empty':
+                return this._("no action");
+            case 'debug':
+                return this._("show debugging information");
+            case 'maybe':
+                return this._("maybe");
+            case 'nevermind':
+                return this._("cancel");
+            case 'stop':
+                return this._("stop");
+            case 'help':
+                return this._("help");
+            case 'makerule':
+                return this._("make a new command");
+            case 'wakeup':
+                return this._("wake up");
+            default:
+                return clean(specialType);
+        }
+    }
+
+    _describeBookkeeping(input) {
+        const intent = input.intent;
+        if (intent.isSpecial)
+            return this._describeSpecial(intent.type);
+        else if (intent.isCommandList)
+            return this._("list the commands of %s, in category %s").format(this.describeArg(intent.device), clean(intent.category));
+        else if (intent.isChoice)
+            return this._("choice number %d").format(intent.value+1);
+        else if (intent.isAnswer)
+            return this.describeArg(intent.value);
+        else if (intent.isPredicate)
+            return this.describeFilter(intent.predicate);
+        else
+            throw new TypeError();
+    }
+
+    describe(input) {
+        if (input.isProgram)
+            return this.describeProgram(input);
+        else if (input.isPermissionRule)
+            return this.describePermissionRule(input);
+        else if (input.isBookkeeping)
+            return this._describeBookkeeping(input);
+        else
+            throw new TypeError(`Unrecognized input type ${input}`);
+    }
 }
 
 function capitalize(str) {

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -18,7 +18,7 @@ const FormatUtils = require('./format_utils');
 const { Currency } = require('./builtin/values');
 
 class Describer {
-    constructor(gettext, locale, timezone) {
+    constructor(gettext, locale = gettext.locale, timezone) {
         this._ = gettext.dgettext.bind(gettext, 'thingtalk');
         this.locale = locale;
         this.timezone = timezone;

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -109,7 +109,26 @@
     }
 }
 
-input = permission_rule / short_remote_program / wrapped_program / simple_program
+input = bookkeeping_stmt / permission_rule / short_remote_program / wrapped_program / simple_program
+
+bookkeeping_stmt = _ 'bookkeeping' _ '(' _ intent:bookkeeping_intent _ ')' _ ';' _ {
+    return new Ast.Input.Bookkeeping(intent);
+}
+bookkeeping_intent = 'commands' _ '(' _ 'device' _ '=' _ device:(entity_value / undefined_value) _ ',' _ 'category' _ '=' _ category:literal_string _ ')' {
+    return new Ast.BookkeepingIntent.CommandList(device, category);
+} / 'commands' _ '(' _  'category' _ '=' _ category:literal_string _ ',' _ 'device' _ '=' _ device:(entity_value / undefined_value) _ ')' {
+    return new Ast.BookkeepingIntent.CommandList(device, category);
+} / 'commands' _ '(' _  'category' _ '=' _ category:literal_string _ ')' {
+    return new Ast.BookkeepingIntent.CommandList(new Ast.Value.Undefined(true), category);
+} / 'choice' _ '(' _ value:literal_number _ ')' {
+    return new Ast.BookkeepingIntent.Choice(value);
+} / 'answer' _ '(' _ value:constant_value _ ')' {
+    return new Ast.BookkeepingIntent.Answer(value);
+} / 'predicate' _ '(' _ predicate:or_expr _ ')' {
+    return new Ast.BookkeepingIntent.Predicate(predicate);
+} / type:ident {
+    return new Ast.BookkeepingIntent.Special(type);
+}
 
 short_remote_program = _ principal:program_principal _ statement:top_level_statement {
     return makeInput([statement], principal);
@@ -773,7 +792,7 @@ comparison_operator "comparison operator" = '>=' / '<=' / '=~' / '~=' / '=='
 literal_bool = 'true' !identchar { return true; } / 'false' !identchar { return false; }
 
 // keywords which are not allowed as identifiers
-keyword = literal_bool / ('let' / 'now' / 'new' / 'as' / 'of' / 'in' / 'out' / 'req' / 'opt' / 'notify' / 'return' / 'join' / 'edge' / 'monitor' / 'class' / 'extends' / 'mixin' / 'this' / 'import' / 'null' / 'enum' / 'aggregate' / 'dataset' / 'oninput' / 'sort' / 'asc' / 'desc') !identchar
+keyword = literal_bool / ('let' / 'now' / 'new' / 'as' / 'of' / 'in' / 'out' / 'req' / 'opt' / 'notify' / 'return' / 'join' / 'edge' / 'monitor' / 'class' / 'extends' / 'mixin' / 'this' / 'import' / 'null' / 'enum' / 'aggregate' / 'dataset' / 'oninput' / 'sort' / 'asc' / 'desc' / 'bookkeeping') !identchar
 
 // dqstrchar = double quote string char
 // sqstrchar = single quote string char

--- a/lib/nn-syntax/lexer.js
+++ b/lib/nn-syntax/lexer.js
@@ -55,6 +55,8 @@ module.exports = class SequenceLexer {
             this._instring = !this._instring;
         } else if (this._instring) {
             next = new TokenWrapper('WORD', next, this._i);
+        } else if (/^[0-9]+$/.test(next) && next !== '0' && next !== '1') {
+            next = new TokenWrapper('LITERAL_INTEGER', parseInt(next));
         } else if (/^[A-Z]/.test(next)) {
             // check if we have a unit next, to pass to the entity retriever
             let unit = null;
@@ -95,6 +97,8 @@ module.exports = class SequenceLexer {
             next = new TokenWrapper('UNIT', next.substring('unit:'.length));
         } else if (next.startsWith('device:')) {
             next = new TokenWrapper('DEVICE', next.substring('device:'.length));
+        } else if (next.startsWith('special:')) {
+            next = new TokenWrapper('SPECIAL', next.substring('special:'.length));
         } else if (next.startsWith('^^')) {
             next = new TokenWrapper('ENTITY_TYPE', next.substring('^^'.length));
         }

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -63,9 +63,33 @@ const { parseDate } = require('../date_utils');
 
 input = {
     program;
-    'answer' c:constant => c;
-    'filter' f:filter => f;
+    'bookkeeping' 'special' s:SPECIAL => new Ast.Input.Bookkeeping(new Ast.BookkeepingIntent.Special(s.value));
+    'bookkeeping' 'answer' c:constant => new Ast.Input.Bookkeeping(new Ast.BookkeepingIntent.Answer(c));
+    'bookkeeping' 'filter' f:filter => new Ast.Input.Bookkeeping(new Ast.BookkeepingIntent.Predicate(f));
+    'bookkeeping' 'category' c:command_category => new Ast.Input.Bookkeeping(new Ast.BookkeepingIntent.CommandList(new Ast.Value.Undefined(true), c));
+    'bookkeeping' 'commands' c:command_category d:constant_Entity__tt__device => new Ast.Input.Bookkeeping(new Ast.BookkeepingIntent.CommandList(d, c));
+    'bookkeeping' 'choice' n:literal_integer => new Ast.Input.Bookkeeping(new Ast.BookkeepingIntent.Choice(n));
+
     'policy' p:policy => p;
+}
+
+literal_integer = {
+    '0' => 0;
+    '1' => 1;
+    n:LITERAL_INTEGER => n.value;
+}
+
+command_category = {
+    'online' => 'online';
+    'physical' => 'physical';
+    'data' => 'data';
+    'media' => 'media';
+    'home' => 'home';
+    'social-network' => 'social-network';
+    'communication' => 'communication';
+    'data-management' => 'data-management';
+    'health' => 'health';
+    'service' => 'service';
 }
 
 program = {

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -654,8 +654,40 @@ module.exports = class ToNNConverter {
         return sequence.flatten([]);
     }
 
+    _bookkeepingFilterToNN(filter) {
+        filter = filterToCNF(filter);
+        if (filter.isFalse)
+            throw new UnsynthesizableError('Always false filters');
+        if (filter.isTrue)
+            throw new UnsynthesizableError('Always true filters');
+        return this.cnfFilterToNN(filter, null);
+    }
+
+    _bookkeepingIntentToNN(intent) {
+        if (intent.isSpecial)
+            return List.concat('special', 'special:' + intent.type);
+        else if (intent.isCommandList && intent.device.isUndefined)
+            return List.concat('category', intent.category);
+        else if (intent.isCommandList)
+            return List.concat('commands', intent.category, this.valueToNN(intent.device));
+        else if (intent.isChoice)
+            return List.concat('choice', String(intent.value));
+        else if (intent.isAnswer)
+            return List.concat('answer', this.valueToNN(intent.value));
+        else if (intent.isPredicate)
+            return List.concat('filter', this._bookkeepingFilterToNN(intent.predicate));
+        else
+            throw new TypeError(`Unrecognized bookkeeping intent ${intent}`);
+    }
+
+    bookkeepingToNN(program) {
+        return List.concat('bookkeeping', this._bookkeepingIntentToNN(program.intent)).flatten([]);
+    }
+
     toNN(program) {
-        if (program instanceof Ast.Program)
+        if (program instanceof Ast.Input.Bookkeeping)
+            return this.bookkeepingToNN(program);
+        else if (program instanceof Ast.Program)
             return this.programToNN(program);
         else if (program instanceof Ast.PermissionRule)
             return this.permissionRuleToNN(program);

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -415,7 +415,25 @@ function prettyprintMeta(ast) {
     return meta;
 }
 
+function prettyprintBookkeepingIntent(intent) {
+    if (intent.isSpecial)
+        return intent.type;
+    else if (intent.isCommandList)
+        return `commands(category=${stringEscape(intent.category)}, device=${prettyprintValue(intent.device)})`;
+    else if (intent.isChoice)
+        return `choice(${intent.value})`;
+    else if (intent.isAnswer)
+        return `answer(${prettyprintValue(intent.value)})`;
+    else if (intent.isPredicate)
+        return `predicate(${prettyprintFilterExpression(intent.predicate)})`;
+    else
+        throw new TypeError(`Unrecognized bookkeeping intent ${intent}`);
+}
+
 function prettyprint(ast, short = true) {
+    if (ast.isBookkeeping)
+        return `bookkeeping(${prettyprintBookkeepingIntent(ast.intent)});`;
+
     if (ast.isProgram)
         return prettyprintProgram(ast, short);
     else if (ast.isPermissionRule)

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -964,7 +964,19 @@ async function typeCheckMeta(meta, schemas, getMeta = false) {
         await typeCheckDataset(dataset, schemas, classes, getMeta);
 }
 
+async function typeCheckBookkeeping(intent) {
+    if (intent.isSpecial) {
+        if (Ast.BookkeepingSpecialTypes.indexOf(intent.type) < 0)
+            throw new TypeError(`Invalid special ${intent.type}`);
+    } else if (intent.isCommandList) {
+        const valueType = typeForValue(intent.device.value, {});
+        if (!Type.isAssignable(valueType, Type.Entity('tt:device'), {}, true))
+            throw new TypeError('Invalid device parameter');
+    }
+}
+
 module.exports = {
+    typeCheckBookkeeping,
     typeCheckProgram,
     typeCheckFilter,
     typeCheckPermissionRule,

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -969,7 +969,7 @@ async function typeCheckBookkeeping(intent) {
         if (Ast.BookkeepingSpecialTypes.indexOf(intent.type) < 0)
             throw new TypeError(`Invalid special ${intent.type}`);
     } else if (intent.isCommandList) {
-        const valueType = typeForValue(intent.device.value, {});
+        const valueType = typeForValue(intent.device, {});
         if (!Type.isAssignable(valueType, Type.Entity('tt:device'), {}, true))
             throw new TypeError('Invalid device parameter');
     }

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1167,3 +1167,40 @@ monitor (@com.bing.web_search() join @com.thecatapi.get()) => notify;
 // propagating monitorable bit from table joins, part 2
 
 monitor (@com.bing.web_search() join @com.twitter.search()) => notify;
+
+====
+// bookkeeping statements: special
+bookkeeping(yes);
+
+====
+// bookkeeping statements: special
+bookkeeping(no);
+
+====
+// bookkeeping statements: special
+// ** typecheck: expect TypeError **
+bookkeeping(foo);
+
+====
+// bookkeeping statements: commands
+bookkeeping(commands(device="com.twitter"^^tt:device, category="social-network"));
+
+====
+// bookkeeping statements: commands
+bookkeeping(commands(device=$?, category="social-network"));
+
+====
+// bookkeeping statements: commands
+bookkeeping(commands(category="social-network"));
+
+====
+// bookkeeping statements: choice
+bookkeeping(choice(0));
+
+====
+// bookkeeping statements: answer
+bookkeeping(answer(42));
+
+====
+// bookkeeping statements: predicate
+bookkeeping(predicate(foo == 42));

--- a/test/test_describe.js
+++ b/test/test_describe.js
@@ -281,7 +281,7 @@ function test(i) {
     var [code, expected, expectedname] = TEST_CASES[i];
 
     return Grammar.parseAndTypecheck(code, schemaRetriever, true).then((prog) => {
-        const describer = new Describe.Describer(gettext);
+        const describer = new Describe.Describer(gettext, 'en-US', 'America/Los_Angeles');
         let reconstructed = describer.describe(prog);
         if (expected !== reconstructed) {
             console.error('Test Case #' + (i+1) + ': does not match what expected');

--- a/test/test_describe.js
+++ b/test/test_describe.js
@@ -11,8 +11,6 @@
 
 require('./polyfill');
 
-const Q = require('q');
-Q.longStackSupport = true;
 const Describe = require('../lib/describe');
 const Grammar = require('../lib/grammar_api');
 const SchemaRetriever = require('../lib/schema');
@@ -247,6 +245,30 @@ var TEST_CASES = [
     [`now => [file_name] of sort file_size asc of @com.google.drive.list_drive_files() => notify;`,
     'get the file name of the files in your Google Drive sorted by increasing file size and then notify you',
     'Google Drive ⇒ Notification'],
+
+    [`bookkeeping(yes);`,
+    'yes', ''],
+
+    [`bookkeeping(no);`,
+    'no', ''],
+
+    [`bookkeeping(nevermind);`,
+    'cancel', ''],
+
+    [`bookkeeping(commands(category="online-account"));`,
+    'list the commands of ____, in category online-account', ''],
+
+    [`bookkeeping(commands(device="com.twitter"^^tt:device, category="social-network"));`,
+    'list the commands of com.twitter, in category social-network', ''],
+
+    [`bookkeeping(commands(device="com.twitter"^^tt:device("Twitter"), category="social-network"));`,
+    'list the commands of Twitter, in category social-network', ''],
+
+    [`bookkeeping(answer(42));`,
+    '42', ''],
+
+    [`bookkeeping(choice(0));`,
+    'choice number 1', ''],
 ];
 
 const gettext = {
@@ -259,7 +281,8 @@ function test(i) {
     var [code, expected, expectedname] = TEST_CASES[i];
 
     return Grammar.parseAndTypecheck(code, schemaRetriever, true).then((prog) => {
-        let reconstructed = Describe.describeProgram(gettext, prog);
+        const describer = new Describe.Describer(gettext);
+        let reconstructed = describer.describe(prog);
         if (expected !== reconstructed) {
             console.error('Test Case #' + (i+1) + ': does not match what expected');
             console.error('Expected: ' + expected);
@@ -267,13 +290,15 @@ function test(i) {
             if (process.env.TEST_MODE)
                 throw new Error(`testDescribe ${i+1} FAILED`);
         }
-        let name = Describe.getProgramName(gettext, prog);
-        if (name !== expectedname) {
-            console.error('Test Case #' + (i+1) + ': does not match what expected');
-            console.error('Expected: ' + expectedname);
-            console.error('Generated: ' + name);
-            if (process.env.TEST_MODE)
-                throw new Error(`testDescribe ${i+1} FAILED`);
+        if (prog.isProgram) {
+            let name = Describe.getProgramName(gettext, prog);
+            if (name !== expectedname) {
+                console.error('Test Case #' + (i+1) + ': does not match what expected');
+                console.error('Expected: ' + expectedname);
+                console.error('Generated: ' + name);
+                if (process.env.TEST_MODE)
+                    throw new Error(`testDescribe ${i+1} FAILED`);
+            }
         }
     }).catch((e) => {
         console.error('Test Case #' + (i+1) + ': failed with exception');
@@ -284,15 +309,9 @@ function test(i) {
     });
 }
 
-function loop(i) {
-    if (i === TEST_CASES.length)
-        return Q();
-
-    return Q(test(i)).then(() => loop(i+1));
-}
-
-function main() {
-    return loop(0);
+async function main() {
+    for (let i = 0; i < TEST_CASES.length; i++)
+        await test(i);
 }
 module.exports = main;
 if (!module.parent)

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -278,13 +278,13 @@ const TEST_CASES = [
      '', {'SLOT_0': undefined},
      `now => @com.xkcd.get_comic(number=$?) => notify;`],
 
-    [`filter param:title:String =~ SLOT_0`,
+    [`bookkeeping filter param:title:String =~ SLOT_0`,
     '', {'SLOT_0': Ast.Value.String('foo') },
-    `title =~ "foo"`],
+    `bookkeeping(predicate(title =~ "foo"));`],
 
-    [`filter param:title:String == SLOT_0`,
+    [`bookkeeping filter param:title:String == SLOT_0`,
     '', {'SLOT_0': Ast.Value.String('foo') },
-    `title == "foo"`],
+    `bookkeeping(predicate(title == "foo"));`],
 
     [`now => @com.xkcd.get_comic param:number:Number = undefined => notify`,
      'get some specific xkcd comic', {},
@@ -317,6 +317,42 @@ const TEST_CASES = [
     ['now => ( @com.gmail.inbox ) [ NUMBER_0 , NUMBER_1 , NUMBER_2 ] => notify',
     'show me exactly the emails number NUMBER_0 , NUMBER_1 and NUMBER_2', { NUMBER_0: 3, NUMBER_1: 7, NUMBER_2: 22 },
     `now => (@com.gmail.inbox())[3, 7, 22] => notify;`],
+
+    ['bookkeeping special special:yes',
+    'yes', {},
+    'bookkeeping(yes);'],
+
+    ['bookkeeping special special:no',
+    'no', {},
+    'bookkeeping(no);'],
+
+    ['bookkeeping commands social-network device:com.twitter',
+    'twitter', {},
+    `bookkeeping(commands(category="social-network", device="com.twitter"^^tt:device));`],
+
+    ['bookkeeping category social-network',
+    'social networks', {},
+    `bookkeeping(commands(category="social-network", device=$?));`],
+
+    ['bookkeeping choice 0',
+    'the first choice', {},
+    `bookkeeping(choice(0));`],
+
+    ['bookkeeping choice 1',
+    'the second choice', {},
+    `bookkeeping(choice(1));`],
+
+    ['bookkeeping choice 2',
+    'the third choice', {},
+    `bookkeeping(choice(2));`],
+
+    ['bookkeeping answer NUMBER_0',
+    'NUMBER_0', { NUMBER_0: 42 },
+    `bookkeeping(answer(42));`],
+
+    ['bookkeeping answer 0',
+    'zero', {},
+    `bookkeeping(answer(0));`],
 ];
 
 async function testCase(test, i) {


### PR DESCRIPTION
This adds all the bookkeeping commands (yes, no, more, back, etc.) to ThingTalk proper.

This has three advantages:
- Genie can generate data from them without any new code, and other Genie related libraries have no trouble with them (allowing to fix https://github.com/stanford-oval/genie-toolkit/issues/34 without a lot of code changes)
- We consolidate a lot of code that was scattered around in almond-dialog-agent
- Train Almond no longer needs a copy of the intent and reconstruction code from almond-dialog-agent

It also has one clear disadvantage: it blurs the definition of ThingTalk, introducing more non-executable elements. But we had already introduced some with the policy code in ThingTalk, and the TT runtime might need to learn more/back/yes/no for the multi-frame code anway.

I'm not yet fully convinced this is the right approach, or just the least of all evils. Hence the RFC status of this PR.