### PR TITLE
Fix duplicate notifications

### DIFF
--- a/lib/builtin/primitive_ops.js
+++ b/lib/builtin/primitive_ops.js
@@ -96,6 +96,12 @@ function equalityTest(a, b) {
         return false;
     if (a === undefined || b === undefined)
         return false;
+    if (Number.isNaN(a) && Number.isNaN(b))
+        return true;
+    if (a instanceof Date && typeof b === 'string')
+        return +a === +new Date(b);
+    if (typeof a === 'string' && b instanceof Date)
+        return +new Date(a) === +b;
     if (hasValueOf(a) && hasValueOf(b))
         return +a === +b;
     if (a instanceof Currency && b instanceof Currency)

--- a/test/test_builtin_values.js
+++ b/test/test_builtin_values.js
@@ -75,12 +75,45 @@ function main() {
     testEval(new __builtin.Entity('xyz', ''));
     testEval(new __builtin.Entity('xyz', "Display"));
 
+    assert(equality(null, null));
+    assert(!equality(null, undefined));
+
+    assert(equality('', ''));
+    assert(equality('a', 'a'));
+    assert(!equality('a', 'b'));
+    assert(equality(1, 1));
+    assert(!equality(1, 0));
+    assert(!equality(1, NaN));
+    assert(!equality(1, '1'));
+    assert(!equality('a', NaN));
+    assert(!equality('', 0));
+    assert(equality(+0.0, -0.0));
+    assert(equality(NaN, NaN));
+
     assert(equality(new __builtin.Currency(42, 'USD'), new __builtin.Currency(42, 'usd')));
     assert(!equality(new __builtin.Currency(42, 'USD'), new __builtin.Currency(44, 'usd')));
     assert(!equality(new __builtin.Currency(42, 'USD'), new __builtin.Currency(42, 'eur')));
     assert(equality(new __builtin.Currency(42, 'USD'), 42));
     assert(equality(new __builtin.Currency(42, 'EUR'), 42));
     assert(equality(42, new __builtin.Currency(42, 'usd')));
+
+    assert(equality(new __builtin.Entity('foo', null), new __builtin.Entity('foo', null)));
+    assert(equality(new __builtin.Entity('foo', 'Foo'), new __builtin.Entity('foo', 'Foo')));
+    assert(equality(new __builtin.Entity('foo', 'Foo'), new __builtin.Entity('foo', 'Bar')));
+    assert(!equality(new __builtin.Entity('foo', null), new __builtin.Entity('bar', null)));
+    assert(equality(new __builtin.Entity('foo', null), 'foo'));
+
+    assert(equality(new Date('2019-04-30T15:00:00.000Z'), '2019-04-30T15:00:00.000Z'));
+    assert(equality('2019-04-30T15:00:00.000Z', new Date('2019-04-30T15:00:00.000Z')));
+    assert(equality(new Date('2019-04-30T15:00:00.000Z'), new Date('2019-04-30T15:00:00.000Z')));
+    assert(equality(new Date('2019-04-30T15:00:00.000Z'), 1556636400000));
+    assert(equality(1556636400000, new Date('2019-04-30T15:00:00.000Z')));
+
+    assert(equality([1, 2], [1, 2]));
+    assert(equality([], []));
+    assert(!equality([1, 2], [1]));
+    assert(!equality([1], [1, 2]));
+    assert(!equality([1, 2], [1, 3]));
 }
 module.exports = main;
 if (!module.parent)

--- a/test/test_runtime.js
+++ b/test/test_runtime.js
@@ -36,7 +36,7 @@ class MockState {
     }
     writeState(stateId, value) {
         assert(value.length >= 0);
-        assert(value.length <= 3);
+        assert(value.length <= 4);
         assert(stateId >= 0);
         assert(stateId <= this._states.length);
         return this._states[stateId] = value;
@@ -327,6 +327,43 @@ some alt text` }
         { __timestamp: 1, number: 1235, title: 'Settled',
           link: 'https://xkcd.com/1235/',
           picture_url: 'https://imgs.xkcd.com/comics/settled.png' }
+      ]
+    },
+    {},
+    [
+    {
+     type: 'action',
+     fn: 'com.twitter:post',
+     params: { status: 'Douglas Engelbart (1925-2013)' }
+    },
+    {
+     type: 'action',
+     fn: 'com.twitter:post',
+     params: { status: 'Settled' }
+    }
+    ]],
+
+    [`monitor @com.xkcd.get_comic() => @com.twitter.post(status=title);`,
+    { fn: 'com.xkcd:get_comic',
+      value: [
+        { __timestamp: 0, number: 1234, title: 'Douglas Engelbart (1925-2013)',
+          link: 'https://xkcd.com/1234/',
+          picture_url: 'https://imgs.xkcd.com/comics/douglas_engelbart_1925_2013.png' },
+        { __timestamp: 0, number: 1235, title: 'Settled',
+          link: 'https://xkcd.com/1235/',
+          picture_url: 'https://imgs.xkcd.com/comics/settled.png' },
+        { __timestamp: 1, number: 1234, title: 'Douglas Engelbart (1925-2013)',
+          link: 'https://xkcd.com/1234/',
+          picture_url: 'https://imgs.xkcd.com/comics/douglas_engelbart_1925_2013.png' },
+        { __timestamp: 1, number: 1235, title: 'Settled',
+          link: 'https://xkcd.com/1235/',
+          picture_url: 'https://imgs.xkcd.com/comics/settled.png' },
+        { __timestamp: 2, number: 1234, title: 'Douglas Engelbart (1925-2013)',
+          link: 'https://xkcd.com/1234/',
+          picture_url: 'https://imgs.xkcd.com/comics/douglas_engelbart_1925_2013.png' },
+        { __timestamp: 2, number: 1235, title: 'Settled',
+          link: 'https://xkcd.com/1235/',
+          picture_url: 'https://imgs.xkcd.com/comics/settled.png' },
       ]
     },
     {},


### PR DESCRIPTION
There is a bug in current TT that causes notifications to be duplicated.
Turns out it is caused by JS Date objects, which we serialize as strings and then fail to recognize as equal.
As it happens, RSS feeds all include a Date parameter, which is why I noticed this problem.

The first commit is a test I added trying to debug, the second is the actual fix, and the third is more tests.