### PR TITLE
Grammar: allow program examples (prim templates) with parameters

### DIFF
--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -266,7 +266,7 @@ example = 'stream'  _ params:(lambda_param_decl_list)? _ ':=' _ stream:stream _ 
     return new Ast.Example(id, 'program', params ? params : [], makeInput(take(statements, 0)), utterances, preprocessed, other);
 } / 'program'  _ params:(lambda_param_decl_list)? _ ':=' _ rule:rule_body _ annotations:(annotation _)* _ ';' {
     const [id, utterances, preprocessed, other] = checkExampleAnnotations(take(annotations, 0));
-    return new Ast.Example(id, 'program', params ? params : [], new Ast.Program([], [], [rule], null), utterances, preprocessed, other);
+    return new Ast.Example(id, 'program', params ? params : [], (new Ast.Program([], [], [rule], null)).optimize(), utterances, preprocessed, other);
 }
 
 // Function Calls

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -261,12 +261,12 @@ example = 'stream'  _ params:(lambda_param_decl_list)? _ ':=' _ stream:stream _ 
 } / 'action'  _ params:(lambda_param_decl_list)? _ ':=' _ action:action _ annotations:(annotation _)* _ ';' {
     const [id, utterances, preprocessed, other] = checkExampleAnnotations(take(annotations, 0));
     return new Ast.Example(id, 'action', params ? params : [], action, utterances, preprocessed, other);
-} / 'program'  _ ':=' _ '{' _ statements:(statement _)+ '}' _ annotations:(annotation _)* _ ';' {
+} / 'program'  _ params:(lambda_param_decl_list)? _ ':=' _ '{' _ statements:(statement _)+ '}' _ annotations:(annotation _)* _ ';' {
     const [id, utterances, preprocessed, other] = checkExampleAnnotations(take(annotations, 0));
-    return new Ast.Example(id, 'program', [], makeInput(take(statements, 0)), utterances, preprocessed, other);
-} / 'program'  _ ':=' _ rule:rule_body _ annotations:(annotation _)* _ ';' {
+    return new Ast.Example(id, 'program', params ? params : [], makeInput(take(statements, 0)), utterances, preprocessed, other);
+} / 'program'  _ params:(lambda_param_decl_list)? _ ':=' _ rule:rule_body _ annotations:(annotation _)* _ ';' {
     const [id, utterances, preprocessed, other] = checkExampleAnnotations(take(annotations, 0));
-    return new Ast.Example(id, 'program', [], new Ast.Program([], [], [rule], null), utterances, preprocessed, other);
+    return new Ast.Example(id, 'program', params ? params : [], new Ast.Program([], [], [rule], null), utterances, preprocessed, other);
 }
 
 // Function Calls
@@ -824,13 +824,3 @@ __ = (whitespace / comment)+ / !identchar
 
 whitespace "whitespace" = [ \r\n\t\v]
 comment "comment" = '/*' ([^*] / '*'[^/])* '*/' / '//' [^\n]* '\n'
-
-
-
-
-
-
-
-
-
-

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -841,8 +841,6 @@ async function typeCheckDeclaration(ast, schemas, scope, classes, useMeta) {
 }
 
 async function typeCheckExample(ast, schemas, classes = {}, useMeta = false) {
-    if (ast.type === 'program' && Object.keys(ast.args).length !== 0)
-        throw new TypeError(`Arguments are not allowed for example program.`);
     await typeCheckDeclarationCommon(ast, schemas, new Scope(), classes, useMeta);
 
     if (!Array.isArray(ast.utterances))

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1204,3 +1204,13 @@ bookkeeping(answer(42));
 ====
 // bookkeeping statements: predicate
 bookkeeping(predicate(foo == 42));
+
+====
+
+// example program with parameters
+
+dataset @foo {
+  program (p_hashtag : Entity(tt:hashtag)) := monitor(@com.twitter.home_timeline()), contains(hashtags, p_hashtag) => @com.twitter.retweet(tweet_id=tweet_id)
+  #[id=-1]
+  #_[preprocessed=["autoretweet tweets with $p_hashtag", "autoretweet $p_hashtag"]];
+}


### PR DESCRIPTION
There is no reason not to