### PR TITLE
ToNN: add the ability to allocate the entities sequentially

### DIFF
--- a/lib/nn-syntax/index.js
+++ b/lib/nn-syntax/index.js
@@ -23,14 +23,14 @@ function fromNN(sequence, entities) {
     });
 }
 
-function toNN(program, sentence, entities) {
+function toNN(program, sentence, entities, options = {}) {
     // for backward compatibility with the old API
     if (!entities) {
         entities = sentence;
         sentence = '';
     }
 
-    let converter = new ToNNConverter(sentence, entities);
+    let converter = new ToNNConverter(sentence, entities, options.allocateEntities);
     return converter.toNN(program);
 }
 

--- a/lib/nn-syntax/lexer.js
+++ b/lib/nn-syntax/lexer.js
@@ -73,6 +73,8 @@ module.exports = class SequenceLexer {
                     display: entity.display,
                     type: entityType.substring('GENERIC_ENTITY_'.length)
                 });
+            } else if (entityType.startsWith('MEASURE_')) {
+                next = new TokenWrapper('MEASURE', entity);
             } else {
                 next = new TokenWrapper(entityType, entity);
             }

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -378,6 +378,7 @@ word_list = {
 // almond-nnparser autogenerates this part
 constant_Measure = {
     num:constant_Number unit:UNIT => new Ast.Value.Measure(num.value, unit.value);
+    tok:MEASURE => new Ast.Value.Measure(tok.value.value, tok.value.unit);
     v1:constant_Measure num:constant_Number unit:UNIT => {
       if (v1.isCompoundMeasure) {
           v1.value.push(new Ast.Value.Measure(num.value, unit.value));

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -93,18 +93,75 @@ function filterToCNF(filter) {
     return Ast.BooleanExpression.And(clauses);
 }
 
-module.exports = class ToNNConverter {
+// convert AST values to on-the-wire entities, as returned by almond-tokenizer
+// the two are mostly the same, except for some weird historical stuff where
+// units are sometimes called codes and similar
+function valueToEntity(type, value) {
+    if (type === 'CURRENCY')
+        return { unit: value.code, value: value.value };
+    if (type === 'LOCATION')
+        return { latitude: value.value.lat, longitude: value.value.lon, display: value.value.display };
+    if (type === 'DURATION' ||
+        type.startsWith('MEASURE_'))
+        return { unit: value.unit, value: value.value };
+    if (type === 'TIME')
+        return { hour: value.hour, minute: value.minute, second: value.second };
+    if (type.startsWith('GENERIC_ENTITY_'))
+        return { value: value.value, display: value.display };
+
+    return value.value;
+}
+
+function entitiesEqual(type, one, two) {
+    if (one === two)
+        return true;
+    if (!one || !two)
+        return false;
+    if (type.startsWith('GENERIC_ENTITY_'))
+        return (one.value === two.value);
+
+    if (type.startsWith('MEASURE_') ||
+        type === 'DURATION')
+        return one.value === two.value && one.unit === two.unit;
+
+    switch (type) {
+    case 'CURRENCY':
+        return one.value === two.value && one.unit === two.unit;
+    case 'TIME':
+        return one.hour === two.hour &&
+            one.minute === two.minute &&
+            (one.second || 0) === (two.second || 0);
+    case 'DATE':
+        if (!(one instanceof Date))
+            one = parseDate(one);
+        if (!(two instanceof Date))
+            two = parseDate(two);
+
+        return +one === +two;
+    case 'LOCATION':
+        return Math.abs(one.latitude - two.latitude) < 0.01 &&
+            Math.abs(one.longitude - two.longitude) < 0.01;
+    }
+
+    return false;
+}
+
+class EntityRetriever {
     constructor(sentence, entities) {
         if (typeof sentence === 'string')
             sentence = sentence.split(' ');
         this.sentence = sentence;
-        this.entities = entities;
+
+        this.entities = {};
+        Object.assign(this.entities, entities);
+
+        this._used = {};
     }
 
-    findEntityFromSentence(entityType, value, display) {
-        let entityString = entityType.startsWith('GENERIC_ENTITY_') ? display : value;
+    _findEntityFromSentence(entityType, entity) {
+        let entityString = entityType.startsWith('GENERIC_ENTITY_') ? entity.display : entity;
         if (entityType === 'QUOTED_STRING' || entityType === 'HASHTAG' || entityType === 'USERNAME' ||
-            (entityType.startsWith('GENERIC_ENTITY_') && value === null && display)) {
+            (entityType.startsWith('GENERIC_ENTITY_') && entity.value === null && entity.display)) {
 
             let entityTokens = entityString.split(' ');
             for (let i = 0; i <= this.sentence.length-entityTokens.length; i++) {
@@ -130,81 +187,91 @@ module.exports = class ToNNConverter {
         throw new Error('Cannot find entity ' + entityString + ' of type ' + entityType + ', have ' + util.inspect(this.entities));
     }
 
-    findEntity(entityType, value, display, entities, { ignoreNotFound = false, ignoreMultiple = true } = {}) {
+    _findEntityInBag(entityType, value, entities) {
         let candidates = [];
 
         for (let what in entities) {
-            if (what === '$used')
-                continue;
             if (!what.startsWith(entityType + '_'))
                 continue;
 
-            if (entities[what] === value)
+            if (entitiesEqual(entityType, entities[what], value))
                 candidates.push(what);
-            if (entityType.startsWith('GENERIC_ENTITY_') && entities[what].value === value)
-                candidates.push(what);
-
-            switch (entityType) {
-            case 'DURATION':
-                if (entities[what].value === value.value &&
-                    entities[what].unit === value.unit)
-                    candidates.push(what);
-                break;
-            case 'CURRENCY':
-                if (entities[what].value === value.value &&
-                    entities[what].unit === value.code)
-                    candidates.push(what);
-                break;
-            case 'TIME':
-                if (entities[what].hour === value.hour &&
-                    entities[what].minute === value.minute &&
-                    (entities[what].second || 0) === value.second)
-                    candidates.push(what);
-                break;
-            case 'DATE':
-                if (!(entities[what] instanceof Date))
-                    entities[what] = parseDate(entities[what]);
-                if (+entities[what] === +value)
-                    candidates.push(what);
-                break;
-            case 'LOCATION':
-                if (Math.abs(entities[what].latitude - value.lat) < 0.01 &&
-                    Math.abs(entities[what].longitude - value.lon) < 0.01)
-                    candidates.push(what);
-                break;
-            }
         }
+        return candidates;
+    }
 
-        if (!ignoreMultiple && candidates.length > 1)
-            throw new Error('Ambiguous entity ' + value + ' of type ' + entityType);
+    findEntity(entityType, value, { ignoreNotFound = false }) {
+        const entity = valueToEntity(entityType, value);
+        const candidates = this._findEntityInBag(entityType, entity, this.entities);
 
         if (ignoreNotFound && candidates.length === 0)
             return null;
-        if (!ignoreMultiple)
-            return candidates[0];
 
         if (candidates.length === 0) {
             // uh oh we don't have the entity we want
             // see if we have an used pile, and try there for an unambiguous one
 
-            let reuse = this.findEntity(entityType, value, display, entities.$used || {}, { ignoreMultiple: false, ignoreNotFound: true });
-            if (reuse !== null)
-                return reuse;
-            else if (entityType === 'GENERIC_ENTITY_tt:country' && value === 'uk')
-                return this.findEntity(entityType, 'gb', display, entities);
-            else
-                return this.findEntityFromSentence(entityType, value, display);
-        } else {
-            if (!entities.$used)
-                Object.defineProperty(entities, '$used', { value: {}, writable: true, enumerable: false });
+            let reuse = this._findEntityInBag(entityType, entity, this._used);
+            if (reuse.length > 0) {
+                if (reuse.length > 1)
+                    throw new Error('Ambiguous entity ' + entity + ' of type ' + entityType);
+                return reuse[0];
+            }
 
-            // move the first entity (in sentence order) from this pile to the
+            return this._findEntityFromSentence(entityType, entity);
+        } else {
+            // move the first entity (in sentence order) from the main bag to the used bag
             candidates.sort();
             let result = candidates.shift();
-            entities.$used[result] = entities[result];
-            delete entities[result];
+            this._used[result] = this.entities[result];
+            delete this.entities[result];
             return result;
         }
+    }
+}
+
+class SequentialEntityAllocator {
+    constructor(entities) {
+        this.offsets = {};
+        this.entities = entities;
+    }
+
+    findEntity(entityType, value, { ignoreNotFound = false }) {
+        const entity = valueToEntity(entityType, value);
+
+        for (let what in this.entities) {
+            if (!what.startsWith(entityType + '_'))
+                continue;
+
+            if (entitiesEqual(entityType, this.entities[what], entity))
+                return what;
+        }
+
+        let num;
+        if (entityType in this.offsets) {
+            num = this.offsets[entityType];
+            this.offsets[entityType] += 1;
+        } else {
+            num = 0;
+            this.offsets[entityType] = 1;
+        }
+
+        const key = entityType + '_' + num;
+        this.entities[key] = entity;
+        return key;
+    }
+}
+
+module.exports = class ToNNConverter {
+    constructor(sentence, entities, allocateEntities) {
+        if (allocateEntities)
+            this.entityFinder = new SequentialEntityAllocator(entities);
+        else
+            this.entityFinder = new EntityRetriever(sentence, entities);
+    }
+
+    findEntity(entityType, value, options = {}) {
+        return this.entityFinder.findEntity(entityType, value, options);
     }
 
     valueToNN(value, schema) {
@@ -229,16 +296,22 @@ module.exports = class ToNNConverter {
                 return List.concat('0', 'unit:' + value.unit);
             if (value.value === 1)
                 return List.concat('1', 'unit:' + value.unit);
-            if (value.getType().unit === 'ms') {
-                let duration = this.findEntity('DURATION', value, null, this.entities, { ignoreNotFound: true });
+
+            const baseunit = value.getType().unit;
+            if (baseunit === 'ms') {
+                let duration = this.findEntity('DURATION', value, { ignoreNotFound: true });
                 if (duration !== null)
                     return List.concat(duration);
+            } else {
+                let measure = this.findEntity('MEASURE_' + baseunit, value, { ignoreNotFound: true });
+                if (measure !== null)
+                    return List.concat(measure);
             }
-            return List.concat(this.findEntity('NUMBER', value.value, null, this.entities), 'unit:' + value.unit);
+            return List.concat(this.findEntity('NUMBER', value), 'unit:' + value.unit);
         } else if (value.isString) {
             if (value.value === '')
                 return '""';
-            return this.findEntity('QUOTED_STRING', value.value, null, this.entities);
+            return this.findEntity('QUOTED_STRING', value);
         } else if (value.isCompoundMeasure) {
             let list = this.valueToNN(value.value[0]);
             for (let i = 1; i < value.value.length; i++)
@@ -249,14 +322,14 @@ module.exports = class ToNNConverter {
                 return '0';
             if (value.value === 1)
                 return '1';
-            return this.findEntity('NUMBER', value.value, null, this.entities);
+            return this.findEntity('NUMBER', value);
         } else if (value.isCurrency) {
-            return this.findEntity('CURRENCY', value, null, this.entities);
+            return this.findEntity('CURRENCY', value);
         } else if (value.isLocation) {
             if (value.value.isRelative)
                 return 'location:' + value.value.relativeTag;
             else
-                return this.findEntity('LOCATION', value.value, null, this.entities);
+                return this.findEntity('LOCATION', value);
         } else if (value.isDate) {
             let base;
             if (value.value === null)
@@ -264,7 +337,7 @@ module.exports = class ToNNConverter {
             else if (value.value instanceof Ast.DateEdge)
                 base = List.concat(value.value.edge, 'unit:' + value.value.unit);
             else
-                base = this.findEntity('DATE', value.value, null, this.entities);
+                base = this.findEntity('DATE', value);
             let offset;
             if (value.offset === null)
                 offset = List.Nil;
@@ -272,7 +345,7 @@ module.exports = class ToNNConverter {
                 offset = List.Cons(value.operator, this.valueToNN(value.offset));
             return List.concat(base, offset);
         } else if (value.isTime) {
-            return this.findEntity('TIME', value, null, this.entities);
+            return this.findEntity('TIME', value);
         } else if (value.isEntity) {
             switch (value.type) {
             case 'tt:function':
@@ -282,19 +355,19 @@ module.exports = class ToNNConverter {
                 return 'device:' + value.value;
             case 'tt:username':
             case 'tt:contact_name':
-                return this.findEntity('USERNAME', value.value, null, this.entities);
+                return this.findEntity('USERNAME', value);
             case 'tt:hashtag':
-                return this.findEntity('HASHTAG', value.value, null, this.entities);
+                return this.findEntity('HASHTAG', value);
             case 'tt:url':
-                return this.findEntity('URL', value.value, null, this.entities);
+                return this.findEntity('URL', value);
             case 'tt:phone_number':
-                return this.findEntity('PHONE_NUMBER', value.value, null, this.entities);
+                return this.findEntity('PHONE_NUMBER', value);
             case 'tt:email_address':
-                return this.findEntity('EMAIL_ADDRESS', value.value, null, this.entities);
+                return this.findEntity('EMAIL_ADDRESS', value);
             case 'tt:path_name':
-                return this.findEntity('PATH_NAME', value.value, null, this.entities);
+                return this.findEntity('PATH_NAME', value);
             default:
-                return this.findEntity('GENERIC_ENTITY_' + value.type, value.value, value.display, this.entities);
+                return this.findEntity('GENERIC_ENTITY_' + value.type, value);
             }
         } else if (value.isEnum) {
             return 'enum:' + value.value;

--- a/test/test_all.js
+++ b/test/test_all.js
@@ -26,6 +26,7 @@ seq([
     ('./test_grammar'),
     ('./test_typecheck'),
     ('./test_nn_syntax'),
+    ('./test_nn_syntax_allocator'),
     ('./test_compiler'),
     ('./test_builtin'),
     ('./test_describe'),

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -350,6 +350,10 @@ const TEST_CASES = [
     'NUMBER_0', { NUMBER_0: 42 },
     `bookkeeping(answer(42));`],
 
+    ['bookkeeping answer LOCATION_0',
+    'LOCATION_0', { LOCATION_0: { latitude: 0, longitude: 0, display: "North Pole" } },
+    `bookkeeping(answer(makeLocation(0, 0, "North Pole")));`],
+
     ['bookkeeping answer 0',
     'zero', {},
     `bookkeeping(answer(0));`],

--- a/test/test_nn_syntax_allocator.js
+++ b/test/test_nn_syntax_allocator.js
@@ -1,0 +1,186 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingTalk
+//
+// Copyright 2017 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const assert = require('assert');
+const Ast = require('../lib/ast');
+const NNSyntax = require('../lib/nn-syntax');
+//const NNOutputParser = require('../lib/nn_output_parser');
+const SchemaRetriever = require('../lib/schema');
+
+const _mockSchemaDelegate = require('./mock_schema_delegate');
+const schemaRetriever = new SchemaRetriever(_mockSchemaDelegate, null, true);
+
+/*class SimpleSequenceLexer {
+    constructor(sequence) {
+        this._sequence = sequence;
+        this._i = 0;
+    }
+
+    next() {
+        if (this._i >= this._sequence.length)
+            return { done: true };
+
+        let next = this._sequence[this._i++];
+        if (/^[A-Z]/.test(next)) {
+            // entity
+            next = next.substring(0, next.lastIndexOf('_'));
+        } else if (next.startsWith('@')) {
+            next = 'FUNCTION';
+        } else if (next.startsWith('enum:')) {
+            next = 'ENUM';
+        } else if (next.startsWith('param:')) {
+            next = 'PARAM_NAME';
+        } else if (next.startsWith('unit:')) {
+            next = 'UNIT';
+        }
+        return { done: false, value: next };
+    }
+}*/
+
+const TEST_CASES = [
+    [`monitor ( @com.xkcd.get_comic ) => notify`, {}],
+
+    [`now => @com.twitter.post param:status:String = QUOTED_STRING_0`,
+     {'QUOTED_STRING_0': 'hello'}],
+
+    [`now => @com.twitter.post param:status:String = ""`, {}],
+
+    [`now => @com.xkcd.get_comic param:number:Number = NUMBER_0 => notify`,
+     {'NUMBER_0': 1234}],
+
+    [`now => @com.xkcd.get_comic param:number:Number = NUMBER_0 => @com.twitter.post on param:status:String = param:title:String`,
+     {'NUMBER_0': 1234}],
+
+    [`now => ( @org.thingpedia.builtin.thingengine.builtin.get_random_between param:high:Number = NUMBER_0 param:low:Number = NUMBER_1 ) join ( @com.xkcd.get_comic ) on param:number:Number = param:random:Number => notify`,
+     {'NUMBER_0': 55, 'NUMBER_1': 1024}],
+
+    [`( ( timer base = now , interval = 1 unit:h ) => ( @org.thingpedia.builtin.thingengine.builtin.get_random_between param:high:Number = NUMBER_0 param:low:Number = NUMBER_1 ) ) => ( @com.xkcd.get_comic ) on param:number:Number = param:random:Number => notify`,
+    {'NUMBER_0': 55, 'NUMBER_1': 1024}],
+
+    [`( timer base = now , interval = 1 unit:h ) => ( ( @org.thingpedia.builtin.thingengine.builtin.get_random_between param:high:Number = NUMBER_0 param:low:Number = NUMBER_1 ) join ( @com.xkcd.get_comic ) on param:number:Number = param:random:Number ) => notify`,
+     {'NUMBER_0': 55, 'NUMBER_1': 1024}],
+
+    [`now => @org.thingpedia.builtin.thingengine.builtin.get_random_between param:high:Number = NUMBER_0 param:low:Number = NUMBER_1 => notify`,
+    {'NUMBER_0': 55, 'NUMBER_1': 1024}],
+
+    [`now => @org.thingpedia.builtin.thingengine.builtin.get_random_between param:high:Number = NUMBER_0 param:low:Number = NUMBER_1 => notify`,
+    {'NUMBER_0': 1024, 'NUMBER_1': 55}],
+
+    [`monitor ( @thermostat.get_temperature ) => notify`, {}],
+
+    [`monitor ( ( @thermostat.get_temperature ) filter param:value:Measure(C) > MEASURE_C_0 ) => notify`,
+     {'MEASURE_C_0': { unit: 'F', value: 70 }}],
+
+    [`now => timeseries now , 1 unit:week of ( monitor ( @thermostat.get_temperature ) ) => notify`,
+     {}],
+
+    [`now => ( @com.bing.image_search ) filter param:width:Number > NUMBER_0 or param:height:Number > NUMBER_1 => notify`,
+    { NUMBER_0: 100, NUMBER_1:200 }],
+
+    [`now => ( @com.bing.image_search ) filter param:width:Number > NUMBER_0 or param:height:Number > NUMBER_1 and param:width:Number < NUMBER_2 => notify`,
+    {NUMBER_0: 100, NUMBER_1:200, NUMBER_2: 500}],
+
+    [`now => ( @com.bing.image_search ) filter param:width:Number > NUMBER_0 or param:height:Number > NUMBER_0 => notify`,
+    {NUMBER_0: 100}],
+
+    [`now => ( @com.bing.image_search ) filter param:width:Number > NUMBER_0 => notify`,
+     {NUMBER_0: 100 }],
+
+    ['monitor ( ( @com.instagram.get_pictures param:count:Number = NUMBER_0 ) filter param:caption:String in_array [ QUOTED_STRING_0 , QUOTED_STRING_1 ] ) => notify',
+    {NUMBER_0: 100, QUOTED_STRING_0: 'abc', QUOTED_STRING_1: 'def'}],
+
+    ['timer base = now , interval = DURATION_0 => notify',
+     {DURATION_0: { value: 2, unit: 'h'}}],
+
+    ['monitor ( ( @com.phdcomics.get_post ) filter not param:title:String =~ QUOTED_STRING_0 ) => notify',
+     {QUOTED_STRING_0: 'abc'}],
+
+    ['now => ( @com.uber.price_estimate param:end:Location = location:home param:start:Location = location:work ) filter param:low_estimate:Currency >= CURRENCY_0 => notify',
+     {CURRENCY_0: { value: 50, unit: 'usd' } }],
+
+    ['now => ( @com.nytimes.get_front_page ) filter param:updated:Date >= now - DURATION_0 => notify',
+     { DURATION_0: { value: 2, unit: 'h' } }],
+
+    [`executor = USERNAME_0 : now => @com.twitter.post`,
+     { USERNAME_0: 'bob' }],
+
+
+    [`policy param:source:Entity(tt:contact) == USERNAME_0 : now => @com.twitter.post filter param:status:String =~ QUOTED_STRING_0`,
+     { USERNAME_0: 'bob', QUOTED_STRING_0: 'foo' }],
+
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = DATE_0 => notify`,
+     { DATE_0: new Date(2018, 5, 23, 0, 0, 0) }],
+
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = DATE_0 => notify`,
+     { DATE_0: new Date(2018, 5, 23, 10, 40, 0) }],
+
+    ['now => ( @com.bing.web_search ) join ( @com.yandex.translate.translate param:target_language:Entity(tt:iso_lang_code) = GENERIC_ENTITY_tt:iso_lang_code_0 ) on param:text:String = event => notify',
+    { 'GENERIC_ENTITY_tt:iso_lang_code_0': { value: 'it', display: "Italian" } }],
+
+    ['now => ( @com.gmail.inbox ) [ 1 : NUMBER_0 ] => notify',
+    { NUMBER_0: 3 }],
+
+    ['now => ( @com.gmail.inbox ) [ NUMBER_0 : NUMBER_1 ] => notify',
+    { NUMBER_0: 3, NUMBER_1: 2 }],
+
+    ['now => ( @com.gmail.inbox ) [ NUMBER_0 , NUMBER_1 , NUMBER_2 ] => notify',
+    { NUMBER_0: 3, NUMBER_1: 7, NUMBER_2: 22 }],
+
+    ['now => ( @com.gmail.inbox ) [ NUMBER_0 , NUMBER_1 , NUMBER_0 ] => notify',
+    { NUMBER_0: 3, NUMBER_1: 7 }],
+
+    ['bookkeeping answer LOCATION_0',
+     { LOCATION_0: { latitude: 0, longitude: 0, display: "North Pole" } }],
+
+    ['bookkeeping answer TIME_0',
+     { TIME_0: { hour: 18, minute: 0, second: 0 } }],
+
+
+];
+
+async function testCase(test, i) {
+    if (test.length !== 2)
+        throw new Error('invalid test ' + test[0]);
+    let [sequence, entities] = test;
+
+    console.log('Test Case #' + (i+1));
+    try {
+        sequence = sequence.split(' ');
+        let program = NNSyntax.fromNN(sequence, entities);
+        await program.typecheck(schemaRetriever);
+
+        const into = {};
+        let reconstructed = NNSyntax.toNN(program, '', into, { allocateEntities: true }).join(' ');
+        if (reconstructed !== test[0]) {
+            console.error('Test Case #' + (i+1) + ' failed (wrong NN syntax)');
+            console.error('Expected:', test[0]);
+            console.error('Generated:', reconstructed);
+            if (process.env.TEST_MODE)
+                throw new Error(`testNNSyntax ${i+1} FAILED`);
+        }
+
+        assert.deepStrictEqual(into, entities);
+    } catch (e) {
+        console.error('Test Case #' + (i+1) + ' failed with exception');
+        console.error(sequence.join(' '));
+        console.error(e);
+        if (process.env.TEST_MODE)
+            throw e;
+    }
+}
+
+async function main() {
+    for (let i = 0; i < TEST_CASES.length; i++)
+        await testCase(TEST_CASES[i], i);
+}
+module.exports = main;
+if (!module.parent)
+    main();


### PR DESCRIPTION
When passing the context to the neural network, we want a representation
that does not depend on the input sentence, in particular in which order
entities where represented in the sentence. Instead, we want
a normalized, sequential order.

This adds an option to toNN that uses a different entity assignment
strategy, instead of fetching from a precomputed bag.

I will need this for the contextual work.