### PR TITLE
Introduce unresolved locations

### DIFF
--- a/lib/ast/values.js
+++ b/lib/ast/values.js
@@ -24,6 +24,9 @@ const Location = adt.data({
     },
     Relative: {
         relativeTag: adt.only(String)
+    },
+    Unresolved: {
+        name: adt.only(String)
     }
 });
 module.exports.Location = Location.seal();
@@ -171,7 +174,7 @@ Value.fromJSON = function fromJSON(type, v) {
 };
 
 Value.prototype.isConcrete = function isConcrete() {
-    if (this.isLocation && this.value.isRelative)
+    if (this.isLocation && (this.value.isRelative || this.value.isUnresolved))
         return false;
     if (this.isEntity && !this.display)
         return false;

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -32,6 +32,8 @@ class Describer {
                 return loc.display;
             else
                 return this._("[Latitude: %0.3f deg, Longitude: %0.3f deg]").format(loc.lat, loc.lon);
+        } else if (loc.isUnresolved) {
+            return loc.name;
         } else {
             switch (loc.relativeTag) {
             case 'current_location':

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -699,6 +699,8 @@ time_value = 'makeTime' _ '(' hour:literal_number _ ',' _ minute:literal_number 
 bool_value = v:literal_bool { return Ast.Value.Boolean(v); }
 location_value = 'makeLocation' _ '(' _ lat:literal_number _ ',' _ lon:literal_number _ display:(',' _ literal_string _)?')' {
     return Ast.Value.Location(Ast.Location.Absolute(lat, lon, display !== null ? display[2] : null));
+} / 'makeLocation' _ '(' _ name:literal_string _ ')' {
+    return Ast.Value.Location(Ast.Location.Unresolved(name));
 } / '$context' _ '.' _ 'location' _ '.' _ ctx:('home' / 'work' / 'current_location') {
     return Ast.Value.Location(Ast.Location.Relative(ctx));
 }

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -409,6 +409,7 @@ constant_Location = {
     'location:home' => new Ast.Value.Location(new Ast.Location.Relative('home'));
     'location:work' => new Ast.Value.Location(new Ast.Location.Relative('work'));
     loc:LOCATION => new Ast.Value.Location(new Ast.Location.Absolute(loc.value.latitude, loc.value.longitude, loc.value.display||null));
+    'location:' '"' str:word_list '"' => new Ast.Value.Location(new Ast.Location.Unresolved(str));
 }
 
 // start_of/end_of with less than 1h are not supported

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -99,8 +99,12 @@ function filterToCNF(filter) {
 function valueToEntity(type, value) {
     if (type === 'CURRENCY')
         return { unit: value.code, value: value.value };
-    if (type === 'LOCATION')
-        return { latitude: value.value.lat, longitude: value.value.lon, display: value.value.display };
+    if (type === 'LOCATION') {
+        if (value.value.isAbsolute)
+            return { latitude: value.value.lat, longitude: value.value.lon, display: value.value.display };
+        else // isUnresolved (because isRelative is handled elsewhere) - note that NaN !== NaN so this will never match (which is the goal)
+            return { latitude: NaN, longitude: NaN, display: value.value.name };
+    }
     if (type === 'DURATION' ||
         type.startsWith('MEASURE_'))
         return { unit: value.unit, value: value.value };
@@ -159,8 +163,15 @@ class EntityRetriever {
     }
 
     _findEntityFromSentence(entityType, entity) {
-        let entityString = entityType.startsWith('GENERIC_ENTITY_') ? entity.display : entity;
+        let entityString;
+
+        if (entityType.startsWith('GENERIC_ENTITY_') || entityType === 'LOCATION')
+            entityString = entity.display;
+        else
+            entityString = entity;
+
         if (entityType === 'QUOTED_STRING' || entityType === 'HASHTAG' || entityType === 'USERNAME' ||
+            (entityType === 'LOCATION' && Number.isNaN(entity.latitude) && Number.isNaN(entity.longitude)) ||
             (entityType.startsWith('GENERIC_ENTITY_') && entity.value === null && entity.display)) {
 
             let entityTokens = entityString.split(' ');
@@ -179,6 +190,8 @@ class EntityRetriever {
                         return List.concat('"', entityString, '"', '^^tt:hashtag');
                     else if (entityType === 'USERNAME')
                         return List.concat('"', entityString, '"', '^^tt:username');
+                    else if (entityType === 'LOCATION')
+                        return List.concat('location:', '"', entityString, '"');
                     else
                         return List.concat('"', entityString, '"', '^^' + entityType.substring('GENERIC_ENTITY_'.length));
                 }

--- a/lib/permission_checker.js
+++ b/lib/permission_checker.js
@@ -49,7 +49,9 @@ class SmtReduction {
         this._declarations.push(smt.DeclareSort('ResultId'));
         this._declarations.push(smt.DeclareDatatype('Location',
             ['loc.home', 'loc.work', 'loc.current_location',
-             ['loc.absolute', '(loc.lat Real)', '(loc.lon Real)']]));
+             ['loc.absolute', '(loc.lat Real)', '(loc.lon Real)'],
+             ['loc.byName', '(loc.name String)']
+            ]));
         this._entityTypes = new Set;
         let contactType = this._declareEntityType(Type.Entity('tt:contact'));
         let contactGroupType = this._declareEntityType(Type.Entity('tt:contact_group'));
@@ -161,6 +163,8 @@ class SmtReduction {
     _locToSmtValue(loc) {
         if (loc.isRelative)
             return 'loc.' + loc.relativeTag;
+        if (loc.isUnresolved)
+            return new smt.SExpr('loc.byName', smt.StringLiteral(loc.name));
 
         return new smt.SExpr('loc.absolute', this._numberToSmt(loc.lat),
             this._numberToSmt(loc.lon));
@@ -987,8 +991,8 @@ class RuleTransformer {
                 else
                     return new Ast.BooleanExpression.Atom(lhs.name, filter.operator, rhs);
             } else {
-                if ((lhs.isLocation && lhs.value.isRelative) ||
-                    (rhs.isLocation && rhs.value.isRelative))
+                if ((lhs.isLocation && (lhs.value.isRelative || lhs.value.isUnresolved)) ||
+                    (rhs.isLocation && (rhs.value.isRelative || rhs.value.isUnresolved)))
                     return expr;
                 if (rhs.isVarRef)
                     return new Ast.BooleanExpression.Atom(Ast.Filter(rhs.name, flipOperator(filter.operator), lhs));

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -25,6 +25,8 @@ function prettyprintLocation(ast) {
         return 'makeLocation(' + ast.lat + ', ' + ast.lon + ', ' + stringEscape(ast.display) + ')';
     else if (ast.isAbsolute)
         return 'makeLocation(' + ast.lat + ', ' + ast.lon + ')';
+    else if (ast.isUnresolved)
+        return `makeLocation(${stringEscape(ast.name)})`;
     else
         return '$context.location.' + ast.relativeTag;
 }

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1237,3 +1237,8 @@ now => @com.spotify.play_songs(toPlay=[1, 2]);
 
 // typechecking arrays
 now => @com.spotify.play_songs(toPlay=["foo", "bar"]);
+
+====
+
+// unresolved locations
+now => @org.thingpedia.weather.current(location=makeLocation("stanford california")) => notify;

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -357,6 +357,10 @@ const TEST_CASES = [
     ['bookkeeping answer 0',
     'zero', {},
     `bookkeeping(answer(0));`],
+
+    ['now => @org.thingpedia.weather.current param:location:Location = location: " stanford california " => notify',
+    'get weather for stanford california', {},
+    `now => @org.thingpedia.weather.current(location=makeLocation("stanford california")) => notify;`]
 ];
 
 async function testCase(test, i) {


### PR DESCRIPTION
Currently, locations are preprocessed and resolved (mapped to a concrete
point on Earth) by the tokenizer. This is not great, because it
relies on CoreNLP's NER for locations (which has poor quality and is
inefficient to run), and because ambiguous locations cannot be resolved
by the user.

Instead, we can treat locations in manner similar to entities:
copy the tokens from the input into the program, and defer entity
linking to the dialog agent during slot filling.
Among other things, this will also enable personalized location
databases.

This is part of https://github.com/stanford-oval/genie-toolkit/issues/53 and is a long overdue cleanup.