### PR TITLE
Add a method to return the canonical of arguments

### DIFF
--- a/lib/ast/function_def.js
+++ b/lib/ast/function_def.js
@@ -59,6 +59,15 @@ class ArgumentDef {
         this.unique = this.annotations.unique && this.annotations.unique.isBoolean && this.annotations.unique.value === true;
     }
 
+    get canonical() {
+        let canonical = this.metadata.canonical;
+        if (typeof canonical === 'string')
+            return canonical;
+        if (typeof canonical === 'object' && 'npp' in canonical)
+            return canonical['npp'];
+        return this.name;
+    }
+
     getAnnotation(key) {
         if (Object.prototype.hasOwnProperty.call(this.annotations, key))
             return this.annotations[key].toJS();
@@ -155,7 +164,7 @@ class ExpressionSignature {
         questions = [];
 
         for (let arg of args) {
-            argcanonicals.push(arg.metadata.canonical || arg.name);
+            argcanonicals.push(arg.canonical);
             questions.push(arg.metadata.question || arg.metadata.prompt || '');
             argmap[arg.name] = arg;
         }
@@ -190,6 +199,10 @@ class ExpressionSignature {
     getArgType(arg) {
         return this._argmap[arg] ? this._argmap[arg].type : undefined;
     }
+    getArgCanonical(arg) {
+        return this.argcanonicals[arg];
+    }
+
     getArgMetadata(arg) {
         return this._argmap[arg].metadata;
     }


### PR DESCRIPTION
Handle both string and object canonical annotations