### PR TITLE
Bug fix

### DIFF
--- a/lib/runtime/formatter.js
+++ b/lib/runtime/formatter.js
@@ -84,7 +84,9 @@ module.exports = class Formatter extends FormatUtils {
             return clean(key);
         const [kind, function_name] = outputType.split(':');
         const functionDef = await this._schemas.getMeta(kind, 'query', function_name);
-        return functionDef.getArgCanonical(key);
+        if (functionDef.hasArgument(key))
+            return functionDef.getArgCanonical(key);
+        return clean(key);
     }
 
     _replaceInString(str, argMap) {

--- a/test/test_formatter.js
+++ b/test/test_formatter.js
@@ -279,6 +279,12 @@ Picture: http://example.com/security-camera.jpg`
     }, null,
     ['The total number of children is 10.']
     ],
+
+    ['org.wikidata:person', {
+        text: 'lol'
+    }, null,
+    ['text: lol']
+    ],
 ];
 
 const gettext = {


### PR DESCRIPTION
Do not throw an error when the returned object contains keys not in the schema.