### PR TITLE
typecheck: allow __const_ variables for principals

### DIFF
--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -222,7 +222,8 @@ function typecheckPrincipal(principal) {
     if (principal.isUndefined)
         return;
 
-    if (!principal.isEntity || !ALLOWED_PRINCIPAL_TYPES.has(principal.type))
+    const type = typeForValue(principal, {});
+    if (!type.isEntity || !ALLOWED_PRINCIPAL_TYPES.has(type.type))
         throw new TypeError(`Invalid principal ${principal}, must be a contact or a group`);
 }
 


### PR DESCRIPTION
Use `typeForValue` instead of checking the AST node type, which
correctly interprets VarRefs and other types.