### PR TITLE
Re-implement support for sub-function

### DIFF
--- a/lib/ast/api.js
+++ b/lib/ast/api.js
@@ -663,7 +663,7 @@ function makeSendSchema(sendFrom, secondSendFrom) {
     ];
     for (let argname in sendFrom.schema.out)
         args.push(new Ast.ArgumentDef(Ast.ArgDirection.IN_REQ, argname, sendFrom.schema.out[argname]));
-    return new Ast.FunctionDef('action', 'send', args, false, false);
+    return new Ast.FunctionDef('action', 'send', [], args, false, false);
 }
 function makeReceiveSchema(receiveFrom) {
     const args = [
@@ -675,7 +675,7 @@ function makeReceiveSchema(receiveFrom) {
     ];
     for (let argname in receiveFrom.schema.out)
         args.push(new Ast.ArgumentDef(Ast.ArgDirection.OUT, argname, receiveFrom.schema.out[argname]));
-    return new Ast.FunctionDef('query', 'receive', args, true, true);
+    return new Ast.FunctionDef('query', 'receive', [], args, true, true);
 }
 
 function makeDynamicClass(classes, sendSchema, receiveSchema) {

--- a/lib/ast/class_def.js
+++ b/lib/ast/class_def.js
@@ -34,6 +34,7 @@ class ClassDef extends Statement {
         this.queries = queries;
         this.actions = actions;
         this._adjustParentPointers();
+        this._flattenSchemaArguments();
         this.imports = imports || [];
         this.metadata = metadata ? toJS(metadata) : {};
         this.annotations = annotations || {};
@@ -48,6 +49,22 @@ class ClassDef extends Statement {
             this.queries[name]._parent = this;
         for (let name in this.actions)
             this.actions[name]._parent = this;
+    }
+
+    // for each function, flatten arguments from base functions into its own schema
+    _flattenSchemaArguments() {
+        for (let name in this.queries)
+            this.queries[name].flattenArguments();
+        for (let name in this.actions)
+            this.actions[name].flattenArguments();
+    }
+
+    getFunction(type, name) {
+        if (type === 'query')
+            return this.queries[name];
+        if (type === 'action')
+            return this.actions[name];
+        return undefined;
     }
 
     getAnnotation(key) {

--- a/lib/ast/function_def.js
+++ b/lib/ast/function_def.js
@@ -50,13 +50,27 @@ function legacyAnnotationToValue(value) {
 class ArgumentDef {
     constructor(direction, name, type, metadata, annotations) {
         this.direction = direction;
-        this.is_input = direction !== ArgDirection.OUT;
-        this.required = direction === ArgDirection.IN_REQ;
+        this.is_input = direction ? direction !== ArgDirection.OUT : undefined;
+        this.required = direction ? direction === ArgDirection.IN_REQ : undefined;
         this.name = name;
         this.type = type;
         this.metadata = metadata || {};
         this.annotations = annotations || {};
         this.unique = this.annotations.unique && this.annotations.unique.isBoolean && this.annotations.unique.value === true;
+        if (this.direction && type.isCompound)
+            this._updateFields(type);
+    }
+
+    _updateFields(type) {
+        for (let field in type.fields) {
+            const argumentDef = type.fields[field];
+            argumentDef.direction = this.direction;
+            argumentDef.is_input = this.is_input;
+            argumentDef.required = this.required;
+
+            if (argumentDef.type.isCompound)
+                this._updateFields(argumentDef.type);
+        }
     }
 
     get canonical() {
@@ -85,8 +99,8 @@ class ArgumentDef {
             metadata, annotations);
     }
 
-    toString() {
-        return `${this.direction} ${this.name}: ${this.type}${prettyprintAnnotations(this, ' ', false)}`;
+    toString(prefix = '') {
+        return `${this.direction} ${this.name}: ${prettyprintType(this.type, prefix)}${prettyprintAnnotations(this, ' ', false)}`;
     }
     prettyprint(prefix = '') {
         return `${prefix}${this}`;
@@ -151,6 +165,8 @@ class ExpressionSignature {
         this.argcanonicals = [];
         this.questions = [];
 
+        // flatten compound parameters
+        args = this._flattenCompoundArguments(args);
         this._loadArguments(args);
 
         this.is_list = is_list;
@@ -184,6 +200,26 @@ class ExpressionSignature {
             this._argmap[arg.name] = arg;
         }
 
+    }
+
+    _flattenCompoundArguments(args) {
+        let flattened = args;
+        const existed = args.map((a) => a.name);
+        for (let arg of args)
+            flattened = flattened.concat(this._flattenCompoundArgument(existed, arg));
+        return flattened;
+    }
+
+    _flattenCompoundArgument(existed, arg) {
+        let flattened = existed.includes(arg.name) ? [] : [arg];
+        if (arg.type.isCompound) {
+            for (let f in arg.type.fields) {
+                const a = arg.type.fields[f].clone();
+                a.name = arg.name + '.' + a.name;
+                flattened = flattened.concat(this._flattenCompoundArgument(existed, a));
+            }
+        }
+        return flattened;
     }
 
     hasArgument(arg) {
@@ -342,17 +378,19 @@ class FunctionDef extends ExpressionSignature {
     toString(prefix = '') {
         let annotations = prettyprintAnnotations(this);
         const firstline = `${prefix}${this.is_monitorable ? 'monitorable ' : ''}${this.is_list ? 'list ' : ''}${this.functionType} ${this.name}`;
+        // skip arguments flattened from compound param
+        const args = this.args.filter((a) => !a.includes('.'));
 
-        if (this.args.length === 0)
-            return `${firstline}()${annotations};`;
-        if (this.args.length === 1)
-            return `${firstline}(${this._argmap[this.args[0]]})${annotations};`;
-
-        let buffer = `${firstline}(${this._argmap[this.args[0]]},\n`;
         let padding = ' '.repeat(firstline.length+1);
-        for (let i = 1; i < this.args.length-1; i++)
-            buffer += `${padding}${this._argmap[this.args[i]]},\n`;
-        buffer += `${padding}${this._argmap[this.args[this.args.length-1]]})${annotations};`;
+        if (args.length === 0)
+            return `${firstline}()${annotations};`;
+        if (args.length === 1)
+            return `${firstline}(${this._argmap[args[0]].toString(padding)})${annotations};`;
+
+        let buffer = `${firstline}(${this._argmap[args[0]].toString(padding)},\n`;
+        for (let i = 1; i < args.length-1; i++)
+            buffer += `${padding}${this._argmap[args[i]].toString(padding)},\n`;
+        buffer += `${padding}${this._argmap[args[args.length-1]].toString(padding)})${annotations};`;
         return buffer;
     }
     prettyprint(prefix = '') {

--- a/lib/ast/function_def.js
+++ b/lib/ast/function_def.js
@@ -382,6 +382,16 @@ class FunctionDef extends ExpressionSignature {
         return this._cloneInternal(this.args.map((a) => this._argmap[a]));
     }
 
+    *iterateBaseFunctions() {
+        yield this.name;
+        if (this.extends.length > 0) {
+            if (!this.class)
+                throw new Error(`Class information missing from the function definition.`);
+            for (let fname of this.extends)
+                yield* this.class.getFunction(this.functionType, fname).iterateBaseFunctions();
+        }
+    }
+
 
     toManifest() {
         let interval = this._annotations['poll_interval'];

--- a/lib/ast/function_def.js
+++ b/lib/ast/function_def.js
@@ -130,7 +130,7 @@ module.exports.ArgumentDef = ArgumentDef;
 // the signature (functional type) of a TT expression,
 // either a table, stream or action
 class ExpressionSignature {
-    constructor(functionType, args, is_list, is_monitorable, require_filter, default_projection, no_filter) {
+    constructor(functionType, _extends, args, is_list, is_monitorable, require_filter, default_projection, no_filter) {
         // ignored, for compat only
         this.kind_type = 'other';
 
@@ -188,6 +188,7 @@ class ExpressionSignature {
 
         this.argcanonicals = argcanonicals;
         this.questions = questions;
+        this.extends = _extends || [];
     }
 
     hasArgument(arg) {
@@ -214,7 +215,7 @@ class ExpressionSignature {
     }
 
     _cloneInternal(args) {
-        return new ExpressionSignature(this._functionType, args,
+        return new ExpressionSignature(this._functionType, this.extends, args,
             this.is_list, this.is_monitorable, this.require_filter, this.default_projection, this.no_filter);
     }
 
@@ -260,7 +261,7 @@ class ExpressionSignature {
 module.exports.ExpressionSignature = ExpressionSignature;
 
 class FunctionDef extends ExpressionSignature {
-    constructor(functionType, name, args, is_list, is_monitorable, metadata, annotations, parent = null) {
+    constructor(functionType, name, _extends, args, is_list, is_monitorable, metadata, annotations, parent = null) {
         metadata = metadata || {};
         annotations = annotations || {};
         let require_filter, default_projection;
@@ -276,7 +277,7 @@ class FunctionDef extends ExpressionSignature {
             default_projection = [];
         }
 
-        super(functionType, args, is_list, is_monitorable, require_filter, default_projection);
+        super(functionType, _extends, args, is_list, is_monitorable, require_filter, default_projection);
 
         this._name = name;
         this._metadata = metadata;
@@ -346,7 +347,7 @@ class FunctionDef extends ExpressionSignature {
         Object.assign(metadata, this._metadata);
         Object.assign(annotations, this._annotations);
 
-        return new FunctionDef(this._functionType, this._name, args,
+        return new FunctionDef(this._functionType, this._name, this.extends, args,
             this.is_list, this.is_monitorable, metadata, annotations, this._parent);
     }
 
@@ -394,7 +395,7 @@ class FunctionDef extends ExpressionSignature {
 
         if (manifest.url)
             annotations.url = new Value.String(manifest.url);
-        return new FunctionDef(functionType, name, args, is_list, is_monitorable, metadata, annotations);
+        return new FunctionDef(functionType, name, [], args, is_list, is_monitorable, metadata, annotations);
     }
 }
 module.exports.FunctionDef = FunctionDef;

--- a/lib/ast/function_def.js
+++ b/lib/ast/function_def.js
@@ -130,12 +130,10 @@ module.exports.ArgumentDef = ArgumentDef;
 // the signature (functional type) of a TT expression,
 // either a table, stream or action
 class ExpressionSignature {
-    constructor(functionType, _extends, args, is_list, is_monitorable, require_filter, default_projection, no_filter) {
+    constructor(functionType, _extends, args, is_list, is_monitorable, require_filter, default_projection, no_filter, parent = null) {
         // ignored, for compat only
         this.kind_type = 'other';
-
-        let argnames, types, index, inReq, inOpt, out;
-        let argcanonicals, questions, argmap = {};
+        this._functionType = functionType;
 
         assert(functionType === 'stream' || functionType === 'query' || functionType === 'action');
         assert(Array.isArray(args));
@@ -144,41 +142,16 @@ class ExpressionSignature {
             assert(typeof is_monitorable === 'boolean');
         }
 
-        argnames = args.map((a) => a.name);
-        types = args.map((a) => a.type);
-        index = makeIndex(argnames);
+        this._args = [];
+        this._types = [];
+        this._argmap = {};
+        this._inReq = {};
+        this._inOpt = {};
+        this._out = {};
+        this.argcanonicals = [];
+        this.questions = [];
 
-        inReq = {};
-        inOpt = {};
-        out = {};
-        for (let arg of args) {
-            if (arg.is_input && arg.required)
-                inReq[arg.name] = arg.type;
-            else if (arg.is_input)
-                inOpt[arg.name] = arg.type;
-            else
-                out[arg.name] = arg.type;
-        }
-
-        argcanonicals = [];
-        questions = [];
-
-        for (let arg of args) {
-            argcanonicals.push(arg.canonical);
-            questions.push(arg.metadata.question || arg.metadata.prompt || '');
-            argmap[arg.name] = arg;
-        }
-
-        this._functionType = functionType;
-
-        this.args = argnames;
-        this._argmap = argmap;
-
-        this._types = types;
-        this._inReq = inReq;
-        this._inOpt = inOpt;
-        this._out = out;
-        this._index = index;
+        this._loadArguments(args);
 
         this.is_list = is_list;
         this.is_monitorable = is_monitorable;
@@ -186,9 +159,31 @@ class ExpressionSignature {
         this.default_projection = default_projection || [];
         this.no_filter = no_filter || false;
 
-        this.argcanonicals = argcanonicals;
-        this.questions = questions;
-        this.extends = _extends || [];
+        this._extends = _extends || [];
+        this._parent = parent;
+        this._argFlattened = false;
+    }
+
+    _loadArguments(args) {
+        this._args = this._args.concat(args.map((a) => a.name));
+        this._types = this._types.concat(args.map((a) => a.type));
+        this._index = makeIndex(this._args);
+
+        for (let arg of args) {
+            if (arg.is_input && arg.required)
+                this._inReq[arg.name] = arg.type;
+            else if (arg.is_input)
+                this._inOpt[arg.name] = arg.type;
+            else
+                this._out[arg.name] = arg.type;
+        }
+
+        for (let arg of args) {
+            this.argcanonicals.push(arg.canonical);
+            this.questions.push(arg.metadata.question || arg.metadata.prompt || '');
+            this._argmap[arg.name] = arg;
+        }
+
     }
 
     hasArgument(arg) {
@@ -214,31 +209,65 @@ class ExpressionSignature {
         return this._argmap[arg].required;
     }
 
+    *iterateArguments() {
+        for (let arg of this._args)
+            yield this._argmap[arg];
+        if (this.extends.length > 0 && !this._argFlattened) {
+            if (!this.class)
+                throw new Error(`Class information missing from the function definition.`);
+            for (let fname of this.extends)
+                yield *this.class.getFunction(this.functionType, fname).iterateArguments();
+        }
+        this._argFlattened = true;
+    }
+
+    // extract arguments from base functions
+    flattenArguments() {
+        const args = [];
+        for (let arg of this.iterateArguments())
+            args.push(arg);
+        this._loadArguments(args);
+    }
+
     _cloneInternal(args) {
         return new ExpressionSignature(this._functionType, this.extends, args,
             this.is_list, this.is_monitorable, this.require_filter, this.default_projection, this.no_filter);
     }
 
     clone() {
-        return this._cloneInternal(this.args.map((a) => this._argmap[a]));
+        return this._cloneInternal(this._args.map((a) => this._argmap[a]));
     }
     addArguments(toAdd) {
-        const args = this.args.map((a) => this._argmap[a]);
+        const args = this._args.map((a) => this._argmap[a]);
         args.push(...toAdd);
         return this._cloneInternal(args);
     }
     removeArgument(arg) {
-        const args = this.args.filter((a) => a !== arg).map((a) => this._argmap[a]);
+        const args = this._args.filter((a) => a !== arg).map((a) => this._argmap[a]);
         return this._cloneInternal(args);
     }
     filterArguments(filter) {
-        const args = this.args.filter((a, i) => filter(this._argmap[a], i)).map((a) => this._argmap[a]);
+        const args = this._args.filter((a, i) => filter(this._argmap[a], i)).map((a) => this._argmap[a]);
         return this._cloneInternal(args);
     }
 
     // 'stream', 'query' or 'action'
     get functionType() {
         return this._functionType;
+    }
+
+    // a list of names of the base function
+    get extends() {
+        return this._extends;
+    }
+
+    // the associated classdef, or null if this functiondef came out of thin air
+    get class() {
+        return this._parent;
+    }
+
+    get argnames() {
+        return this._args;
     }
 
     // for compatibility
@@ -277,13 +306,16 @@ class FunctionDef extends ExpressionSignature {
             default_projection = [];
         }
 
-        super(functionType, _extends, args, is_list, is_monitorable, require_filter, default_projection);
+        super(functionType, _extends, args, is_list, is_monitorable, require_filter, default_projection, false, parent);
 
         this._name = name;
         this._metadata = metadata;
         this._annotations = annotations;
 
-        this._parent = parent;
+        // args contains only arguments defined in this function, exclude the ones defined in base functions
+        // in contrast, all the argument-related fields inside ExpressionSignature will contains all arguments
+        // including the ones in base functions, in order to serve as the schema for all streams/tables/actions
+        this.args = args.map((a) => a.name);
     }
 
     getAnnotation(key) {
@@ -296,11 +328,6 @@ class FunctionDef extends ExpressionSignature {
     // the function name
     get name() {
         return this._name;
-    }
-
-    // the associated classdef, or null if this functiondef came out of thin air
-    get class() {
-        return this._parent;
     }
 
     // NL metadata (canonical, confirmation, confirmation_remote)
@@ -350,6 +377,11 @@ class FunctionDef extends ExpressionSignature {
         return new FunctionDef(this._functionType, this._name, this.extends, args,
             this.is_list, this.is_monitorable, metadata, annotations, this._parent);
     }
+
+    clone() {
+        return this._cloneInternal(this.args.map((a) => this._argmap[a]));
+    }
+
 
     toManifest() {
         let interval = this._annotations['poll_interval'];

--- a/lib/builtin/defs.js
+++ b/lib/builtin/defs.js
@@ -187,7 +187,7 @@ module.exports.Aggregations = {
 };
 
 function builtinFunction(name) {
-    return new FunctionDef('action', name, [], false, false, {}, {});
+    return new FunctionDef('action', name, [], [], false, false, {}, {});
 }
 module.exports.emptyFunction = builtinFunction;
 module.exports.Triggers = {

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -234,7 +234,7 @@ function_name_list = first:ident _ rest:(',' _ ident _)* {
 function_def = modifiers:query_modifiers? _ type:('query' / 'action') __ name:ident _ extends_:('extends' _ function_name_list _ )? args:function_param_decl_list _ annotations: ( _ annotation _)* ';' _ {
     let [is_monitorable, is_list] = modifiers || [false, false];
     const [nl_annotations, impl_annotations] = splitAnnotations(annotations);
-    return new Ast.FunctionDef(type, name, args, is_list, is_monitorable, nl_annotations, impl_annotations);
+    return new Ast.FunctionDef(type, name, extends_ !== null ? extends_[2] : null, args, is_list, is_monitorable, nl_annotations, impl_annotations);
 }
 function_param_decl_list = '(' _ ')' { return []; } /
     '(' _ first:function_param_decl _ rest:(',' _ function_param_decl _)* ')' {

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -309,7 +309,7 @@ full_function_name = sel:device_selector _ '.' _ name:ident {
     return [sel, name];
 }
 
-input_param = name:ident _ '=' _ value:value {
+input_param = name:qualified_name _ '=' _ value:value {
     return new Ast.InputParam(name, value);
 }
 input_param_list = '(' _ ')' { return [] } / '(' _ first:input_param _ rest:(',' _ input_param _)* ')' {
@@ -345,7 +345,7 @@ primary_table_expression =
   / aggregate_expression / computed_table / sort_expression /
   sliced_table
 
-table_projection = '[' _ first:ident _ rest:(',' _ ident _)* _ ']' _ 'of' __ table:alias_table {
+table_projection = '[' _ first:qualified_name _ rest:(',' _ qualified_name _)* _ ']' _ 'of' __ table:alias_table {
   return new Ast.Table.Projection(table, [first].concat(take(rest, 2)), null);
 }
 computed_table = 'compute' __ expr:primary_scalar_expression _ alias:('as' __ ident)? _ 'of' __ table:alias_table
@@ -368,10 +368,10 @@ history_expression = what:('sequence' / 'history') __ base:value _ ',' _ delta:v
 
 aggregate_expression = 'aggregate' __ 'count' __ alias:('as' _ ident _)? 'of' __ table:alias_table {
   return new Ast.Table.Aggregation(table, '*', 'count', alias !== null ? alias[2] : null, null);
-} / 'aggregate' __ op:ident __ field:ident _ alias:('as' _ ident _)? 'of' __ table:alias_table {
+} / 'aggregate' __ op:ident __ field:qualified_name _ alias:('as' _ ident _)? 'of' __ table:alias_table {
   return new Ast.Table.Aggregation(table, field, op, alias !== null ? alias[2] : null, null);
 }
-sort_expression = 'sort' __ field:ident __ direction:('asc' / 'desc') __ 'of' __ table:alias_table {
+sort_expression = 'sort' __ field:qualified_name _ direction:('asc' / 'desc') __ 'of' __ table:alias_table {
   return new Ast.Table.Sort(table, field, direction, null);
 }
 
@@ -424,7 +424,7 @@ edge_trigger = 'edge' __ stream:alias_stream _ 'on' __ edge:('new' !identchar / 
     return new Ast.Stream.EdgeNew(stream, null);
 }
 
-out_param_list = '[' _ first:ident _ rest:(',' _ ident _)* _ ']' {
+out_param_list = '[' _ first:qualified_name _ rest:(',' _ qualified_name _)* _ ']' {
   return [first].concat(take(rest, 2));
 }
 
@@ -556,13 +556,13 @@ get_predicate = fn:thingpedia_function_name _ in_params:input_param_list _ '{' _
     return new Ast.BooleanExpression.External(selector, function_name, in_params, filter, null);
  }
 
-function_style_predicate = fn:ident _ '(' _ lhs:ident _ ',' _ rhs:value _ ')' {
+function_style_predicate = fn:ident _ '(' _ lhs:qualified_name _ ',' _ rhs:value _ ')' !'(' {
     if (fn === 'substr')
         fn = '=~';
     return new Ast.BooleanExpression.Atom(lhs, fn, rhs);
 }
 
-infix_predicate = lhs:ident _ op:comparison_operator _ rhs:value {
+infix_predicate = lhs:qualified_name _ op:comparison_operator _ rhs:value {
     return new Ast.BooleanExpression.Atom(lhs, op, rhs);
 }
 
@@ -805,7 +805,20 @@ type_ref = 'Measure' _ '(' _ unit:ident? _ ')' { return Type.Measure(unit); } /
     'Stream' { return Type.Stream; } /
     'ArgMap' { return Type.ArgMap; } /
     'Object' { return Type.Object; } /
+    compound_type_ref /
     invalid:ident { return Type.Unknown(invalid); }
+
+compound_type_ref = '{' _ first:compound_type_field _ rest:(',' _ compound_type_field _)* _ '}' {
+    let fields = {};
+    [first].concat(take(rest, 2)).forEach((arg) => {
+        fields[arg.name] = arg;
+    });
+    return Type.Compound(null, fields);
+}
+compound_type_field = name:ident _ ':' _ type:type_ref annotations:( _ annotation _)* {
+    const [nl_annotations, impl_annotations] = splitAnnotations(annotations);
+    return new Ast.ArgumentDef(undefined, name, type, nl_annotations, impl_annotations);
+}
 
 // Tokens
 

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -228,7 +228,10 @@ import_mixin_stmt = 'import' __ first:ident _ rest:(',' _ ident _)* 'from' __ na
   return new Ast.ImportStmt.Mixin([first].concat(take(rest, 2)), name, in_params);
 }
 
-function_def = modifiers:query_modifiers? _ type:('query' / 'action') __ name:ident _ args:function_param_decl_list _ annotations: ( _ annotation _)* ';' _ {
+function_name_list = first:ident _ rest:(',' _ ident _)* {
+    return [first].concat(take(rest, 2))
+}
+function_def = modifiers:query_modifiers? _ type:('query' / 'action') __ name:ident _ extends_:('extends' _ function_name_list _ )? args:function_param_decl_list _ annotations: ( _ annotation _)* ';' _ {
     let [is_monitorable, is_list] = modifiers || [false, false];
     const [nl_annotations, impl_annotations] = splitAnnotations(annotations);
     return new Ast.FunctionDef(type, name, args, is_list, is_monitorable, nl_annotations, impl_annotations);

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -11,13 +11,17 @@
 
 const { stringEscape } = require('./escaping');
 
-function prettyprintType(ast) {
-    if (ast.isTuple)
+function prettyprintType(ast, prefix='') {
+    if (ast.isTuple) {
         return '(' + ast.schema.map(prettyprintType).join(', ') + ')';
-    else if (ast.isArray)
+    } else if (ast.isArray) {
         return 'Array(' + prettyprintType(ast.elem) + ')';
-    else
+    } else if (ast.isCompound) {
+        const fields = Object.keys(ast.fields).map((f) => `${f}: ${prettyprintType(ast.fields[f].type, prefix + '  ')}`);
+        return `{\n${prefix}  ${fields.join(',\n' + prefix + '  ')}\n${prefix}}`;
+    } else {
         return ast.toString();
+    }
 }
 
 function prettyprintLocation(ast) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -210,7 +210,7 @@ module.exports = class SchemaRetriever {
         for (let i = 0; i < types.length; i++)
             args.push(new Ast.ArgumentDef(Ast.ArgDirection.OUT, argnames[i], Type.fromString(types[i]), {}, {}));
 
-        return new Ast.FunctionDef('query', table, args,
+        return new Ast.FunctionDef('query', table, [], args,
                                    true /* is list */,
                                    true /* is monitorable */,
                                    {} /* metadata */,

--- a/lib/type.js
+++ b/lib/type.js
@@ -49,6 +49,10 @@ const Type = adt.data(function() {
         Type: null,
         ArgMap: null,
         Object: null,
+        Compound: {
+            name: adt.only(String, null),
+            fields: adt.only(Object)
+        },
 
         // forward compatibility: a type that we know nothing about,
         // because it was introduced in a later version of the language

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -933,6 +933,14 @@ function typeCheckFunctionInheritance(func) {
                 throw new TypeError(`Parameter ${a} is defined multiple times in ${func.functionType} ${func.name}`);
             args.push(a);
         }
+
+        if (func.is_monitorable && !f.is_monitorable)
+            throw new TypeError(`Monitorable query ${func.name} cannot extends non-monitorable query ${f.name}`);
+            // the reverse is allowed
+            // e.g., if func add a new non-monitorable parameter to monitable function f, func becomes non-monitorable
+        if (!func.is_list && f.is_list)
+            throw new TypeError(`Non-list query ${func.name} cannot extends list query ${f.name}`);
+            // the reverse is allowed
     }
 }
 

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -938,9 +938,6 @@ function typeCheckFunctionInheritance(func) {
             throw new TypeError(`Monitorable query ${func.name} cannot extends non-monitorable query ${f.name}`);
             // the reverse is allowed
             // e.g., if func add a new non-monitorable parameter to monitable function f, func becomes non-monitorable
-        if (!func.is_list && f.is_list)
-            throw new TypeError(`Non-list query ${func.name} cannot extends list query ${f.name}`);
-            // the reverse is allowed
     }
 }
 

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -913,6 +913,26 @@ function typeCheckFunctionAnnotations(func) {
     });
 }
 
+function typeCheckFunctionInheritance(func) {
+    if (func.extends.length === 0)
+        return;
+    const functions = [];
+    const args = [];
+    for (let fname of func.iterateBaseFunctions()) {
+        if (functions.includes(fname))
+            continue;
+        functions.push(fname);
+        const f = func.class.getFunction(func.functionType, fname);
+        if (!f)
+            throw new TypeError(`Cannot find ${func.functionType} with name ${fname}`);
+        for (let a of f.args) {
+            if (args.includes(a))
+                throw new TypeError(`Parameter ${a} is defined multiple times in ${func.functionType} ${func.name}`);
+            args.push(a);
+        }
+    }
+}
+
 function typeCheckFunctionDef(type, func) {
     for (let argname of func.args) {
         const type = func.getArgType(argname);
@@ -923,6 +943,7 @@ function typeCheckFunctionDef(type, func) {
 
     typeCheckMetadata(func);
     typeCheckFunctionAnnotations(func);
+    typeCheckFunctionInheritance(func);
 
     if (type === 'query') {
         if (func.is_monitorable) {

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -516,6 +516,7 @@ function resolveJoin(ast, lhs, rhs) {
     }
 
     return new Ast.ExpressionSignature(ast instanceof Ast.Stream ? 'stream' : 'query',
+        [],
         joinargs,
         lhs.is_list || rhs.is_list,
         lhs.is_monitorable && rhs.is_monitorable,
@@ -633,14 +634,14 @@ async function typeCheckStream(ast, schemas, scope, classes, useMeta = false) {
         ast.schema = await typeCheckInputArgs(ast, ast.schema, scope, classes);
         scope.addAll(ast.schema.out);
     } else if (ast.isTimer) {
-        ast.schema = new Ast.ExpressionSignature('stream', [], false, true);
+        ast.schema = new Ast.ExpressionSignature('stream', [], [], false, true);
         if (!Type.isAssignable(typeForValue(ast.base, scope), Type.Date, {}, true))
             throw new TypeError(`Invalid type for timer base`);
         if (!Type.isAssignable(typeForValue(ast.interval, scope), Type.Measure('ms'), {}, true))
             throw new TypeError(`Invalid type for timer interval`);
         scope.addAll(ast.schema.out);
     } else if (ast.isAtTimer) {
-        ast.schema = new Ast.ExpressionSignature('stream', [], false, true);
+        ast.schema = new Ast.ExpressionSignature('stream', [], [], false, true);
         for (let i = 0; i < ast.time.length; i++) {
             const value = ast.time[i];
             if (!Type.isAssignable(typeForValue(value, scope), Type.Time, {}, true))
@@ -776,9 +777,9 @@ function loadAllSchemas(ast, schemas, scope, classes, useMeta) {
             if (schema === null)
                 throw new TypeError(`Cannot find declaration ${prim.name} in memory`);
             if (schema === Type.Table)
-                schema = new Ast.ExpressionSignature('query', [], false, false);
+                schema = new Ast.ExpressionSignature('query', [], [], false, false);
             if (schema === Type.Stream)
-                schema = new Ast.ExpressionSignature('stream', [], false, false);
+                schema = new Ast.ExpressionSignature('stream', [], [], false, false);
             if (!(schema instanceof Ast.ExpressionSignature) || schema.functionType !== primType)
                 throw new TypeError(`Variable ${prim.name} does not name a ${primType}`);
         } else if (prim.isResultRef) {
@@ -801,7 +802,7 @@ async function typeCheckClass(klass, schemas, isLibrary) {
     if (!isLibrary) {
         if (klass.extends && klass.extends[0] === 'remote')
             klass.extends = ['org.thingpedia.builtin.thingengine.remote'];
-        if (klass.extends.length !== 1 && klass.extends[0] !== 'org.thingpedia.builtin.thingengine.remote')
+        if (klass.extends && klass.extends.length !== 1 && klass.extends[0] !== 'org.thingpedia.builtin.thingengine.remote')
             throw new TypeError('Inline class definitions that extend other than @org.thingpedia.builtin.thingengine.remote are not supported');
     }
 
@@ -1000,7 +1001,7 @@ function makeFunctionSchema(ast) {
         .concat(Object.keys(ast.args).map((name) =>
         new Ast.ArgumentDef(Ast.ArgDirection.IN_REQ, name, ast.args[name])));
 
-    return new Ast.FunctionDef(ast.type, ast.name, argdefs,
+    return new Ast.FunctionDef(ast.type, ast.name, [], argdefs,
         ast.value.schema.is_monitorable,
         ast.value.schema.is_list,
         ast.metadata, ast.annotations);
@@ -1012,7 +1013,7 @@ function makeProgramSchema(ast) {
         new Ast.ArgumentDef(Ast.ArgDirection.IN_REQ, name, ast.args[name]));
 
     // a program can be called on the action side, so it's an action
-    return new Ast.FunctionDef('action', ast.name, argdefs,
+    return new Ast.FunctionDef('action', ast.name, [], argdefs,
         false, /* is_monitorable */
         false, /* is_list */
         ast.metadata, ast.annotations);

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -500,7 +500,7 @@ function resolveJoin(ast, lhs, rhs) {
     for (let inParam of ast.in_params)
         joinparams.add(inParam.name);
 
-    for (let rhsarg of rhs.args) {
+    for (let rhsarg of rhs.argnames) {
         if (joinargnames.has(rhsarg))
             continue;
         if (joinparams.has(rhsarg))
@@ -508,7 +508,7 @@ function resolveJoin(ast, lhs, rhs) {
         joinargs.push(rhs.getArgument(rhsarg));
         joinargnames.add(rhsarg);
     }
-    for (let lhsarg of lhs.args) {
+    for (let lhsarg of lhs.argnames) {
         if (joinargnames.has(lhsarg))
             continue;
         joinargs.push(lhs.getArgument(lhsarg));
@@ -995,7 +995,7 @@ async function typeCheckDeclarationCommon(ast, schemas, scope, classes, useMeta)
 function makeFunctionSchema(ast) {
     // remove all input parameters (which will be filled with undefined)
     // and add the lambda arguments
-    const argdefs = ast.value.schema.args
+    const argdefs = ast.value.schema.argnames
         .map((argname) => ast.value.schema.getArgument(argname))
         .filter((arg) => !arg.is_input)
         .concat(Object.keys(ast.args).map((name) =>

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -919,6 +919,9 @@ function typeCheckFunctionInheritance(func) {
     const functions = [];
     const args = [];
     for (let fname of func.iterateBaseFunctions()) {
+        // parameters with the same name are only allowed if they are inherited from the same
+        // base functions. thus, we check `args` newly defined in each functions, as long as they
+        // are have unique names, we are good.
         if (functions.includes(fname))
             continue;
         functions.push(fname);

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1568,3 +1568,36 @@ now => @thermostat.get_temperature(), value >= __const_MEASURE__C_0 => notify;
 // ** typecheck: expect TypeError **
 // wrong type
 now => @com.twitter.post(status=__const_NUMBER_0);
+
+====
+
+// compound value type
+{
+  class @org.schema {
+    list query restaurants(out name: String,
+                           out rating: {
+                             value: Number,
+                             count: Number
+                           });
+  }
+
+  now => @org.schema.restaurants(), rating.value >= 4 => notify;
+}
+
+====
+
+// nested compound value type
+{
+  class @org.schema {
+    list query restaurants(out name: String,
+                           out rating: {
+                             value: Number,
+                             count: Number,
+                             author: {
+                                name: String
+                             }
+                           });
+  }
+
+  now => @org.schema.restaurants(), rating.author.name ~= "bob" => notify;
+}

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -192,6 +192,40 @@ class @foo.bar {
 
 ====
 
+// sub function with conflict parameters
+class @foo.bar {
+    query q1 (out a: Number);
+    list query q2 extends q1 (out b: String);
+}
+
+====
+
+// sub function with conflict parameters
+class @foo.bar {
+    monitorable query q1 (out a: Number);
+    query q2 extends q1 (out b: String);
+}
+
+====
+
+// ** typecheck: expect TypeError **
+// sub function with conflict parameters
+class @foo.bar {
+    list query q1 (out a: Number);
+    query q2 extends q1 (out b: String);
+}
+
+====
+
+// ** typecheck: expect TypeError **
+// sub function with conflict parameters
+class @foo.bar {
+    query q1 (out a: Number);
+    monitorable query q2 extends q1 (out b: String);
+}
+
+====
+
 // without wrapping it should still work
 
 monitor @com.twitter.home_timeline() => notify;

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -211,15 +211,6 @@ class @foo.bar {
 // ** typecheck: expect TypeError **
 // sub function with conflict parameters
 class @foo.bar {
-    list query q1 (out a: Number);
-    query q2 extends q1 (out b: String);
-}
-
-====
-
-// ** typecheck: expect TypeError **
-// sub function with conflict parameters
-class @foo.bar {
     query q1 (out a: Number);
     monitorable query q2 extends q1 (out b: String);
 }

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -162,6 +162,36 @@ executor = "matrix-account:@gcampax:matrix.org"^^tt:contact : { // WithPrincipal
 
 ====
 
+// sub function with conflict parameters
+class @foo.bar {
+    query q0 (out a: Number);
+    query q1 extends q0 (out b: Number);
+    query q2 extends q0 (out c: String);
+    query q3 extends q1, q2 (out d: Number);
+}
+
+====
+
+// ** typecheck: expect TypeError **
+// sub function with conflict parameters
+class @foo.bar {
+    query q1 (out a: Number);
+    query q2 (out a: String);
+    query q3 extends q1, q2 (out c: Number);
+}
+
+====
+
+// ** typecheck: expect TypeError **
+// sub function with conflict parameters
+class @foo.bar {
+    query q1 (out a: Number);
+    query q2 (out b: String);
+    query q3 extends q1, q2 (out a: Number);
+}
+
+====
+
 // without wrapping it should still work
 
 monitor @com.twitter.home_timeline() => notify;

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -136,6 +136,30 @@ executor = "matrix-account:@gcampax:matrix.org"^^tt:contact : { // WithPrincipal
     }
     now => @dyn_0.send(foo="foo");
 }
+
+====
+
+// sub function
+{
+    class @foo.bar {
+        query q1 (out a: Number);
+        query q2 extends q1 (out b: String);
+    }
+    now => @foo.bar.q2(), a >= 0 && b =~ "foo" => notify;
+}
+
+====
+
+// sub function
+{
+    class @foo.bar {
+        query q1 (out a: Number);
+        query q2 (out b: String);
+        query q3 extends q1, q2 (out c: Number);
+    }
+    now => @foo.bar.q3(), a >= 0 && b =~ "foo" && c == 1 => notify;
+}
+
 ====
 
 // without wrapping it should still work

--- a/test/test_ast.js
+++ b/test/test_ast.js
@@ -51,6 +51,7 @@ function testValues() {
 
 function testClone() {
     let fn = new Ast.FunctionDef('action', 'foo',
+        [], // extends
         [], // args
         false, // is_list
         false, // is_monitorable,

--- a/test/thingpedia.tt
+++ b/test/thingpedia.tt
@@ -1713,3 +1713,4 @@ class @org.wikidatasportsskill
   #[default_projection=['id']];
 
 }
+


### PR DESCRIPTION
Keep track of inheritance in FunctionDef instead of expanding all of the arguments while parsing the code. 
All arguments including the ones from base functions will be flattened in ExpressionSignature for typechecking, while in FunctionDef, only the new arguments are kept. 

Typechecking will handle the conflicts on parameters and types of function.