### PR TITLE
Formatter: support compound types in format string

### DIFF
--- a/lib/runtime/formatter.js
+++ b/lib/runtime/formatter.js
@@ -33,7 +33,7 @@ function isPlainObject(value) {
 // - the second one matches '$' followed by an identifier, followed by a non-identifier char
 //   the identifier is captured and returned
 // - the third one matches '${', then an identifier, then optionally ':' and either '%' or an option key, and finally a '}'
-const PARAM_REGEX = /\$(?:\$|([a-zA-Z0-9_]+(?![a-zA-Z0-9_]))|{([a-zA-Z0-9_]+)(?::(%|[a-zA-Z-]+))?})/g;
+const PARAM_REGEX = /\$(?:\$|([a-zA-Z0-9_.]+(?![a-zA-Z0-9_.]))|{([a-zA-Z0-9_.]+)(?::(%|[a-zA-Z-]+))?})/g;
 
 
 // Heuristics for default formatting, coming from Brassau
@@ -75,6 +75,17 @@ const OUTPUT_PARAM_IMPORTANCE_BY_TYPE = {
     'Entity(sportradar:ncaambb_team)': -20,
     'Entity(instagram:media_id)': -20
 };
+
+function get(obj, key) {
+    let parts = key.split('.');
+    for (let part of parts) {
+        const value = obj[part];
+        if (value === undefined || value === null)
+            return undefined;
+        obj = value;
+    }
+    return obj;
+}
 
 module.exports = class Formatter extends FormatUtils {
     constructor(locale, timezone, schemaRetriever, gettext = I18n.get(locale)) {
@@ -161,7 +172,7 @@ module.exports = class Formatter extends FormatUtils {
             if (match === '$$')
                 return '$';
             let param = param1 || param2;
-            let value = argMap[param];
+            let value = get(argMap, param);
             return this._displayValue(value, opt, null, '');
         });
     }
@@ -180,7 +191,7 @@ module.exports = class Formatter extends FormatUtils {
                 continue;
             }
             const param = match[1] || match[2];
-            if (!isNull(argMap[param]))
+            if (!isNull(get(argMap, param)))
                 existSome = true;
             match = reg.exec(str);
         }

--- a/test/test_formatter_api.js
+++ b/test/test_formatter_api.js
@@ -78,7 +78,7 @@ function main() {
         v5: 0.42,
         v6: 10,
         v7: 9.5
-    }), [ 'lol$foo$ null 69.8 2018-05-24T04:18:00.000Z 42 10 9.50' ]);
+    }), [ 'lol$foo$ undefined 69.8 2018-05-24T04:18:00.000Z 42 10 9.50' ]);
 
     assert.deepStrictEqual(formatter.format([{ type: 'text', text: '$v1$$foo$$ ${v2} ${v3:F} ${v4:iso-date} ${v5:%} ${v6} ${v7}' }], {
         v1: 'lol',
@@ -88,7 +88,7 @@ function main() {
         v5: 0.42,
         v6: 10,
         v7: 9.5
-    }, 'string'), 'lol$foo$ null 69.8 2018-05-24T04:18:00.000Z 42 10 9.50');
+    }, 'string'), 'lol$foo$ undefined 69.8 2018-05-24T04:18:00.000Z 42 10 9.50');
 
     assert.deepStrictEqual(formatter.format(['$v1$$foo$$ ${v2} ${v3:F} ${v4:iso-date} ${v5:%} ${v6} ${v7}'], {
         v1: 'lol',
@@ -98,7 +98,7 @@ function main() {
         v5: 0.42,
         v6: 10,
         v7: 9.5
-    }, 'string'), 'lol$foo$ null 69.8 2018-05-24T04:18:00.000Z 42 10 9.50');
+    }, 'string'), 'lol$foo$ undefined 69.8 2018-05-24T04:18:00.000Z 42 10 9.50');
 
     assert.deepStrictEqual(formatter.format([{ type: 'rdl', displayTitle:'text', webCallback: '$v1$$foo$$ ${v2} ${v3:F} ${v4:iso-date} ${v5:%} ${v6} ${v7}' }], {
         v1: 'lol',
@@ -108,7 +108,7 @@ function main() {
         v5: 0.42,
         v6: 10,
         v7: 9.5
-    }, 'string'), 'Link: text <lol$foo$ null 69.8 2018-05-24T04:18:00.000Z 42 10 9.50>');
+    }, 'string'), 'Link: text <lol$foo$ undefined 69.8 2018-05-24T04:18:00.000Z 42 10 9.50>');
 
     assert.deepStrictEqual(formatter.format([{ type: 'text', text: '$v1 ${v1} ${v1:enum}' }], {
         v1: 'some_enum'


### PR DESCRIPTION
Allow parameter names to contain a dot, and if so, access objects
recursively.