### PR TITLE
SchemaRetriever: add negative caching

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,96 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingTalk
+//
+// Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+function expired(obj, now) {
+    return obj.expires >= 0 && obj.expires < Date.now();
+}
+
+/**
+  A Map-like data structure where objects expire on their own based on timeouts.
+
+  @package
+ */
+module.exports = class Cache {
+    constructor(expiration) {
+        this.store = new Map;
+        this._expiration = expiration;
+    }
+
+    clear() {
+        this.store.clear();
+    }
+
+    delete(key) {
+        const obj = this.store.get(key);
+        if (obj === undefined)
+            return false;
+        this.store.delete(key);
+        // if the object was not expired, it was deleted
+        // otherwise, it is as if the object was never there
+        return !expired(obj, Date.now());
+    }
+
+    *entries() {
+        const now = Date.now();
+        for (let [key, obj] of this.store.entries()) {
+            if (expired(obj, now))
+                this.store.delete(key);
+            else
+                yield [key, obj.value];
+        }
+    }
+    [Symbol.iterator]() {
+        return this.entries();
+    }
+
+    *keys() {
+        for (let [key,] of this.entries())
+            yield key;
+    }
+    *values() {
+        for (let [,value] of this.entries())
+            yield value;
+    }
+
+    forEach(callback, thisArg) {
+        for (let [key, value] of this.entries())
+            callback.call(thisArg, value, key, this);
+    }
+
+    set(key, value, expires = this._expiration) {
+        this.store.set(key, {
+            value,
+            expires: expires >= 0 ? Date.now() + expires : -1
+        });
+    }
+
+    has(key) {
+        const obj = this.store.get(key);
+        if (obj === undefined)
+            return false;
+        if (expired(obj, Date.now())) {
+            this.store.delete(key);
+            return false;
+        }
+        return true;
+    }
+
+    get(key) {
+        const obj = this.store.get(key);
+        if (obj === undefined)
+            return undefined;
+        if (expired(obj, Date.now())) {
+            this.store.delete(key);
+            return undefined;
+        }
+        return obj.value;
+    }
+};

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -16,6 +16,8 @@ const Grammar = require('./grammar_api');
 const { typeCheckClass } = require('./typecheck');
 const Ast = require('./ast/function_def');
 
+const Cache = require('./cache');
+
 function delay(timeout) {
     return new Promise((resolve, reject) => {
         setTimeout(resolve, timeout);
@@ -113,8 +115,9 @@ class SchemaRetriever {
             true: []
         };
         this._classCache = {
-            false: new Map,
-            true: new Map
+            // expire class caches in 24 hours (same as on-disk thingpedia caches)
+            false: new Cache(24 * 3600 * 1000),
+            true: new Cache(24 * 3600 * 1000)
         };
 
         this._thingpediaClient = tpClient;
@@ -150,8 +153,9 @@ class SchemaRetriever {
      * @param {Ast.ClassDef} classDef - class definition to inject
      */
     injectClass(classDef) {
-        this._classCache[false].set(classDef.kind, classDef);
-        this._classCache[true].set(classDef.kind, classDef);
+        // never expire explicitly injected class
+        this._classCache[false].set(classDef.kind, classDef, -1);
+        this._classCache[true].set(classDef.kind, classDef, -1);
         this._manifestCache.set(classDef.kind, classDef);
     }
 
@@ -201,15 +205,25 @@ class SchemaRetriever {
         if (!parsed)
             return result;
 
+        const missing = new Set(pending);
+
         await Promise.all(parsed.classes.map(async (classDef) => {
             try {
                 await typeCheckClass(classDef, this, true);
                 this._classCache[isMeta].set(classDef.kind, classDef);
                 result[classDef.kind] = classDef;
+                missing.delete(classDef.kind);
             } catch(e) {
                 result[classDef.kind] = e;
             }
         }));
+        // add negative cache entry (with small 10 minute timeout) for the missing class
+        for (let kind of missing) {
+            // we add it for both with & without metadata (if the class doesn't exist it doesn't exist)
+            this._classCache[true].set(kind, null, 600 * 1000);
+            this._classCache[false].set(kind, null, 600 * 1000);
+        }
+
         return result;
     }
     _ensureRequest(isMeta) {
@@ -221,8 +235,12 @@ class SchemaRetriever {
     async _getClass(kind, useMeta) {
         if (typeof kind !== 'string')
             throw new TypeError();
-        if (this._classCache[useMeta].has(kind))
-            return this._classCache[useMeta].get(kind);
+        const cached = this._classCache[useMeta].get(kind);
+        if (cached !== undefined) {
+            if (cached === null) // negative cache
+                throw new TypeError('Invalid kind ' + kind);
+            return cached;
+        }
 
         if (this._pendingRequests[useMeta].indexOf(kind) < 0)
             this._pendingRequests[useMeta].push(kind);


### PR DESCRIPTION
Store the fact that a class does not exist in the local cache,
so we don't hit the Thingpedia database repeatedly when typechecking
datasets.
This is particularly a problem for the non-developer model in almond-cloud,
which typechecks a lot of sentences with invisible devices, and thus
hammers the database