### PR TITLE
Removed "time:" prefix in LITERAL_TIME token.value

### DIFF
--- a/lib/nn-syntax/lexer.js
+++ b/lib/nn-syntax/lexer.js
@@ -58,7 +58,8 @@ module.exports = class SequenceLexer {
         } else if (/^[0-9]+$/.test(next) && next !== '0' && next !== '1') {
             next = new TokenWrapper('LITERAL_INTEGER', parseInt(next));
         } else if (/^time:[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}$/.test(next)) {
-            next = new TokenWrapper('LITERAL_TIME', next);
+            // need to remove 'time:' prefix because parser.lr uses split(':')[0] for hour
+            next = new TokenWrapper('LITERAL_TIME', next.replace('time:', ''));
         } else if (/^[A-Z]/.test(next)) {
             // check if we have a unit next, to pass to the entity retriever
             let unit = null;

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -386,6 +386,13 @@ const TEST_CASES = [
     { QUOTED_STRING_0: "it's the evening" },
     `attimer(time=$context.time.evening) => @org.thingpedia.builtin.thingengine.builtin.say(message="it's the evening");`],
 
+    // To test LITERAL_TIME but might want to drop this functionality
+    // Left sentence blank because "at noon" should map to TIME_0 instead
+    [`attimer time = time:12:0:0 => @org.thingpedia.builtin.thingengine.builtin.say param:message:String = QUOTED_STRING_0`,
+    '',
+    { QUOTED_STRING_0: "it's noon" },
+    `attimer(time=makeTime(12, 0)) => @org.thingpedia.builtin.thingengine.builtin.say(message="it's noon");`],
+
     ['now => [ param:description:String , param:title:String ] of ( @com.bing.web_search ) => notify',
     'get title and description from bing', {},
 


### PR DESCRIPTION
Alternatively, we can change line 441 in parser.lr to use split(':')[1] for hour instead

This is to fix the `makeTime(NaN, 12)` bug when using genie.