### PR TITLE
Pictures inside RDLs

### DIFF
--- a/lib/format_utils.js
+++ b/lib/format_utils.js
@@ -11,7 +11,22 @@
 
 const Units = require('./units');
 
-module.exports = class FormatUtils {
+/**
+ * Formatting utilities.
+ *
+ * This class provides an abstraction over {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl|the Intl API}
+ * that ensures the correct locale and timezone information are used.
+ *
+ * @package
+ */
+class FormatUtils {
+    /**
+     * Construct a new format utils object.
+     *
+     * @param {string} locale - the user's locale, as a BCP47 tag
+     * @param {string} timezone - the user's timezone, as a string in the IANA timezone database (e.g. America/Los_Angeles, Europe/Rome)
+     * @param {Gettext} [gettext] - gettext instance; this is optional if {@link I18n.init} has been called
+     */
     constructor(locale, timezone, gettext) {
         this._locale = locale;
         this._timezone = timezone;
@@ -21,6 +36,14 @@ module.exports = class FormatUtils {
             this._ = (x) => x;
     }
 
+    /**
+     * Convert a measurement to a user-visible string.
+     *
+     * @param {number} value - the value, in the ThingTalk base unit (e.g. Celius for temperature, meters for distance)
+     * @param {number} [precision] - the number of digits after the decimal separator, defaults to 0
+     * @param {string} unit - the unit to display as, as a ThingTalk unit code
+     * @return {string} the formatted measurement
+     */
     measureToString(value, precision, unit) {
         var baseUnit = Units.UnitsToBaseUnit[unit];
         if (!baseUnit)
@@ -33,6 +56,16 @@ module.exports = class FormatUtils {
             return ((1/coeff)*value).toFixed(precision);
     }
 
+    /**
+     * Convert a date to a user-visible string (without the time part).
+     *
+     * This is a small wrapper over {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString|Date.toLocaleString}
+     * that applies the correct timezone.
+     *
+     * @param {Date} date - the date to display
+     * @param {Object} [options] - additional options to pass to `toLocaleString`
+     * @return {string} the formatted date
+     */
     dateToString(date, options) {
         if (!options) {
             options = {
@@ -46,6 +79,16 @@ module.exports = class FormatUtils {
         return date.toLocaleDateString(this._locale, options);
     }
 
+    /**
+     * Convert a date object to a user-visible string, displaying _only_ the time part.
+     *
+     * This is a small wrapper over {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString|Date.toLocaleString}
+     * that applies the correct timezone.
+     *
+     * @param {Date} date - the time to display
+     * @param {Object} [options] - additional options to pass to `toLocaleString`
+     * @return {string} the formatted time
+     */
     timeToString(date, options) {
         if (!options) {
             options = {
@@ -59,14 +102,31 @@ module.exports = class FormatUtils {
         return date.toLocaleTimeString(this._locale, options);
     }
 
+    /**
+     * Convert a date object to a user-visible string, displaying both the date and the time part.
+     *
+     * This is a small wrapper over {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString|Date.toLocaleString}
+     * that applies the correct timezone.
+     *
+     * @param {Date} date - the date to display
+     * @param {Object} [options] - additional options to pass to `toLocaleString`
+     * @return {string} the formatted date
+     */
     dateAndTimeToString(date, options = {}) {
         options.timeZone = this._timezone;
         return date.toLocaleString(this._locale, options);
     }
 
-    locationToString(o) {
-        if (o.display)
-            return o.display;
-        return this._("[Latitude: %.3f deg, Longitude: %.3f deg]").format(Number(o.y), Number(o.x));
+    /**
+     * Convert a location to a string.
+     *
+     * @param {Builtin.Location} loc - the location to display
+     * @return {string} the formatted location
+     */
+    locationToString(loc) {
+        if (loc.display)
+            return loc.display;
+        return this._("[Latitude: %.3f deg, Longitude: %.3f deg]").format(Number(loc.y), Number(loc.x));
     }
-};
+}
+module.exports = FormatUtils;

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -18,11 +18,46 @@ const _defaultGettext = {
     dngettext(d, x1, xn, n) { return n === 1 ? x1 : xn; }
 };
 
-module.exports = {
+/**
+ * The node-gettext library.
+ * @external Gettext
+ * @see {@link https://www.npmjs.com/package/node-gettext}
+ */
+
+module.exports =
+/**
+ * Internationalization support.
+ *
+ * @alias I18n
+ * @namespace
+ */
+{
+    /**
+     * Initialize internationalization support.
+     *
+     * This function should be called before any other API in the ThingTalk library.
+     * It might be called multiple times to initialize multiple locales (e.g. in
+     * a multi-user application).
+     *
+     * The passed-in gettext instance must have the `thingtalk` domain loaded with
+     * the .mo files in this package.
+     *
+     * @param {string} locale - the locale to initialize, as a BCP 47 tag
+     * @param {external:Gettext} gettext - the initialized gettext instance for this locale
+     */
     init(locale, gettext) {
         _languages.set(locale.toLowerCase(), gettext);
     },
 
+    /**
+     * Retrieve translations for a given locale.
+     *
+     * If the locale is unsupported, this method will return a valid Gettext-like object
+     * that returns no translation.
+     *
+     * @param {string} locale - the locale to retrieve
+     * @return {external:Gettext} the gettext instance in the given locale, with loaded translations
+     */
     get(locale) {
         if (!locale)
             return _defaultGettext;

--- a/lib/runtime/format_objects.js
+++ b/lib/runtime/format_objects.js
@@ -151,6 +151,7 @@ class RDL extends FormattedObject {
      * @param {string} [spec.displayText] - the description associated with the link
      * @param {string} spec.webCallback - the link target
      * @param {string} [spec.callback] - a different link target, to use on plaforms where deep-linking is allowed (e.g. Android)
+     * @param {string} [spec.pictureUrl] - a picture associated with this link
      */
     constructor(spec) {
         super();
@@ -166,6 +167,7 @@ class RDL extends FormattedObject {
         this.webCallback = spec.webCallback;
         this.displayTitle = spec.displayTitle;
         this.displayText = spec.displayText;
+        this.pictureUrl = spec.pictureUrl;
     }
 
     replaceParameters(formatter, argMap) {

--- a/lib/runtime/format_objects.js
+++ b/lib/runtime/format_objects.js
@@ -24,7 +24,58 @@ function isNull(value) {
     return false;
 }
 
+/**
+ * The base class of all formatting objects.
+ *
+ * Formatting objects are created from spec objects provided in the `#_[formatted]`
+ * function annotation.
+ *
+ * @alias FormatObjects~FormattedObject
+ * @abstract
+ */
 class FormattedObject {
+    /**
+     * A string identifying the type of this formatted object.
+     *
+     * @name FormatObjects~FormattedObject#type
+     * @member
+     * @type {string}
+     * @readonly
+     */
+
+    /**
+     * Check if this formatted object is valid.
+     *
+     * A formatted object is valid if the required properties are substituted with
+     * valid values (not null, undefined, empty or NaN). Invalid formatted objects
+     * are not displayed to the user.
+     *
+     * @name FormatObjects~FormattedObject#isValid
+     * @method
+     * @abstract
+     * @return {boolean} true if this formatted object is valid, false otherwise
+     */
+
+    /**
+     * Convert this formatted object to a localized string.
+     *
+     * The resulting string is suitable for speech, or for displaying to user in
+     * a text-only interface. It is also suitable as a fallback for all formatting
+     * objects not recognized by the application.
+     *
+     * @name FormatObjects~FormattedObject#toLocaleString
+     * @method
+     * @abstract
+     * @param {string} locale - the locale to localize any message into
+     * @return {string} a string representation of this formatted object
+     */
+
+    /**
+     * Replace all placeholders in this object, using the provided structured result.
+     *
+     * @param {Formatter} formatter - the formatter to use for replacement
+     * @param {Object.<string,any>} argMap - the structured ThingTalk result with the values to substitute
+     */
     replaceParameters(formatter, argMap) {
         for (let key in this) {
             if (key === 'type')
@@ -44,15 +95,27 @@ function localeCompat(locale) {
 }
 
 /**
-  A simple still picture.
-
-  Properties:
-  - url: the URL of the picture to display
-*/
+ * A simple still picture.
+ *
+ * @alias FormatObjects~Picture
+ * @extends FormatObjects~FormattedObject
+ */
 class Picture extends FormattedObject {
+    /**
+     * Construct a new picture object.
+     *
+     * @param {Object} spec
+     * @param {string} spec.url - the URL of the picture to display
+     */
     constructor(spec) {
         super();
 
+        /**
+         * A string identifying the type of this formatted object. Always the value `picture`.
+         *
+         * @readonly
+         * @type {string}
+         */
         this.type = 'picture';
         this.url = spec.url;
     }
@@ -68,21 +131,36 @@ class Picture extends FormattedObject {
 }
 
 /**
-  A rich deep link.
-
-  Properties:
-  - displayTitle: the title of the link
-  - displayText (optional): the description associated with the link
-  - webCallback: the link target
-  - callback (optional): a different link target, to use on plaforms where deep-linking is allowed (e.g. Android)
-
-  If displayTitle is unspecified but displayText is, displayText is moved to displayTitle.
-  If callback is not specified, it is set to the same value as webCallback.
-*/
+ * A rich deep link (also known as a card).
+ *
+ * An RDL is expected to be displayed as a clickable card with optional
+ * description and picture.
+ *
+ * @alias FormatObjects~RDL
+ * @extends FormatObjects~FormattedObject
+ */
 class RDL extends FormattedObject {
+    /**
+     * Construct a new RDL
+     *
+     * If displayTitle is unspecified but displayText is, displayText is moved to displayTitle.
+     * If callback is not specified, it is set to the same value as webCallback.
+     *
+     * @param {Object} spec
+     * @param {string} spec.displayTitle - the title of the link
+     * @param {string} [spec.displayText] - the description associated with the link
+     * @param {string} spec.webCallback - the link target
+     * @param {string} [spec.callback] - a different link target, to use on plaforms where deep-linking is allowed (e.g. Android)
+     */
     constructor(spec) {
         super();
 
+        /**
+         * A string identifying the type of this formatted object. Always the value `rdl`.
+         *
+         * @readonly
+         * @type {string}
+         */
         this.type = 'rdl';
         this.callback = spec.callback;
         this.webCallback = spec.webCallback;
@@ -102,6 +180,8 @@ class RDL extends FormattedObject {
         }
         if (!this.displayTitle)
             this.displayTitle = this.webCallback;
+        if (!this.pictureUrl)
+            this.pictureUrl = undefined;
     }
 
     isValid() {
@@ -115,17 +195,35 @@ class RDL extends FormattedObject {
 }
 
 /**
-  A map, with a single pin at the specified location (indicated as latitude, longitude)
-
-  Properties:
-  - lat: latitude
-  - lon: longitude
-  - display (optional): a label for the pin (the name of the location being selected)
-*/
+ * A map, with a single pin at the specified location (indicated as latitude, longitude)
+ *
+ * Whether the map is interactive (can be panned, zoomed) is implementation-dependent.
+ *
+ * The name `MapFO` is chosen to avoid confusion by JavaScript's builtin
+ * [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
+ * data structure.
+ *
+ * @alias FormatObjects~MapFO
+ * @extends FormatObjects~FormattedObject
+ */
 class MapFO extends FormattedObject {
+    /**
+     * Construct a new map format object.
+     *
+     * @param {Object} spec
+     * @param {string|number} spec.lat - latitude; this can be a string with placeholders, or a number
+     * @param {string|number} spec.lon - longitude; this can be a string with placeholders, or a number
+     * @param {string} [spec.display] - a label for the pin (the name of the location being selected)
+     */
     constructor(spec) {
         super();
 
+        /**
+         * A string identifying the type of this formatted object. Always the value `map`.
+         *
+         * @readonly
+         * @type {string}
+         */
         this.type = 'map';
         this.lat = spec.lat;
         this.lon = spec.lon;
@@ -152,16 +250,28 @@ class MapFO extends FormattedObject {
 }
 
 /**
-  A short notification sound from a predefined library.
-
-  Properties:
-  - name: the name of the sound, from the Freedesktop Sound Theme Spec: http://0pointer.de/public/sound-theme-spec.html
-          (with a couple Almond-specific extensions)
+ * A short notification sound from a predefined library.
+ *
+ * @alias FormatObjects~SoundEffect
+ * @extends FormatObjects~FormattedObject
 */
 class SoundEffect extends FormattedObject {
+    /**
+     * Construct a new sound effect object.
+     *
+     * @param {Object} spec
+     * @param {string} spec.name - the name of the sound, from the {@link http://0pointer.de/public/sound-theme-spec.html|Freedesktop Sound Theme Spec}
+     *                             (with a couple Almond-specific extensions)
+     */
     constructor(spec) {
         super();
 
+        /**
+         * A string identifying the type of this formatted object. Always the value `sound`.
+         *
+         * @readonly
+         * @type {string}
+         */
         this.type = 'sound';
         this.name = spec.name;
     }
@@ -177,19 +287,31 @@ class SoundEffect extends FormattedObject {
 }
 
 /**
-  Audio/video display with controls
-
-  Properties:
-  - url: the URL of the music/video to display
-
-  Whether the URL is audio or video will be identified
-  based on Content-Type, URL patterns and potentially
-  file extension.
+ * Audio/video display with controls
+ *
+ * @alias FormatObjects~Media
+ * @extends FormatObjects~FormattedObject
 */
 class Media extends FormattedObject {
+    /**
+     * Construct a new media object.
+     *
+     * Whether the URL is audio or video will be identified
+     * based on Content-Type, URL patterns and potentially
+     * file extension.
+     *
+     * @param {Object} spec
+     * @param {string} spec.url - the URL of the music/video to display
+     */
     constructor(spec) {
         super();
 
+        /**
+         * A string identifying the type of this formatted object. Always the value `media`.
+         *
+         * @readonly
+         * @type {string}
+         */
         this.type = 'media';
         this.url = spec.url;
     }

--- a/lib/runtime/formatter.js
+++ b/lib/runtime/formatter.js
@@ -87,7 +87,31 @@ function get(obj, key) {
     return obj;
 }
 
-module.exports = class Formatter extends FormatUtils {
+/**
+ * Namespace for format objects.
+ *
+ * Classes in this namespace are not accessible directly, but objects
+ * of this classes are returned by {@link Formatter} methods.
+ *
+ * @name FormatObjects
+ * @namespace
+ */
+
+/**
+ * An object that is able to convert structured ThingTalk results
+ * into something suitable for display to the user.
+ *
+ * @extends FormatUtils
+ */
+class Formatter extends FormatUtils {
+    /**
+     * Construct a new formatter.
+     *
+     * @param {string} locale - the user's locale, as a BCP47 tag
+     * @param {string} timezone - the user's timezone, as a string in the IANA timezone database (e.g. America/Los_Angeles, Europe/Rome)
+     * @param {SchemaRetriever} schemaRetriever - the interface to access Thingpedia for formatting information
+     * @param {Gettext} [gettext] - gettext instance; this is optional if {@link I18n.init} has been called
+     */
     constructor(locale, timezone, schemaRetriever, gettext = I18n.get(locale)) {
         super(locale, timezone, gettext);
         this._schemas = schemaRetriever;
@@ -462,4 +486,5 @@ module.exports = class Formatter extends FormatUtils {
         else
             return String(o);
     }
-};
+}
+module.exports = Formatter;


### PR DESCRIPTION
Improves the UX of our APIs that return cards (Washington Post, Cat API, Restaurants, etc.)

This is a small Almond API break, in the sense that, once Thingpedia APIs start using this feature, Almond API users will have to adapt or they'll lose the picture. This is probably ok for most APIs where the picture is decoration - for Cat or Instagram, we should wait until all clients are updated before making the switch.

Asked by @euirim 