### PR TITLE
Extend device selectors to refer to devices by name

### DIFF
--- a/lib/ast/api.js
+++ b/lib/ast/api.js
@@ -34,9 +34,10 @@ const {
     recursiveYieldArraySlots,
     makeScope,
     InputParamSlot,
+    DeviceAttributeSlot,
     FilterSlot,
     ArrayIndexSlot,
-    FieldSlot
+    FieldSlot,
 } = require('./slots');
 
 const InvocationProto = Object.getPrototypeOf(new Ast.Invocation(Ast.Selector.Builtin, 'notify', [], null));
@@ -464,8 +465,16 @@ function* iterateSlots2InputParams(prim, scope) {
  * @yields {Ast~AbstractSlot}
  */
 InvocationProto.iterateSlots2 = function* iterateSlots2(scope) {
-    if (this.selector.isDevice)
+    if (this.selector.isDevice) {
+        for (let attr of this.selector.attributes)
+            yield new DeviceAttributeSlot(this, attr);
+
+        // note that we yield the selector after the device attributes
+        // this way, almond-dialog-agent will first ask any question to slot-fill
+        // the device attributes (if somehow it needs to) and then use the chosen
+        // device attributes to choose the device
         yield this.selector;
+    }
     return yield* iterateSlots2InputParams(this, scope);
 };
 

--- a/lib/ast/api.js
+++ b/lib/ast/api.js
@@ -1052,7 +1052,7 @@ function lowerReturnAction(state, action, lastPrimitive, principal) {
     ];
     for (let name in lastPrimitive.schema.out)
         sendInputs.push(Ast.InputParam(name, Ast.Value.VarRef(name)));
-    action.invocation.selector = Ast.Selector.Device(localClass.name, null, null);
+    action.invocation.selector = new Ast.Selector.Device(localClass.name, null, null);
     action.invocation.channel = 'send';
     action.invocation.in_params = sendInputs;
     action.invocation.schema = sendSchema;
@@ -1065,7 +1065,7 @@ function lowerReturnAction(state, action, lastPrimitive, principal) {
     ];
     let receiveTrigger = new Ast.Stream.Monitor(
         new Ast.Table.Invocation(
-            new Ast.Invocation(Ast.Selector.Device(toSendClass.name, null, null), 'receive', receiveInputs, receiveSchema),
+            new Ast.Invocation(new Ast.Selector.Device(toSendClass.name, null, null), 'receive', receiveInputs, receiveSchema),
         receiveSchema),
     null, receiveSchema);
 

--- a/lib/ast/class_def.js
+++ b/lib/ast/class_def.js
@@ -14,7 +14,7 @@ const assert = require('assert');
 //const Ast = require('./ast');
 const Type = require('../type');
 const { prettyprintClassDef } = require('../prettyprint');
-const { clean } = require('../utils');
+const { clean, cleanKind } = require('../utils');
 const { Value } = require('./values');
 const { Statement, InputParam } = require('./program');
 const { FunctionDef } = require('./function_def');
@@ -22,28 +22,6 @@ const { getString, extractImports, typeToHTML } = require('./manifest_utils');
 const toJS = require('./toJS');
 
 // Class definitions
-
-function cleanKind(kind) {
-    // thingengine.phone -> phone
-    if (kind.startsWith('org.thingpedia.builtin.thingengine.'))
-        kind = kind.substr('org.thingpedia.builtin.thingengine.'.length);
-    // org.thingpedia.builtin.omlet -> omlet
-    if (kind.startsWith('org.thingpedia.builtin.'))
-        kind = kind.substr('org.thingpedia.builtin.'.length);
-    // org.thingpedia.weather -> weather
-    if (kind.startsWith('org.thingpedia.'))
-        kind = kind.substr('org.thingpedia.'.length);
-    // com.xkcd -> xkcd
-    if (kind.startsWith('com.'))
-        kind = kind.substr('com.'.length);
-    if (kind.startsWith('gov.'))
-        kind = kind.substr('gov.'.length);
-    if (kind.startsWith('org.'))
-        kind = kind.substr('org.'.length);
-    if (kind.startsWith('uk.co.'))
-        kind = kind.substr('uk.co.'.length);
-    return clean(kind);
-}
 
 /**
  * The definition of a ThingTalk class.

--- a/lib/ast/class_def.js
+++ b/lib/ast/class_def.js
@@ -23,6 +23,28 @@ const toJS = require('./toJS');
 
 // Class definitions
 
+function cleanKind(kind) {
+    // thingengine.phone -> phone
+    if (kind.startsWith('org.thingpedia.builtin.thingengine.'))
+        kind = kind.substr('org.thingpedia.builtin.thingengine.'.length);
+    // org.thingpedia.builtin.omlet -> omlet
+    if (kind.startsWith('org.thingpedia.builtin.'))
+        kind = kind.substr('org.thingpedia.builtin.'.length);
+    // org.thingpedia.weather -> weather
+    if (kind.startsWith('org.thingpedia.'))
+        kind = kind.substr('org.thingpedia.'.length);
+    // com.xkcd -> xkcd
+    if (kind.startsWith('com.'))
+        kind = kind.substr('com.'.length);
+    if (kind.startsWith('gov.'))
+        kind = kind.substr('gov.'.length);
+    if (kind.startsWith('org.'))
+        kind = kind.substr('org.'.length);
+    if (kind.startsWith('uk.co.'))
+        kind = kind.substr('uk.co.'.length);
+    return clean(kind);
+}
+
 /**
  * The definition of a ThingTalk class.
  *
@@ -58,6 +80,10 @@ class ClassDef extends Statement {
         this.metadata = metadata ? toJS(metadata) : {};
         this.annotations = annotations || {};
         this.is_abstract = is_abstract || false;
+    }
+
+    get canonical() {
+        return this.metadata.canonical || cleanKind(this.kind);
     }
 
     *iterateSlots() {}

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -27,48 +27,76 @@ const {
  * Selectors correspond to the `@`-device part of the ThingTalk code,
  * up to but not including the function name.
  *
- * @class
  * @alias Ast.Selector
+ * @property {boolean} isSelector - true
  * @property {boolean} isDevice - true if this is an instance of {@link Ast.Selector.Device}
  * @property {boolean} isBuiltin - true if this is {@link Ast.Selector.Builtin}
  * @abstract
  */
-const Selector = adt.data(/** @lends Ast.Selector */ {
+class Selector {}
+Selector.prototype.isSelector = true;
+
+/**
+ * A selector that maps to one or more devices in Thingpedia.
+ *
+ * @alias Ast.Selector.Device
+ * @extends Ast.Selector
+ */
+class DeviceSelector extends Selector {
     /**
-     * A selector that maps to one or more devices in Thingpedia.
+     * Construct a new device selector.
      *
-     * @class
-     * @extends Ast.Selector
      * @param {string} kind - the Thingpedia class ID
      * @param {string|null} id - the unique ID of the device being selected, or null
      *                           to select all devices
      * @param {null} principal - reserved/deprecated, must be `null`
      */
-    Device: /** @lends Ast.Selector.Device.prototype */ {
-        /**
-         * The Thingpedia class ID to choose.
-         * @type {string}
-         * @readonly
-         */
-        kind: adt.only(String),
-        /**
-         * The unique ID of the device being selected.
-         * @type {string|null}
-         * @readonly
-         */
-        id: adt.only(String, null),
-        principal: adt.only(null),
-    },
-    /**
-     * A selector that maps the builtin `notify`, `return` and `save` functions.
-     *
-     * This is a singleton, not a class.
-     * @type {Ast.Selector}
-     * @readonly
-     */
-    Builtin: null
-});
-module.exports.Selector = Selector.seal();
+    constructor(kind, id, principal) {
+        super();
+
+        assert(typeof kind === 'string');
+        this.kind = kind;
+
+        assert(typeof id === 'string' || id === null);
+        this.id = id;
+
+        assert(principal === null);
+        this.principal = principal;
+    }
+
+    clone() {
+        return new DeviceSelector(this.kind, this.id, this.principal);
+    }
+
+    toString() {
+        return `Device(${this.kind}, ${this.id ? this.id : ''}, ${this.principal ? this.principal : ''})`;
+    }
+}
+DeviceSelector.prototype.isDevice = true;
+Selector.Device = DeviceSelector;
+
+
+class BuiltinDevice extends Selector {
+    clone() {
+        return new BuiltinDevice();
+    }
+
+    toString() {
+        return 'Builtin';
+    }
+}
+BuiltinDevice.prototype.isBuiltin = true;
+
+/**
+ * A selector that maps the builtin `notify`, `return` and `save` functions.
+ *
+ * This is a singleton, not a class.
+ *
+ * @alias Ast.Selector.Builtin
+ * @readonly
+ */
+Selector.Builtin = new BuiltinDevice();
+module.exports.Selector = Selector;
 
 /**
  * An invocation of a ThingTalk function.

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -20,6 +20,7 @@ const {
     recursiveYieldArraySlots,
     FieldSlot
 } = require('./slots');
+const { stringEscape } = require('../escaping');
 
 /**
  * Base class of all expressions that select a device.
@@ -48,10 +49,12 @@ class DeviceSelector extends Selector {
      *
      * @param {string} kind - the Thingpedia class ID
      * @param {string|null} id - the unique ID of the device being selected, or null
-     *                           to select all devices
+     *                           to select devices according to the attributes, or
+     *                           all devices if no attributes are specified
      * @param {null} principal - reserved/deprecated, must be `null`
+     * @param {Ast.InputParam[]} attributes - other attributes used to select a device, if ID is unspecified
      */
-    constructor(kind, id, principal) {
+    constructor(kind, id, principal, attributes = []) {
         super();
 
         assert(typeof kind === 'string');
@@ -62,14 +65,16 @@ class DeviceSelector extends Selector {
 
         assert(principal === null);
         this.principal = principal;
+
+        this.attributes = attributes;
     }
 
     clone() {
-        return new DeviceSelector(this.kind, this.id, this.principal);
+        return new DeviceSelector(this.kind, this.id, this.principal, this.attributes.slice());
     }
 
     toString() {
-        return `Device(${this.kind}, ${this.id ? this.id : ''}, ${this.principal ? this.principal : ''})`;
+
     }
 }
 DeviceSelector.prototype.isDevice = true;

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -77,7 +77,7 @@ class DeviceSelector extends Selector {
     }
 
     toString() {
-
+        return `Device(${this.kind}, ${this.id ? this.id : ''}, )`;
     }
 }
 DeviceSelector.prototype.isDevice = true;

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -73,7 +73,8 @@ class DeviceSelector extends Selector {
     }
 
     clone() {
-        return new DeviceSelector(this.kind, this.id, this.principal, this.attributes.slice());
+        const attributes = this.attributes.map((attr) => attr.clone());
+        return new DeviceSelector(this.kind, this.id, this.principal, attributes);
     }
 
     toString() {

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -20,7 +20,6 @@ const {
     recursiveYieldArraySlots,
     FieldSlot
 } = require('./slots');
-const { stringEscape } = require('../escaping');
 
 /**
  * Base class of all expressions that select a device.
@@ -53,8 +52,10 @@ class DeviceSelector extends Selector {
      *                           all devices if no attributes are specified
      * @param {null} principal - reserved/deprecated, must be `null`
      * @param {Ast.InputParam[]} attributes - other attributes used to select a device, if ID is unspecified
+     * @param {boolean} [all=false] - operate on all devices that match the attributes, instead of
+     *                                having the user choose
      */
-    constructor(kind, id, principal, attributes = []) {
+    constructor(kind, id, principal, attributes = [], all = false) {
         super();
 
         assert(typeof kind === 'string');
@@ -67,6 +68,8 @@ class DeviceSelector extends Selector {
         this.principal = principal;
 
         this.attributes = attributes;
+
+        this.all = all;
     }
 
     clone() {

--- a/lib/ast/slots.js
+++ b/lib/ast/slots.js
@@ -300,7 +300,7 @@ class ArrayIndexSlot extends AbstractSlot {
         return this._type;
     }
     get tag() {
-        return `${this._baseTag}[${this._index}]`;
+        return `${this._baseTag}.${this._index}`;
     }
     getPrompt(locale) {
         const gettext = I18n.get(locale);

--- a/lib/ast/slots.js
+++ b/lib/ast/slots.js
@@ -34,6 +34,7 @@ class AbstractSlot {
      * @protected
      */
     constructor(prim, scope) {
+        assert(prim || prim === null);
         this._prim = prim;
 
 

--- a/lib/ast/slots.js
+++ b/lib/ast/slots.js
@@ -144,6 +144,37 @@ class InputParamSlot extends AbstractSlot {
     }
 }
 
+class DeviceAttributeSlot extends AbstractSlot {
+    constructor(prim, attr) {
+        super(prim, {});
+        this._slot = attr;
+        assert(this._slot.name === 'name');
+    }
+
+    toString() {
+        return `DeviceAttributeSlot(${this._slot.name} : ${this.type})`;
+    }
+
+    get type() {
+        return Type.String;
+    }
+    get tag() {
+        return `attribute.${this._slot.name}`;
+    }
+    getPrompt(locale) {
+        // this method should never be used, because $? does not typecheck in a device
+        // attribute, but we include for completeness, and just in case
+        const gettext = I18n.get(locale);
+        return gettext.dgettext('thingtalk', "Please tell me the name of the device you would like to use.");
+    }
+    get() {
+        return this._slot.value;
+    }
+    set(value) {
+        this._slot.value = value;
+    }
+}
+
 class FilterSlot extends AbstractSlot {
     constructor(prim, scope, arg, filter) {
         super(prim && prim.isPermissionRule ? null : prim, scope);
@@ -456,7 +487,8 @@ module.exports = {
     recursiveYieldArraySlots,
     makeScope,
     InputParamSlot,
+    DeviceAttributeSlot,
     FilterSlot,
     ArrayIndexSlot,
-    FieldSlot
+    FieldSlot,
 };

--- a/lib/compiler/ops-to-jsir.js
+++ b/lib/compiler/ops-to-jsir.js
@@ -48,10 +48,17 @@ module.exports = class OpCompiler {
             ast.__effectiveSelector = ast.selector;
         }
 
-        // TODO more attributes, and dynamic attributes (param-passing)
         const attributes = {};
         if (ast.__effectiveSelector.id)
             attributes.id = ast.__effectiveSelector.id;
+        // NOTE: "all" has no effect on the compiler, it only affects the dialog agent
+        // whether it should slot-fill id or not
+        // (in the future, this should probably be represented as id=$? like everywhere else...)
+
+        for (let attr of ast.__effectiveSelector.attributes) {
+            // attr.value cannot be a parameter passing in a program, so it's safe to call toJS here
+            attributes[attr.name] = attr.value.toJS();
+        }
         return [ast.__effectiveSelector.kind, attributes, ast.channel];
     }
 

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -351,6 +351,14 @@ class Describer {
         return recursiveHelper(expr);
     }
 
+    _getDeviceAttribute(selector, name) {
+        for (let attr of selector.attributes) {
+            if (attr.name === name)
+                return this.describeArg(attr.value, {});
+        }
+        return undefined;
+    }
+
     describePrimitive(obj, scope, extraInParams = []) {
         if (obj.selector.isBuiltin) {
             if (obj.channel === 'return')
@@ -378,10 +386,26 @@ class Describer {
                 throw TypeError('Invalid @remote channel ' + channel);
         } else {
             confirm = schema.confirmation;
+
+            let cleanKind = obj.schema.class ? obj.schema.class.canonical : clean(obj.selector.kind);
+
+            let selector;
+            let name = this._getDeviceAttribute(obj.selector, 'name');
             if (obj.selector.device)
-                confirm = confirm.replace('$__device', obj.selector.device.name);
+                selector = this._("your %s").format(obj.selector.device.name);
+            else if (obj.selector.all && name)
+                selector = this._("all your %s %s").format(name, cleanKind);
+            else if (obj.selector.all)
+                selector = this._("all your %s").format(cleanKind);
+            else if (name)
+                selector = this._("your %s %s").format(name, cleanKind);
             else
-                confirm = confirm.replace('$__device', clean(kind));
+                selector = this._("your %s").format(cleanKind);
+
+            if (confirm.indexOf('$__device') >= 0)
+                confirm = confirm.replace('$__device', selector);
+            else if (confirm.indexOf('${__device}') >= 0)
+                confirm = confirm.replace('${__device}', selector);
         }
 
         let firstExtra = true;

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -13,7 +13,7 @@ const assert = require('assert');
 
 const Ast = require('./ast');
 const Type = require('./type');
-const { clean } = require('./utils');
+const { clean, cleanKind } = require('./utils');
 const FormatUtils = require('./format_utils');
 const { Currency } = require('./builtin/values');
 const I18n = require('./i18n');
@@ -856,9 +856,9 @@ class Describer {
 
             switch (functionType) {
             case 'query':
-                return this._("your %s").format(doCapitalizeSelector(kind));
+                return this._("your %s").format(capitalize(cleanKind(kind)));
             case 'action':
-                return this._("perform any action on your %s").format(doCapitalizeSelector(kind));
+                return this._("perform any action on your %s").format(capitalize(cleanKind(kind)));
             default:
                 return '';
             }
@@ -981,7 +981,7 @@ class Describer {
 }
 
 function capitalize(str) {
-    return (str[0].toUpperCase() + str.substr(1)).replace(/[.\-_]([a-z])/g, (whole, char) => ' ' + char.toUpperCase()).replace(/[.\-_]/g, '');
+    return str.split(/\s+/g).map((word) => word[0].toUpperCase() + word.substring(1)).join(' ');
 }
 
 function capitalizeSelector(prim) {
@@ -994,27 +994,10 @@ function capitalizeSelector(prim) {
 }
 
 function doCapitalizeSelector(kind, channel) {
-    // thingengine.phone -> phone
-    if (kind.startsWith('org.thingpedia.builtin.thingengine.'))
-        kind = kind.substr('org.thingpedia.builtin.thingengine.'.length);
-    // org.thingpedia.builtin.omlet -> omlet
-    if (kind.startsWith('org.thingpedia.builtin.'))
-        kind = kind.substr('org.thingpedia.builtin.'.length);
-    // org.thingpedia.weather -> weather
-    if (kind.startsWith('org.thingpedia.'))
-        kind = kind.substr('org.thingpedia.'.length);
-    // com.xkcd -> xkcd
-    if (kind.startsWith('com.'))
-        kind = kind.substr('com.'.length);
-    if (kind.startsWith('gov.'))
-        kind = kind.substr('gov.'.length);
-    if (kind.startsWith('org.'))
-        kind = kind.substr('org.'.length);
-    if (kind.startsWith('uk.co.'))
-        kind = kind.substr('uk.co.'.length);
+    kind = cleanKind(kind);
 
     if (kind === 'builtin' || kind === 'remote' || kind.startsWith('__dyn_'))
-        return capitalize(channel);
+        return capitalize(clean(channel));
     else
         return capitalize(kind);
 }

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -287,14 +287,23 @@ example = 'stream'  _ params:(lambda_param_decl_list)? _ ':=' _ stream:stream _ 
 
 device_selector = type:class_name _ attrlist:input_param_list {
     let id = null;
+    let all = undefined;
     for (let { name, value } of attrlist) {
         if (name === 'id') {
             if (!value.isString)
                 return error(`id attribute must be a constant string`);
+            if (id)
+                return error(`duplicate device id`);
             id = value.toJS();
+        } else if (name === 'all') {
+            if (!value.isBoolean)
+                return error(`all attribute must be a constant boolean`);
+            if (all !== undefined)
+                return error(`duplicate device attribute all`);
+            all = value.toJS();
         }
     }
-    return new Ast.Selector.Device(type, id, null, attrlist.filter((attr) => attr.name !== 'id'));
+    return new Ast.Selector.Device(type, id, null, attrlist.filter((attr) => attr.name !== 'id'), !!all);
 }
 device_attribute_list = first:device_attribute _ rest:(',' _ device_attribute _)* {
     return [first].concat(take(rest, 2));

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -314,7 +314,7 @@ short_function_name = '@' first_name:classident _ rest_names:('.' _ classident _
     rest_names.pop();
 
     let kind = first_name + (rest_names.length > 0 ? ('.' + take(rest_names, 2).join('.')) : '');
-    return [Ast.Selector.Device(kind, null, null), channel[2]];
+    return [new Ast.Selector.Device(kind, null, null), channel[2]];
 }
 full_function_name = sel:device_selector _ '.' _ name:ident {
     return [sel, name];

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -303,7 +303,8 @@ device_selector = type:class_name _ attrlist:input_param_list {
             all = value.toJS();
         }
     }
-    return new Ast.Selector.Device(type, id, null, attrlist.filter((attr) => attr.name !== 'id'), !!all);
+    return new Ast.Selector.Device(type, id, null,
+        attrlist.filter((attr) => attr.name !== 'id' && attr.name !== 'all'), !!all);
 }
 device_attribute_list = first:device_attribute _ rest:(',' _ device_attribute _)* {
     return [first].concat(take(rest, 2));

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -285,28 +285,22 @@ example = 'stream'  _ params:(lambda_param_decl_list)? _ ':=' _ stream:stream _ 
 
 // Function Calls
 
-device_selector = type:class_name _ '(' _ values:device_attribute_list _ ')' {
-    var id;
-    if (values.id !== undefined)
-        id = values.id;
-    else
-        id = null;
-    if (id !== null)
-        id = id.toJS();
-    return new Ast.Selector.Device(type, id, null);
+device_selector = type:class_name _ attrlist:input_param_list {
+    let id = null;
+    for (let { name, value } of attrlist) {
+        if (name === 'id') {
+            if (!value.isString)
+                return error(`id attribute must be a constant string`);
+            id = value.toJS();
+        }
+    }
+    return new Ast.Selector.Device(type, id, null, attrlist.filter((attr) => attr.name !== 'id'));
 }
 device_attribute_list = first:device_attribute _ rest:(',' _ device_attribute _)* {
-    var obj = {};
-    obj[first[0]] = first[1];
-    for (var [name, value] of rest) {
-        if (obj[name] !== undefined) return error('Duplicate device attribute ' + name);
-        obj[name] = value;
-    }
-    return obj;
+    return [first].concat(take(rest, 2));
 }
-device_attribute = device_id
-device_id = 'id' _ '=' _ value:string_value {
-    return ['id', value];
+device_attribute = name:('id' / 'name') _ '=' _ value:value {
+    return new Ast.InputParam(name, value);
 }
 
 short_function_name = '@' first_name:classident _ rest_names:('.' _ classident _)+ {

--- a/lib/nn-syntax/lexer.js
+++ b/lib/nn-syntax/lexer.js
@@ -100,6 +100,10 @@ module.exports = class SequenceLexer {
             let [,paramname,] = next.split(':');
             this._lastparam = paramname;
             next = new TokenWrapper('PARAM_NAME', paramname);
+        } else if (next.startsWith('attribute:')) {
+            let [,paramname,] = next.split(':');
+            this._lastparam = paramname;
+            next = new TokenWrapper('ATTRIBUTE_NAME', paramname);
         } else if (next.startsWith('unit:')) {
             next = new TokenWrapper('UNIT', next.substring('unit:'.length));
         } else if (next.startsWith('device:')) {

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -242,7 +242,7 @@ selector = {
     fn:FUNCTION => [new Ast.Selector.Device(fn.value.kind, null, null), fn.value.channel];
 
     selector attr:device_attribute => {
-        const [sel, chan] = selector;
+        const [sel,] = selector;
         if (attr.name === 'id')
             sel.id = attr.value.toJS();
         else if (attr.name === 'all')

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -238,8 +238,30 @@ action = {
     call => new Ast.Action.Invocation(call, null);
 }
 
+selector = {
+    fn:FUNCTION => [new Ast.Selector.Device(fn.value.kind, null, null), fn.value.channel];
+
+    selector attr:device_attribute => {
+        const [sel, chan] = selector;
+        if (attr.name === 'id')
+            sel.id = attr.value.toJS();
+        else if (attr.name === 'all')
+            sel.all = attr.value.toJS();
+        else
+            sel.attributes.push(attr);
+        return selector;
+    };
+}
+
+device_attribute = {
+    pname:ATTRIBUTE_NAME '=' v:constant => new Ast.InputParam(pname.value, v);
+}
+
 call = {
-    fn:FUNCTION => new Ast.Invocation(new Ast.Selector.Device(fn.value.kind, null, null), fn.value.channel, [], null);
+    selector => {
+        const [sel, chan] = selector;
+        return new Ast.Invocation(sel, chan, [], null);
+    };
     inv:call ip:const_param => {
         inv = inv.clone();
         inv.in_params.push(ip);

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -702,6 +702,28 @@ module.exports = class ToNNConverter {
         }
     }
 
+    _invocationToNN(invocation) {
+        let fn = `@${invocation.selector.kind}.${invocation.channel}`;
+        if (invocation.selector.all)
+            fn = List.concat(fn, 'attribute:all:Boolean', '=', 'true');
+        invocation.selector.attributes.sort((p1, p2) => {
+            if (p1.name < p2.name)
+                return -1;
+            if (p1.name > p2.name)
+                return 1;
+            return 0;
+        });
+        for (let attr of invocation.selector.attributes) {
+            if (attr.value.isUndefined && attr.value.local)
+                continue;
+
+            // explicitly pass null to valueToNN because there should be no parameter passing in NN-syntax
+            fn = List.concat(fn, `attribute:${attr.name}:String`, '=', this.valueToNN(attr.value, null));
+        }
+
+        return fn;
+    }
+
     tableToNN(table) {
         if (table.isVarRef) {
             throw new UnsynthesizableError('Table macros');
@@ -711,10 +733,6 @@ module.exports = class ToNNConverter {
             else
                 return List.concat(`result`, '(', `@${table.kind}.${table.channel}`, '[', this.valueToNN(table.index, null), ']', ')');
         } else if (table.isInvocation) {
-            let principal = null;
-            if (table.invocation.selector.principal !== null)
-                principal = this.valueToNN(table.invocation.selector.principal, null);
-
             let params = List.Nil;
             table.invocation.in_params.sort((p1, p2) => {
                 if (p1.name < p2.name)
@@ -733,11 +751,7 @@ module.exports = class ToNNConverter {
                 params = List.concat(params, `param:${inParam.name}:${ptype}`, '=', this.valueToNN(inParam.value, null));
             }
 
-            let fn = `@${table.invocation.selector.kind}.${table.invocation.channel}`;
-            if (principal)
-                return List.concat(fn, 'of', principal, params);
-            else
-                return List.concat(fn, params);
+            return List.concat(this._invocationToNN(table.invocation), params);
         } else if (table.isFilter) {
             let optimized = filterToCNF(table.filter);
             if (optimized.isFalse)
@@ -820,10 +834,6 @@ module.exports = class ToNNConverter {
     }
 
     actionInvocationToNN(action, outschema) {
-        let principal = null;
-        if (action.selector.principal !== null)
-            principal = this.valueToNN(action.selector.principal, null);
-
         let const_param = List.Nil;
         let param_passing = List.Nil;
 
@@ -848,11 +858,7 @@ module.exports = class ToNNConverter {
             }
         }
 
-        const fn = `@${action.selector.kind}.${action.channel}`;
-        if (principal)
-            return List.concat(fn, 'of', principal, const_param, param_passing);
-        else
-            return List.concat(fn, const_param, param_passing);
+        return List.concat(this._invocationToNN(action), const_param, param_passing);
     }
 
     actionToNN(action, outschema) {

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -102,9 +102,18 @@ function prettyprintSelector(ast) {
     if (ast.isBuiltin)
         return '';
 
-    if (ast.id)
-        return `@${ast.kind}(id=${stringEscape(ast.id)})`;
-    return `@${ast.kind}`;
+    if (ast.attributes.length > 0) {
+        const attributes = ast.attributes.map(prettyprintInputParam).join(', ');
+
+        if (ast.id)
+            return `@${ast.kind}(id=${stringEscape(ast.id)}, ${attributes})`;
+        else
+            return `@${ast.kind}(${attributes})`;
+    } else {
+        if (ast.id)
+            return `@${ast.kind}(id=${stringEscape(ast.id)})`;
+        return `@${ast.kind}`;
+    }
 }
 
 function prettyprintInputParam(ast) {

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -107,12 +107,17 @@ function prettyprintSelector(ast) {
 
         if (ast.id)
             return `@${ast.kind}(id=${stringEscape(ast.id)}, ${attributes})`;
+        else if (ast.all)
+            return `@${ast.kind}(all=true, ${attributes})`;
         else
             return `@${ast.kind}(${attributes})`;
     } else {
         if (ast.id)
             return `@${ast.kind}(id=${stringEscape(ast.id)})`;
-        return `@${ast.kind}`;
+        else if (ast.all)
+            return `@${ast.kind}(all=true)`;
+        else
+            return `@${ast.kind}`;
     }
 }
 

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -79,6 +79,14 @@ class Scope {
         this._lambda_args = {};
     }
 
+    clone() {
+        const newself = new Scope(this._parentScope);
+        Object.assign(newself._scope, this._scope);
+        newself.$has_event = this.$has_event;
+        Object.assign(newself._lambda_args, this._lambda_args);
+        return newself;
+    }
+
     cleanOutput() {
         this._scope = {};
     }
@@ -620,6 +628,9 @@ function typeCheckInputArgs(ast, schema, scope, classes) {
 
         if (ast.selector.isDevice) {
             let dupes = new Set;
+
+            const attrscope = scope.clone();
+            attrscope.cleanOutput();
             for (let attr of ast.selector.attributes) {
                 if (dupes.has(attr.name))
                     throw new TypeError(`Duplicate device attribute ${attr.name}`);
@@ -628,7 +639,7 @@ function typeCheckInputArgs(ast, schema, scope, classes) {
                 if (VALID_DEVICE_ATTRIBUTES.indexOf(attr.name) < 0)
                     throw new TypeError(`Invalid device attribute ${attr.name}`);
 
-                const valueType = typeForValue(attr.value, scope);
+                const valueType = typeForValue(attr.value, attrscope);
                 if (!Type.isAssignable(valueType, Type.String, {}, false) || attr.value.isUndefined)
                     throw new TypeError(`Invalid type for device attribute ${attr.name}, have ${valueType}, need String`);
             }

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -629,8 +629,9 @@ function typeCheckInputArgs(ast, schema, scope, classes) {
         if (ast.selector.isDevice) {
             let dupes = new Set;
 
-            const attrscope = scope.clone();
-            attrscope.cleanOutput();
+            const attrscope = scope ? scope.clone() : null;
+            if (attrscope)
+                attrscope.cleanOutput();
             for (let attr of ast.selector.attributes) {
                 if (dupes.has(attr.name))
                     throw new TypeError(`Duplicate device attribute ${attr.name}`);

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -614,15 +614,30 @@ function resolveJoin(ast, lhs, rhs) {
 
 function typeCheckInputArgs(ast, schema, scope, classes) {
     if (!ast.isVarRef && !ast.isJoin) {
-        if (ast.selector.kind in classes) {
-            const classdef = classes[ast.selector.kind];
+        assert(ast.selector);
 
-            if (classdef.extends && classdef.extends.length === 1 && classdef.extends[0] === 'org.thingpedia.builtin.thingengine.remote')
-                ast.__effectiveSelector = new Ast.Selector.Device('org.thingpedia.builtin.thingengine.remote', ast.selector.id, ast.selector.principal);
-            else
+        if (ast.selector.isDevice) {
+            let dupes = new Set;
+            for (let attr of ast.selector.attributes) {
+                if (dupes.has(attr.name))
+                    throw new TypeError(`Duplicate device attribute ${attr.name}`);
+                dupes.add(attr.name);
+
+                const valueType = typeForValue(attr.value, scope);
+                if (!Type.isAssignable(valueType, Type.String, {}, false))
+                    throw new TypeError(`Invalid type for device attribute ${attr.name}, have ${valueType}, need String`);
+            }
+
+            if (ast.selector.kind in classes) {
+                const classdef = classes[ast.selector.kind];
+
+                if (classdef.extends && classdef.extends.length === 1 && classdef.extends[0] === 'org.thingpedia.builtin.thingengine.remote')
+                    ast.__effectiveSelector = new Ast.Selector.Device('org.thingpedia.builtin.thingengine.remote', ast.selector.id, ast.selector.principal, ast.selector.attributes.slice());
+                else
+                    ast.__effectiveSelector = ast.selector;
+            } else {
                 ast.__effectiveSelector = ast.selector;
-        } else {
-            ast.__effectiveSelector = ast.selector;
+            }
         }
     }
 

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -618,7 +618,7 @@ function typeCheckInputArgs(ast, schema, scope, classes) {
             const classdef = classes[ast.selector.kind];
 
             if (classdef.extends && classdef.extends.length === 1 && classdef.extends[0] === 'org.thingpedia.builtin.thingengine.remote')
-                ast.__effectiveSelector = Ast.Selector.Device('org.thingpedia.builtin.thingengine.remote', ast.selector.id, ast.selector.principal);
+                ast.__effectiveSelector = new Ast.Selector.Device('org.thingpedia.builtin.thingengine.remote', ast.selector.id, ast.selector.principal);
             else
                 ast.__effectiveSelector = ast.selector;
         } else {

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -612,6 +612,8 @@ function resolveJoin(ast, lhs, rhs) {
     );
 }
 
+const VALID_DEVICE_ATTRIBUTES = ['name'];
+
 function typeCheckInputArgs(ast, schema, scope, classes) {
     if (!ast.isVarRef && !ast.isJoin) {
         assert(ast.selector);
@@ -623,10 +625,16 @@ function typeCheckInputArgs(ast, schema, scope, classes) {
                     throw new TypeError(`Duplicate device attribute ${attr.name}`);
                 dupes.add(attr.name);
 
+                if (VALID_DEVICE_ATTRIBUTES.indexOf(attr.name) < 0)
+                    throw new TypeError(`Invalid device attribute ${attr.name}`);
+
                 const valueType = typeForValue(attr.value, scope);
-                if (!Type.isAssignable(valueType, Type.String, {}, false))
+                if (!Type.isAssignable(valueType, Type.String, {}, false) || attr.value.isUndefined)
                     throw new TypeError(`Invalid type for device attribute ${attr.name}, have ${valueType}, need String`);
             }
+
+            if (ast.selector.id && ast.selector.all)
+                throw new TypeError(`all=true device attribute is incompatible with setting a device ID`);
 
             if (ast.selector.kind in classes) {
                 const classdef = classes[ast.selector.kind];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,6 +23,29 @@ function clean(name) {
     return name.replace(/_/g, ' ').replace(/([^A-Z ])([A-Z])/g, '$1 $2').toLowerCase();
 }
 
+function cleanKind(kind) {
+    // thingengine.phone -> phone
+    if (kind.startsWith('org.thingpedia.builtin.thingengine.'))
+        kind = kind.substr('org.thingpedia.builtin.thingengine.'.length);
+    // org.thingpedia.builtin.omlet -> omlet
+    if (kind.startsWith('org.thingpedia.builtin.'))
+        kind = kind.substr('org.thingpedia.builtin.'.length);
+    // org.thingpedia.weather -> weather
+    if (kind.startsWith('org.thingpedia.'))
+        kind = kind.substr('org.thingpedia.'.length);
+    // com.xkcd -> xkcd
+    if (kind.startsWith('com.'))
+        kind = kind.substr('com.'.length);
+    if (kind.startsWith('gov.'))
+        kind = kind.substr('gov.'.length);
+    if (kind.startsWith('org.'))
+        kind = kind.substr('org.'.length);
+    if (kind.startsWith('uk.co.'))
+        kind = kind.substr('uk.co.'.length);
+    kind = kind.replace(/[.-]/g, ' ');
+    return clean(kind);
+}
+
 // this regexp is similar to the one in runtime/formatter.js, but it does not allow '%' as an option
 // FIXME: unify
 const PARAM_REGEX = /\$(?:\$|([a-zA-Z0-9_]+(?![a-zA-Z0-9_]))|{([a-zA-Z0-9_]+)(?::([a-zA-Z0-9_]+))?})/;
@@ -52,6 +75,7 @@ module.exports = {
     split,
     makeIndex,
     clean,
+    cleanKind,
 
     getSchemaForSelector(schemaRetriever, type, name, schemaType, getMeta = false, classes = {}) {
         if (type in classes) {

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1941,7 +1941,7 @@ now => compute flat(review, author == 'bob') of @org.schema.hotel() => notify;
 now => @light-bulb(name="bathroom").set_power(power=enum(on));
 now => @light-bulb(name="ceiling").set_power(power=enum(on));
 
-let query x(p_name : String) := @light-bulb(name=p_name).set_power(power=enum(on));
+let action x(p_name : String) := @light-bulb(name=p_name).set_power(power=enum(on));
 
 ====
 
@@ -1949,3 +1949,9 @@ dataset @light-bulb {
   action (p_name : String) := @light-bulb(name=p_name).set_power(power=enum(on))
   #_[utterances=["turn on my $p_name lights"]];
 }
+
+====
+
+// ** typecheck: expect TypeError **
+// no param passing into a device attribute
+now => @com.bing.web_search() => @light-bulb(name=title).set_power(power=enum(on));

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1942,3 +1942,10 @@ now => @light-bulb(name="bathroom").set_power(power=enum(on));
 now => @light-bulb(name="ceiling").set_power(power=enum(on));
 
 let query x(p_name : String) := @light-bulb(name=p_name).set_power(power=enum(on));
+
+====
+
+dataset @light-bulb {
+  action (p_name : String) := @light-bulb(name=p_name).set_power(power=enum(on))
+  #_[utterances=["turn on my $p_name lights"]];
+}

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1935,3 +1935,10 @@ now => compute flat(review) of @org.schema.hotel() => notify;
 ====
 
 now => compute flat(review, author == 'bob') of @org.schema.hotel() => notify;
+
+====
+
+now => @light-bulb(name="bathroom").set_power(power=enum(on));
+now => @light-bulb(name="ceiling").set_power(power=enum(on));
+
+let query x(p_name : String) := @light-bulb(name=p_name).set_power(power=enum(on));

--- a/test/test_compiler.js
+++ b/test/test_compiler.js
@@ -6032,6 +6032,34 @@ const TEST_CASES = [
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }`]],
+
+    //78 Test device selector
+    [`now => @light-bulb(name="bedroom").set_power(power=enum(on));`,
+    [`"use strict";
+  let _t_0;
+  let _t_1;
+  try {
+    _t_0 = {};
+    _t_1 = "on";
+    _t_0.power = _t_1;
+    await __env.invokeAction("light-bulb", { name: "bedroom", }, "set_power", _t_0);
+  } catch(_exc_) {
+    __env.reportError("Failed to invoke action", _exc_);
+  }`]],
+
+    //78 Test device selector (with explicit all)
+    [`now => @light-bulb(name="bedroom", all=true).set_power(power=enum(on));`,
+    [`"use strict";
+  let _t_0;
+  let _t_1;
+  try {
+    _t_0 = {};
+    _t_1 = "on";
+    _t_0.power = _t_1;
+    await __env.invokeAction("light-bulb", { name: "bedroom", }, "set_power", _t_0);
+  } catch(_exc_) {
+    __env.reportError("Failed to invoke action", _exc_);
+  }`]],
 ];
 
 // eslint-disable-next-line prefer-arrow-callback

--- a/test/test_describe.js
+++ b/test/test_describe.js
@@ -303,6 +303,20 @@ var TEST_CASES = [
     `tweet ____ every day at ____`, 'Twitter'],
     [`now => @com.twitter.post(status = $context.selection : String);`,
     `tweet the selection on the screen`, `Twitter`],
+
+    ['now => @light-bulb.set_power();',
+    'turn ____ your light-bulb', 'Light Bulb'],
+    ['now => @light-bulb(name="bedroom").set_power();',
+    'turn ____ your “bedroom” light-bulb', 'Light Bulb'],
+    ['now => @light-bulb(name="bedroom", all=true).set_power();',
+    'turn ____ all your “bedroom” light-bulb', 'Light Bulb'],
+    ['now => @light-bulb(all=true).set_power();',
+    'turn ____ all your light-bulb', 'Light Bulb'],
+
+    [`monitor (@smoke-alarm.status()) => notify;`,
+    'notify you when the status of your smoke alarm changes', 'Smoke Alarm ⇒ Notification'],
+    [`monitor (@smoke-alarm(name="kitchen").status()) => notify;`,
+    'notify you when the status of your “kitchen” smoke alarm changes', 'Smoke Alarm ⇒ Notification'],
 ];
 
 const gettext = {

--- a/test/test_describe.js
+++ b/test/test_describe.js
@@ -305,13 +305,13 @@ var TEST_CASES = [
     `tweet the selection on the screen`, `Twitter`],
 
     ['now => @light-bulb.set_power();',
-    'turn ____ your light-bulb', 'Light Bulb'],
+    'turn ____ your light bulb', 'Light Bulb'],
     ['now => @light-bulb(name="bedroom").set_power();',
-    'turn ____ your “bedroom” light-bulb', 'Light Bulb'],
+    'turn ____ your “bedroom” light bulb', 'Light Bulb'],
     ['now => @light-bulb(name="bedroom", all=true).set_power();',
-    'turn ____ all your “bedroom” light-bulb', 'Light Bulb'],
+    'turn ____ all your “bedroom” light bulb', 'Light Bulb'],
     ['now => @light-bulb(all=true).set_power();',
-    'turn ____ all your light-bulb', 'Light Bulb'],
+    'turn ____ all your light bulb', 'Light Bulb'],
 
     [`monitor (@smoke-alarm.status()) => notify;`,
     'notify you when the status of your smoke alarm changes', 'Smoke Alarm ⇒ Notification'],

--- a/test/test_example_program.js
+++ b/test/test_example_program.js
@@ -39,6 +39,9 @@ var TEST_CASES = [
 
     ['dataset foo { action (p_song1 : String, p_song2 : String) := @com.spotify.play_songs(songs=[p_song1, p_song2]); }',
      'now => @com.spotify.play_songs(songs=[__const_SLOT_0, __const_SLOT_1]);'],
+
+     ['dataset foo { action (p_name : String) := @light-bulb(name=p_name).set_power(power=enum(on)); }',
+     'now => @light-bulb(name=__const_SLOT_0).set_power(power=enum(on));'],
 ];
 
 function test(i) {

--- a/test/test_iteration_apis.js
+++ b/test/test_iteration_apis.js
@@ -143,8 +143,8 @@ var TEST_CASES = [
      'Builtin undefined:notify'],
     ['Selector(@com.instagram)',
      'Selector(@org.thingpedia.weather)',
-     'ArrayIndexSlot([0] : Number) table.index[0] What is the index of the first result you would like?',
-     'ArrayIndexSlot([1] : Number) table.index[1] What is the index of the second result you would like?'],
+     'ArrayIndexSlot([0] : Number) table.index.0 What is the index of the first result you would like?',
+     'ArrayIndexSlot([1] : Number) table.index.1 What is the index of the second result you would like?'],
     ],
 
     [`now => (@com.instagram.get_pictures() join @org.thingpedia.weather.current() on (location=location))[1:2] => notify;`,
@@ -368,7 +368,7 @@ var TEST_CASES = [
     [`action: Invocation(Device(com.twitter, , ), post, InputParam(status, Undefined(true)), )`],
     ['Device(com.twitter, , ) com.twitter:post',
      'InputParam(status, Undefined(true)) com.twitter:post'],
-    ['ArrayIndexSlot([0] : Time) attimer.time[0] When do you want your command to run?',
+    ['ArrayIndexSlot([0] : Time) attimer.time.0 When do you want your command to run?',
      'Selector(@com.twitter)',
      'InputParamSlot(status : String) in_param.status What do you want to tweet?']
     ],
@@ -378,8 +378,8 @@ var TEST_CASES = [
     [`action: Invocation(Device(com.twitter, , ), post, InputParam(status, Undefined(true)), )`],
     ['Device(com.twitter, , ) com.twitter:post',
      'InputParam(status, Undefined(true)) com.twitter:post'],
-    ['ArrayIndexSlot([0] : Time) attimer.time[0] What is the first time you would like your command to run?',
-     'ArrayIndexSlot([1] : Time) attimer.time[1] What is the second time you would like your command to run?',
+    ['ArrayIndexSlot([0] : Time) attimer.time.0 What is the first time you would like your command to run?',
+     'ArrayIndexSlot([1] : Time) attimer.time.1 What is the second time you would like your command to run?',
      'Selector(@com.twitter)',
      'InputParamSlot(status : String) in_param.status What do you want to tweet?']
     ],
@@ -389,8 +389,8 @@ var TEST_CASES = [
     [`action: Invocation(Device(com.twitter, , ), post, InputParam(status, Undefined(true)), )`],
     ['Device(com.twitter, , ) com.twitter:post',
      'InputParam(status, Undefined(true)) com.twitter:post'],
-    ['ArrayIndexSlot([0] : Time) attimer.time[0] What is the first time you would like your command to run?',
-     'ArrayIndexSlot([1] : Time) attimer.time[1] What is the second time you would like your command to run?',
+    ['ArrayIndexSlot([0] : Time) attimer.time.0 What is the first time you would like your command to run?',
+     'ArrayIndexSlot([1] : Time) attimer.time.1 What is the second time you would like your command to run?',
      'FieldSlot(expiration_date : Date) attimer.expiration_date When should your command stop?',
      'Selector(@com.twitter)',
      'InputParamSlot(status : String) in_param.status What do you want to tweet?']
@@ -415,8 +415,8 @@ var TEST_CASES = [
     [],
     ['Atom(source, in_array, Array(Undefined(true),Undefined(true)))'],
     ['FilterSlot(source in_array : Array(Entity(tt:contact))) filter.in_array.$source Who is allowed to ask you for this command?',
-    'ArrayIndexSlot([0] : Entity(tt:contact)) filter.in_array.$source[0] Who is the first friend who is allowed to ask you for this command?',
-    'ArrayIndexSlot([1] : Entity(tt:contact)) filter.in_array.$source[1] Who is the second friend who is allowed to ask you for this command?']
+    'ArrayIndexSlot([0] : Entity(tt:contact)) filter.in_array.$source.0 Who is the first friend who is allowed to ask you for this command?',
+    'ArrayIndexSlot([1] : Entity(tt:contact)) filter.in_array.$source.1 Who is the second friend who is allowed to ask you for this command?']
     ],
 
     [`now => @org.schema.restaurant(), count(review, author =~ "bob") >= 1 => notify;`,

--- a/test/test_iteration_apis.js
+++ b/test/test_iteration_apis.js
@@ -429,6 +429,19 @@ var TEST_CASES = [
     ['Selector(@org.schema)',
      'FilterSlot(author =~ : String) filter.=~.author What should the author contain?']
     ],
+
+    [`now => @light-bulb(name="bedroom").set_power(power=enum(off));`,
+    ['action: Invocation(Device(light-bulb, , ), set_power, InputParam(power, Enum(off)), )'],
+    [
+    'Device(light-bulb, , ) light-bulb:set_power',
+    'InputParam(power, Enum(off)) light-bulb:set_power',
+    ],
+    [
+    'DeviceAttributeSlot(name : String) attribute.name Please tell me the name of the device you would like to use.',
+    'Selector(@light-bulb)',
+    'InputParamSlot(power : Enum(on,off)) in_param.power Do you want to turn it on or off?',
+    ]
+    ]
 ];
 
 async function test(i) {

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -458,6 +458,10 @@ const TEST_CASES = [
     [`compute distance ( param:location:Location , location:current_location ) of ( monitor ( @com.yelp.restaurants ) ) => notify`,
     `get restaurants and their distance from here`, {},
     `compute distance(location, $context.location.current_location) of (monitor (@com.yelp.restaurants())) => notify;`],
+
+    [`now => @light-bulb.set_power attribute:name:String = " bedroom " param:power:Enum(on,off) = enum:off`,
+    `turn off my bedroom lights`, {},
+    `now => @light-bulb(name="bedroom").set_power(power=enum(off));`],
 ];
 
 async function testCase(test, i) {

--- a/test/test_prettyprint.js
+++ b/test/test_prettyprint.js
@@ -46,7 +46,11 @@ const TEST_CASES = [
   list query q(out num: Number);
 }
 now => (@foo.bar.q()), @foo.bar.itself(x=num) >= 0 => notify;
-now => (@foo.bar.q()), @for.bar.greaterThanZero(x=num) => notify;`
+now => (@foo.bar.q()), @for.bar.greaterThanZero(x=num) => notify;`,
+
+// device selectors
+`now => @light-bulb(name="bathroom").set_power(power=enum(on));`,
+`now => @light-bulb(id="io.home-assistant/http://hassio.local:8123-light.hue_bloom_1", name="bathroom").set_power(power=enum(on));`
 ];
 
 function main() {

--- a/test/thingpedia.tt
+++ b/test/thingpedia.tt
@@ -708,19 +708,18 @@ class @org.thingpedia.builtin.thingengine.builtin
   #_[canonical="say"]
   #_[confirmation="send me a message $message"];
 }
-class @light-bulb
-#_[canonical="light bulb"] {
+class @light-bulb {
   action alert_long()
   #_[canonical="flash alert lights on light bulb"]
-  #_[confirmation="flash alerts on your lightbulb"];
+  #_[confirmation="flash alerts on ${__device}"];
 
   action color_loop()
   #_[canonical="color loop lights on light bulb"]
-  #_[confirmation="loop colors on your lightbulb"];
+  #_[confirmation="loop colors on ${__device}"];
 
   action set_power(in req power: Enum(on,off) #_[prompt="Do you want to turn it on or off?"] #_[canonical="power"])
   #_[canonical="set power on light bulb"]
-  #_[confirmation="turn $power your lightbulb"];
+  #_[confirmation="turn $power ${__device}"];
 }
 class @com.hue
 #_[canonical="philips hue"] {
@@ -767,6 +766,9 @@ class @com.gmail
 }
 class @smoke-alarm
 #_[canonical="smoke alarm"] {
+  monitorable query status(out detected : Boolean)
+  #_[canonical="smoke alarm status"]
+  #_[confirmation="the status of ${__device}"];
 }
 class @com.google.drive
 #_[canonical="google drive"] {


### PR DESCRIPTION
So we can ask "turn on my bedroom lights"

This is a feature asked by @balloob.
This is only part 1. Part 2 is the dialog agent to actually select the device. Part 3 is Genie to train those sentences. Part 4 is every Thingpedia device that would like this functionality should add relevant templates and change their confirmation string.