### PR TITLE
AbstractSlot: add "arg" property

### DIFF
--- a/lib/ast/slots.js
+++ b/lib/ast/slots.js
@@ -42,17 +42,43 @@ class AbstractSlot {
         this._options = undefined;
     }
 
+    /**
+     * The primitive associated with this slot, if any.
+     * @type {Ast.Invocation|null}
+     * @readonly
+     */
     get primitive() {
         return this._prim;
     }
+    /**
+     * The function argument associated with this slot, if any.
+     * @type {Ast.ArgumentDef|null}
+     * @readonly
+     */
+    get arg() {
+        return null;
+    }
+    /**
+     * Names which are available for parameter passing into this slot.
+     * @type {Object.<string, Ast.ScopeEntry>}
+     * @readonly
+     */
     get scope() {
         return this._scope;
     }
 
-    // the available options to parameter pass from
-    // this is computed lazily because it needs this.type, which
-    // is not available in the constructor
+    /**
+     * The available options to parameter pass from.
+     *
+     * This is the subset of {Ast~AbstractSlot#scope} whose type matches
+     * that of this slot.
+     * @type {Object.<string, Ast.ScopeEntry>}
+     * @readonly
+     */
     get options() {
+        // this is computed lazily because it needs this.type, which
+        // is not available in the constructor
+
         if (this._options)
             return this._options;
 
@@ -67,10 +93,18 @@ class AbstractSlot {
     }
 
     /* istanbul ignore next */
+    /**
+     * The type of this slot.
+     * @type {Type}
+     */
     get type() {
         throw new Error('Abstract method');
     }
     /* istanbul ignore next */
+    /**
+     * Retrieve the question to ask the user to fill this slot.
+     *
+     * @param {string} locale - the locale to use
     getPrompt(locale) {
         throw new Error('Abstract method');
     }
@@ -120,6 +154,9 @@ class InputParamSlot extends AbstractSlot {
         return this._arg ? this._arg.canonical : clean(this._slot.name);
     }
 
+    get arg() {
+        return this._arg || null;
+    }
     get type() {
         if (this._arg)
             return this._arg.type;
@@ -214,6 +251,9 @@ class FilterSlot extends AbstractSlot {
         return this._options = options;
     }
 
+    get arg() {
+        return this._arg || null;
+    }
     get type() {
         if (this._isSourceFilter) {
             switch (this._filter.operator) {


### PR DESCRIPTION
Genie wants to use this to find the right string set to use, even
if the argument comes inside a filter on a join, where "primitive"
is null