### PR TITLE
Fix typechecking enum

### DIFF
--- a/lib/ast/values.js
+++ b/lib/ast/values.js
@@ -324,7 +324,7 @@ Value.prototype.getType = function getType() {
     if (v.isFeed)
         return Type.Feed;
     if (v.isEnum)
-        return Type.Enum(null);
+        return Type.Enum([v.value, '*']);
     if (v.isEvent && v.name === 'type')
         return Type.Entity('tt:function');
     if (v.isEvent && v.name === 'program_id')

--- a/lib/type.js
+++ b/lib/type.js
@@ -185,6 +185,8 @@ module.exports.isAssignable = function isAssignable(type, assignableTo, typeScop
         return true;
     if (type.isEnum && assignableTo.isEnum && arrayEquals(type.entries, assignableTo.entries))
         return true;
+    if (type.isEnum && assignableTo.isEnum && type.entries[1] === '*' && assignableTo.entries.includes(type.entries[0]))
+        return true;
     if (type.isEntity && assignableTo.isEntity && entitySubType(type.type, assignableTo.type))
         return true;
     if (type.isArgMap && assignableTo.isArgMap)

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1955,3 +1955,15 @@ dataset @light-bulb {
 // ** typecheck: expect TypeError **
 // no param passing into a device attribute
 now => @com.bing.web_search() => @light-bulb(name=title).set_power(power=enum(on));
+
+====
+
+// ** typecheck: expect TypeError **
+// invalid enum
+now => @light-bulb.set_power(power=enum(cool));
+
+====
+
+// ** typecheck: expect TypeError **
+// invalid enum
+now => @org.thingpedia.icalendar.list_events(), status==enum(off) => notify;

--- a/test/test_describe_policy.js
+++ b/test/test_describe_policy.js
@@ -203,55 +203,55 @@ var TEST_CASES = [
     ['true : @com.washingtonpost.get_article, section == enum(world) || section == enum(opinions) => notify',
     'anyone is allowed to read the latest articles in the any section section of the Washington Post if the section is equal to world or the section is equal to opinions'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= makeDate() => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after now'],
-    ['true : @com.wsj.get, section == enum(world) && updated <= makeDate() => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is before now'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= makeDate() => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after now'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated <= makeDate() => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is before now'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= makeDate(2018, 5, 4) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after Friday, May 4, 2018'],
-    ['true : @com.wsj.get, section == enum(world) && updated <= makeDate(2018, 5, 4) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is before Friday, May 4, 2018'],
-    ['true : @com.wsj.get, section == enum(world) && !(updated <= makeDate(2018, 5, 4)) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after Friday, May 4, 2018'],
-    ['true : @com.wsj.get, section == enum(world) && !(updated >= makeDate(2018, 5, 4)) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is before Friday, May 4, 2018'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= makeDate(2018, 5, 4) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after Friday, May 4, 2018'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated <= makeDate(2018, 5, 4) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is before Friday, May 4, 2018'],
+    ['true : @com.wsj.get, section == enum(world_news) && !(updated <= makeDate(2018, 5, 4)) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after Friday, May 4, 2018'],
+    ['true : @com.wsj.get, section == enum(world_news) && !(updated >= makeDate(2018, 5, 4)) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is before Friday, May 4, 2018'],
 
-    /*['true : @com.wsj.get, section == enum(world) && updated >= makeDate(2018, 5, 4, 17, 30, 0) => notify',
-    'anyone is allowed to read articles published in the world section if the updated is after 5/4/2018, 5:30:00 PM'],*/
+    /*['true : @com.wsj.get, section == enum(world_news) && updated >= makeDate(2018, 5, 4, 17, 30, 0) => notify',
+    'anyone is allowed to read articles published in the world news section if the updated is after 5/4/2018, 5:30:00 PM'],*/
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= start_of(day) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after the start of today'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= start_of(day) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after the start of today'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= start_of(week) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after the start of this week'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= start_of(week) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after the start of this week'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= start_of(mon) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after the start of this month'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= start_of(mon) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after the start of this month'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= start_of(year) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after the start of this year'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= start_of(year) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after the start of this year'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= end_of(day) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after the end of today'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= end_of(day) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after the end of today'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= end_of(week) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after the end of this week'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= end_of(week) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after the end of this week'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= end_of(mon) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after the end of this month'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= end_of(mon) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after the end of this month'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= end_of(year) => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after the end of this year'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= end_of(year) => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after the end of this year'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= makeDate() + 1h => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after 1 h past now'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= makeDate() + 1h => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after 1 h past now'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= makeDate() + 30min => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after 30 min past now'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= makeDate() + 30min => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after 30 min past now'],
 
-    ['true : @com.wsj.get, section == enum(world) && updated >= makeDate() - 30min => notify',
-    'anyone is allowed to read articles published in the world section of the Wall Street Journal if the updated is after 30 min before now'],
+    ['true : @com.wsj.get, section == enum(world_news) && updated >= makeDate() - 30min => notify',
+    'anyone is allowed to read articles published in the world news section of the Wall Street Journal if the updated is after 30 min before now'],
 ];
 
 const gettext = {


### PR DESCRIPTION
Our typecheck is too loose, and it allows any enum into anything,
because Ast.Value.Enum.getType() returns a Type.Enum without any
entries (because it doesn't know what entries are possible).

Instead, make it return a special form of Enum type with "at least
one entry, possibly others" (the entry specified in the value).
This is assignable to all enum types that include the one entry.