### PR TITLE
tonn: expand the paraphrasing hacks to allow commas in locations

### DIFF
--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -194,7 +194,13 @@ class EntityRetriever {
 
             if (!found && entityType === 'LOCATION') {
                 // HACK to support paraphrasing
-                if (entityString.indexOf(' , ') >= 0) {
+                if (entityString.indexOf(',') >= 0) {
+                    const entitySpacedComma = entityString.replace(/,/g, ' ,').replace(/\s+/g, ' ');
+                    if (this._sentenceContains(entitySpacedComma.split(' '))) {
+                        entityString = entitySpacedComma;
+                        found = true;
+                    }
+
                     const entityNoComma = entityString.replace(' , ', '');
                     if (this._sentenceContains(entityNoComma.split(' '))) {
                         entityString = entityNoComma;


### PR DESCRIPTION
Because we actually always have commas in locations