### PR TITLE
utils: recognize io.home-assistant as a class name prefix

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,6 +33,9 @@ function cleanKind(kind) {
     // org.thingpedia.weather -> weather
     if (kind.startsWith('org.thingpedia.'))
         kind = kind.substr('org.thingpedia.'.length);
+    // io.home-assistant.battery -> battery
+    if (kind.startsWith('io.home-assistant.'))
+        kind = kind.substr('io.home-assistant.'.length);
     // com.xkcd -> xkcd
     if (kind.startsWith('com.'))
         kind = kind.substr('com.'.length);


### PR DESCRIPTION
Long term we should stop using cleanKind and use the #_[canonical]
of the class, but for now, this suffices.