### PR TITLE
Fix typecheck of input args

### DIFF
--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -667,6 +667,9 @@ function typeCheckInputArgs(ast, schema, scope, classes) {
         if (!inParamType || !schema.isArgInput(inParam.name))
             throw new TypeError('Invalid input parameter ' + inParam.name);
 
+        if (inParam.value.isUndefined)
+            continue;
+
         const valueType = typeForValue(inParam.value, scope);
         if (!Type.isAssignable(valueType, inParamType, {}, true))
             throw new TypeError(`Invalid type for parameter ${inParam.name}, have ${valueType}, need ${inParamType}`);


### PR DESCRIPTION
If the value of an input is undefined, do not remove it from the schema