### PR TITLE
Add support for returning values from procedures

### DIFF
--- a/lib/ast/function_def.js
+++ b/lib/ast/function_def.js
@@ -672,6 +672,28 @@ class ExpressionSignature extends Node {
         }
     }
 
+    /**
+     * Check if this expression signature has any input arguments.
+     */
+    hasAnyInputArg() {
+        for (let arg of this.iterateArguments()) {
+            if (arg.is_input)
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check if this expression signature has any output arguments.
+     */
+    hasAnyOutputArg() {
+        for (let arg of this.iterateArguments()) {
+            if (!arg.is_input)
+                return true;
+        }
+        return false;
+    }
+
     // extract arguments from base functions
     _flattenSubFunctionArguments() {
         return Array.from(this.iterateArguments());

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -181,7 +181,7 @@ class Declaration extends Statement {
         const newAnnotations = {};
         Object.assign(newAnnotations, this.annotations);
         return new Declaration(this.location, this.name, this.type, newArgs,
-            this.value.clone(), newMetadata, newAnnotations);
+            this.value.clone(), newMetadata, newAnnotations, this.schema);
     }
 }
 Declaration.prototype.isDeclaration = true;
@@ -206,7 +206,7 @@ class Assignment extends Statement {
      * @param {Ast.Table} value - the expression being assigned
      * @param {Ast.ExpressionSignature | null} schema - the signature corresponding to this assignment
      */
-    constructor(location, name, value, schema = null) {
+    constructor(location, name, value, schema = null, isAction) {
         super(location);
 
         assert(typeof name === 'string');
@@ -231,6 +231,14 @@ class Assignment extends Statement {
          * @type {Ast.ExpressionSignature|null}
          */
         this.schema = schema;
+
+        /**
+         * Whether this assignment calls an action or executes a query.
+         *
+         * This will be `undefined` before typechecking, and then either `true` or `false`.
+         * @type {boolean}
+         */
+        this.isAction = isAction;
     }
 
     visit(visitor) {
@@ -248,7 +256,7 @@ class Assignment extends Statement {
     }
 
     clone() {
-        return new Assignment(this.location, this.name, this.value.clone());
+        return new Assignment(this.location, this.name, this.value.clone(), this.schema, this.isAction);
     }
 }
 Assignment.prototype.isAssignment = true;

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -87,9 +87,7 @@ module.exports = class AppCompiler {
     }
 
     _compileDeclarationFunction(decl, parentIRBuilder) {
-        const extraParams = decl.type === 'action' ? [] : ['emit'];
-
-        const irBuilder = new JSIr.IRBuilder(parentIRBuilder ? parentIRBuilder.nextRegister : 0, extraParams);
+        const irBuilder = new JSIr.IRBuilder(parentIRBuilder ? parentIRBuilder.nextRegister : 0, ['__emit']);
 
         const functionScope = new Scope(this._declarations);
         const args = this._declareArguments(decl.args, functionScope, irBuilder);
@@ -135,10 +133,8 @@ module.exports = class AppCompiler {
         });
     }
 
-    _compileAssignment(assignment, irBuilder, hasAnyStream) {
-        const opCompiler = new OpCompiler(this, this._declarations, irBuilder);
-        const hints = new QueryInvocationHints(new Set(getDefaultProjection(assignment.value.schema)));
-        const tableop = compileTableToOps(assignment.value, [], hints);
+    _compileAssignment(assignment, irBuilder, { hasAnyStream, forProcedure}) {
+        const opCompiler = new OpCompiler(this, this._declarations, irBuilder, forProcedure);
 
         // at the top level, assignments can be referred to by streams, so
         // they need to be persistent (save to disk) such that when the program
@@ -146,7 +142,16 @@ module.exports = class AppCompiler {
         // (this is only needed in top-level since stream is not allowed within
         // procedures)
         const isPersistent = hasAnyStream;
-        const register = opCompiler.compileAssignment(tableop, isPersistent);
+
+        let register;
+
+        if (assignment.isAction) {
+            register = opCompiler.compileActionAssignment(assignment.value, isPersistent);
+        } else {
+            const hints = new QueryInvocationHints(new Set(getDefaultProjection(assignment.value.schema)));
+            const tableop = compileTableToOps(assignment.value, [], hints);
+            register = opCompiler.compileAssignment(tableop, isPersistent);
+        }
 
         this._declarations.set(assignment.name, {
             type: 'assignment',
@@ -158,7 +163,7 @@ module.exports = class AppCompiler {
     _compileProcedure(decl, parentIRBuilder) {
         const saveScope = this._declarations;
 
-        const irBuilder = new JSIr.IRBuilder(parentIRBuilder ? parentIRBuilder.nextRegister : 0, []);
+        const irBuilder = new JSIr.IRBuilder(parentIRBuilder ? parentIRBuilder.nextRegister : 0, ['__emit']);
 
         const procid = this._nextProcId++;
         irBuilder.setBeginEndHooks(
@@ -168,10 +173,12 @@ module.exports = class AppCompiler {
 
         const procedureScope = new Scope(this._declarations);
         const args = this._declareArguments(decl.args, procedureScope, irBuilder);
-
         this._declarations = procedureScope;
 
-        this._compileInScope(decl.value, decl.value.rules, false, irBuilder);
+        this._compileInScope(decl.value, decl.value.rules, irBuilder, {
+            hasAnyStream: false,
+            forProcedure: true
+        });
 
         let code;
         let register;
@@ -196,8 +203,8 @@ module.exports = class AppCompiler {
         });
     }
 
-    _doCompileStatement(stmt, irBuilder) {
-        const opCompiler = new OpCompiler(this, this._declarations, irBuilder);
+    _doCompileStatement(stmt, irBuilder, forProcedure) {
+        const opCompiler = new OpCompiler(this, this._declarations, irBuilder, forProcedure);
         let ruleop = compileStatementToOp(stmt);
         opCompiler.compileStatement(ruleop);
     }
@@ -210,7 +217,7 @@ module.exports = class AppCompiler {
         return this._testMode ? irBuilder.codegen() : irBuilder.compile(this._toplevelscope);
     }
 
-    _compileInScope(program, stmts, hasAnyStream, irBuilder) {
+    _compileInScope(program, stmts, irBuilder, { hasAnyStream, forProcedure }) {
         for (let decl of program.declarations) {
             if (['stream', 'query', 'action'].indexOf(decl.type) >= 0)
                 this._declarations[decl.name] = this._compileDeclarationFunction(decl, irBuilder);
@@ -232,9 +239,9 @@ module.exports = class AppCompiler {
             if (i !== 0)
                 irBuilder.add(new JSIr.ClearGetCache());
             if (stmts[i].isAssignment)
-                this._compileAssignment(stmts[i], irBuilder, hasAnyStream);
+                this._compileAssignment(stmts[i], irBuilder, { hasAnyStream, forProcedure });
             else
-                this._doCompileStatement(stmts[i], irBuilder);
+                this._doCompileStatement(stmts[i], irBuilder, forProcedure);
         }
 
         return irBuilder;
@@ -271,7 +278,10 @@ module.exports = class AppCompiler {
         }
 
         this._declarations = new Scope;
-        const commandIRBuilder = this._compileInScope(program, immediate, rules.length > 0, null);
+        const commandIRBuilder = this._compileInScope(program, immediate, null, {
+            hasAnyStream: rules.length > 0,
+            forProcedure: false
+        });
         let compiledCommand;
         if (commandIRBuilder !== null) {
             if (this._testMode)

--- a/lib/compiler/jsir.js
+++ b/lib/compiler/jsir.js
@@ -476,6 +476,20 @@ class InvokeStreamVarRef {
 }
 
 class InvokeAction {
+    constructor(kind, attrs, fname, into, args) {
+        this._kind = kind;
+        this._attrs = attrs;
+        this._fname = fname;
+        this._into = into;
+        this._args = args;
+    }
+
+    codegen(prefix) {
+        return `${prefix}_t_${this._into} = await __env.invokeAction(${stringEscape(this._kind)}, ${objectToJS(this._attrs)}, ${stringEscape(this._fname)}, _t_${this._args});`;
+    }
+}
+
+class InvokeVoidAction {
     constructor(kind, attrs, fname, args) {
         this._kind = kind;
         this._attrs = attrs;
@@ -485,17 +499,6 @@ class InvokeAction {
 
     codegen(prefix) {
         return `${prefix}await __env.invokeAction(${stringEscape(this._kind)}, ${objectToJS(this._attrs)}, ${stringEscape(this._fname)}, _t_${this._args});`;
-    }
-}
-
-class InvokeActionVarRef {
-    constructor(name, args) {
-        this._name = name;
-        this._args = args;
-    }
-
-    codegen(prefix) {
-        return `${prefix}await _t_${this._name}(__env${this._args.map((a) => ', _t_' + a).join('')});`;
     }
 }
 
@@ -640,7 +643,7 @@ class AsyncFunctionExpression {
     }
 
     codegen(prefix) {
-        return prefix + `_t_${this._into} = async function(emit) {\n` +
+        return prefix + `_t_${this._into} = async function(__emit) {\n` +
             this.body.codegen(prefix + '  ') + '\n' +
             prefix + '}';
     }
@@ -679,7 +682,7 @@ class InvokeEmit {
     }
 
     codegen(prefix) {
-        return `${prefix}emit(${this._values.map((v) => '_t_' + v).join(', ')});`;
+        return `${prefix}__emit(${this._values.map((v) => '_t_' + v).join(', ')});`;
     }
 }
 
@@ -926,7 +929,7 @@ module.exports = {
     InvokeDBQuery,
     InvokeStreamVarRef,
     InvokeAction,
-    InvokeActionVarRef,
+    InvokeVoidAction,
     InvokeOutput,
     InvokeReadState,
     InvokeWriteState,

--- a/lib/compiler/ops-to-jsir.js
+++ b/lib/compiler/ops-to-jsir.js
@@ -30,9 +30,10 @@ const Scope = require('./scope');
 const { notifyAction } = require("../ast/api");
 
 module.exports = class OpCompiler {
-    constructor(compiler, globalScope, irBuilder) {
+    constructor(compiler, globalScope, irBuilder, forProcedure) {
         this._compiler = compiler;
         this._irBuilder = irBuilder;
+        this._forProcedure = forProcedure;
 
         this._globalScope = globalScope;
         this._currentScope = new Scope(globalScope);
@@ -523,7 +524,7 @@ module.exports = class OpCompiler {
 
         let args = this._compileVarRefInputParams(decl, op.in_params);
         let iterator = this._irBuilder.allocRegister();
-        // both stream and query invoke as stream, because of the lazy evaluation of query
+        // all of stream, query and action invoke as stream, because of the lazy evaluation of query
         this._irBuilder.add(new JSIr.InvokeStreamVarRef(fnreg, iterator, args));
 
         let result = this._irBuilder.allocRegister();
@@ -567,33 +568,32 @@ module.exports = class OpCompiler {
         this._compileInvokeGenericVarRef(streamop);
     }
 
-    _compileInvokeActionVarRef(action) {
-        let decl = this._currentScope.get(action.name);
-        assert(decl.type === 'declaration' || decl.type === 'procedure');
-        let fnreg;
-        if (decl.register !== null) {
-            fnreg = decl.register;
-        } else {
-            fnreg = this._irBuilder.allocRegister();
-            this._irBuilder.add(new JSIr.GetScope(action.name, fnreg));
-        }
-
-        let args = this._compileVarRefInputParams(decl, action.in_params);
-        this._irBuilder.add(new JSIr.InvokeActionVarRef(fnreg, args));
-    }
-
-    _compileInvokeOutput(action) {
-        if (action.invocation.channel === 'return')
-                throw new TypeError('return must be lowered before execution, use Generate.lowerReturn');
-        assert(action.invocation.channel === 'notify');
-
-        this._irBuilder.add(new JSIr.InvokeOutput(getRegister('$outputType', this._currentScope), getRegister('$output', this._currentScope)));
+    _compileInvokeOutput() {
+        if (this._forProcedure)
+            this._irBuilder.add(new JSIr.InvokeEmit(getRegister('$outputType', this._currentScope), getRegister('$output', this._currentScope)));
+        else
+            this._irBuilder.add(new JSIr.InvokeOutput(getRegister('$outputType', this._currentScope), getRegister('$output', this._currentScope)));
     }
 
     _compileInvokeAction(action) {
         let [kind, attrs, fname] = this._compileTpFunctionCall(action.invocation);
         let [,args] = this._compileInputParams(action.invocation);
-        this._irBuilder.add(new JSIr.InvokeAction(kind, attrs, fname, args));
+
+        // for compatibility with existing actions that return nothing or random stuff (usually
+        // an HTTP response), we ignore the return value of actions that are declared without
+        // output parameters
+        if (action.schema.hasAnyOutputArg()) {
+            let list = this._irBuilder.allocateRegister();
+            this._irBuilder.add(new JSIr.InvokeAction(kind, attrs, fname, list, args));
+
+            let result = this._compileIterateQuery(list);
+            this._setInvocationOutputs(action.schema, null, result);
+
+            return true;
+        } else {
+            this._irBuilder.add(new JSIr.InvokeVoidAction(kind, attrs, fname, args));
+            return false;
+        }
     }
 
     _compileAction(ast) {
@@ -601,12 +601,29 @@ module.exports = class OpCompiler {
         this._irBuilder.add(tryCatch);
         this._irBuilder.pushBlock(tryCatch.try);
 
-        if (ast.isVarRef)
-            this._compileInvokeActionVarRef(ast);
-        else if (ast.isNotify)
-            this._compileInvokeOutput(ast);
-        else
-            this._compileInvokeAction(ast);
+        if (ast.isNotify) {
+            if (ast.name === 'return')
+                throw new TypeError('return must be lowered before execution, use Generate.lowerReturn');
+            assert(ast.name === 'notify');
+
+            this._compileInvokeOutput();
+        } else {
+            const stack = this._irBuilder.saveStackState();
+
+            let hasResult;
+            if (ast.isVarRef) {
+                this._compileInvokeGenericVarRef(ast);
+                hasResult = true;
+            } else {
+                hasResult = this._compileInvokeAction(ast);
+            }
+
+            if (hasResult && !this._forProcedure)
+                this._compileInvokeOutput();
+
+            // pop the blocks introduced by iterating the query
+            this._irBuilder.popTo(stack);
+        }
 
         this._irBuilder.popBlock();
     }
@@ -1119,6 +1136,41 @@ module.exports = class OpCompiler {
     compileActionDeclaration(action) {
         this._compileAction(action);
         this._irBuilder.popAll();
+    }
+
+    compileActionAssignment(action, isPersistent) {
+        let register = this._irBuilder.allocRegister();
+        let stateId;
+        this._irBuilder.add(new JSIr.CreateTuple(0, register));
+
+        let hasResult;
+        if (action.isVarRef) {
+            this._compileInvokeGenericVarRef(action);
+            hasResult = true;
+        } else {
+            hasResult = this._compileInvokeAction(action);
+        }
+
+        // an action assignment without a result does not make much sense, but it typechecks,
+        // so we allow it, and interpret it to be an empty array
+        if (hasResult) {
+            let resultAndTypeTuple = this._irBuilder.allocRegister();
+            this._irBuilder.add(new JSIr.CreateTuple(2, resultAndTypeTuple));
+            this._irBuilder.add(new JSIr.SetIndex(resultAndTypeTuple, 0, getRegister('$outputType', this._currentScope)));
+            this._irBuilder.add(new JSIr.SetIndex(resultAndTypeTuple, 1, getRegister('$output', this._currentScope)));
+
+            this._irBuilder.add(new JSIr.UnaryMethodOp(register, resultAndTypeTuple, 'push'));
+        }
+
+        this._irBuilder.popAll();
+
+        if (isPersistent) {
+            stateId = this._allocState();
+            this._irBuilder.add(new JSIr.InvokeWriteState(register, stateId));
+            return stateId;
+        } else {
+            return register;
+        }
     }
 
     compileAssignment(tableop, isPersistent) {

--- a/lib/compiler/ops-to-jsir.js
+++ b/lib/compiler/ops-to-jsir.js
@@ -583,7 +583,7 @@ module.exports = class OpCompiler {
         // an HTTP response), we ignore the return value of actions that are declared without
         // output parameters
         if (action.schema.hasAnyOutputArg()) {
-            let list = this._irBuilder.allocateRegister();
+            let list = this._irBuilder.allocRegister();
             this._irBuilder.add(new JSIr.InvokeAction(kind, attrs, fname, list, args));
 
             let result = this._compileIterateQuery(list);

--- a/lib/runtime/exec_environment.js
+++ b/lib/runtime/exec_environment.js
@@ -9,6 +9,8 @@
 // See COPYING for details
 "use strict";
 
+const assert = require('assert');
+
 const Formatter = require('./formatter');
 const I18n = require('../i18n');
 
@@ -16,6 +18,10 @@ module.exports = class ExecEnvironment {
     constructor(locale, timezone, schemaRetriever, gettext = I18n.get(locale)) {
         this.format = new Formatter(locale, timezone, schemaRetriever, gettext);
         this._scope = {};
+
+        this._procedureFrameCounter = 0;
+        this._procedureFrame = 0;
+        this._procedureStack = [];
     }
 
     /* istanbul ignore next */
@@ -23,11 +29,29 @@ module.exports = class ExecEnvironment {
         throw new Error('Must be overridden');
     }
 
+    /**
+     * Returns a unique id of the current stack frame.
+     *
+     * The ID is incremented for every procedure call.
+     */
+    get procedureFrame() {
+        return this._procedureFrame;
+    }
+
     enterProcedure(procid, procname) {
-        // nothing to do by default
+        // save the calling frame ID on the stack
+        this._procedureStack.push(this._procedureFrame);
+
+        // make a fresh ID for the new call
+        this._procedureFrameCounter++;
+        this._procedureFrame = this._procedureFrameCounter;
     }
     exitProcedure(procid, procname) {
-        // nothing to do by default
+        // check that enter & exit are correctly paired
+        assert(this._procedureStack.length > 0);
+
+        // restore the frame ID of the caller from the stack
+        this._procedureFrame = this._procedureStack.pop();
     }
 
     /* istanbul ignore next */

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -815,26 +815,30 @@ function addRequiredInputParamsAction(action) {
         throw new TypeError();
 }
 
+async function loadOneSchema(schemas, scope, classes, useMeta, primType, prim) {
+    if (primType === 'table' || primType === 'filter')
+        primType = 'query';
+
+    let schema;
+    if (prim.isVarRef) {
+        if (scope.has(prim.name))
+            schema = scope.get(prim.name);
+        else
+            schema = await schemas.getMemorySchema(prim.name, useMeta);
+        if (schema === null)
+            throw new TypeError(`Cannot find declaration ${prim.name} in memory`);
+        if (!(schema instanceof Ast.ExpressionSignature) || schema.functionType !== primType)
+            throw new TypeError(`Variable ${prim.name} does not name a ${primType}`);
+    } else {
+        schema = await loadSchema(schemas, classes, prim, primType, useMeta);
+    }
+    if (prim.schema === null)
+        prim.schema = schema;
+}
+
 async function loadAllSchemas(ast, schemas, scope, classes, useMeta) {
     return await Promise.all(Array.from(ast.iteratePrimitives(true)).map(async ([primType, prim]) => {
-        if (primType === 'table' || primType === 'filter')
-            primType = 'query';
-
-        let schema;
-        if (prim.isVarRef) {
-            if (scope.has(prim.name))
-                schema = scope.get(prim.name);
-            else
-                schema = await schemas.getMemorySchema(prim.name, useMeta);
-            if (schema === null)
-                throw new TypeError(`Cannot find declaration ${prim.name} in memory`);
-            if (!(schema instanceof Ast.ExpressionSignature) || schema.functionType !== primType)
-                throw new TypeError(`Variable ${prim.name} does not name a ${primType}`);
-        } else {
-            schema = await loadSchema(schemas, classes, prim, primType, useMeta);
-        }
-        if (prim.schema === null)
-            prim.schema = schema;
+        return loadOneSchema(schemas, scope, classes, useMeta, primType, prim);
     }));
 }
 
@@ -1067,6 +1071,9 @@ async function typeCheckProcedure(ast) {
     for (let stmt of ast.value.rules) {
         if (stmt.isRule)
             throw new TypeError(`Continuous statements are not allowed in nested procedures`);
+
+        if (stmt.isAssignment)
+            continue;
         assert(stmt.isCommand);
         if (stmt.actions.some((a) => a.isNotify)) {
             if (hasNotify)
@@ -1181,12 +1188,29 @@ async function typeCheckExample(ast, schemas, classes = {}, useMeta = false) {
 }
 
 async function typeCheckAssignment(ast, schemas, scope, classes, useMeta = false) {
-    await loadAllSchemas(ast, schemas, scope, classes, useMeta);
+    // if the value is an invocation or varref, without any computation on the result,
+    // we allow it to be an action or varref to an action
+    if (ast.value.isInvocation || ast.value.isVarRef) {
+        try {
+            await loadOneSchema(schemas, scope, classes, useMeta, 'action', ast.value);
+            ast.isAction = true;
+        } catch(e) { /* ignore if it is not an action */ }
+    }
+
+    if (!ast.isAction) {
+        await loadAllSchemas(ast, schemas, scope, classes, useMeta);
+
+        // if isAction was `undefined` (before typechecking) overwrite it to `false`
+        ast.isAction = false;
+    }
+
     addRequiredInputParamsTable(ast.value, null);
     await typeCheckTable(ast.value, schemas, scope, classes, useMeta);
 
     // remove all input parameters (which we have filled with $undefined)
-    ast.schema = ast.value.schema.filterArguments((a) => !a.is_input);
+    const args = Array.from(ast.value.schema.iterateArguments()).filter((a) => !a.is_input);
+    ast.schema = new Ast.FunctionDef(ast.location, 'query', null, ast.name, [],
+        { is_list: ast.value.schema.is_list, is_monitorable: false }, args, {});
     scope.addGlobal(ast.name, ast.schema);
 }
 

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -1062,6 +1062,20 @@ function typeCheckDeclarationArgs(args) {
     }
 }
 
+async function typeCheckProcedure(ast) {
+    let hasNotify = false;
+    for (let stmt of ast.value.rules) {
+        if (stmt.isRule)
+            throw new TypeError(`Continuous statements are not allowed in nested procedures`);
+        assert(stmt.isCommand);
+        if (stmt.actions.some((a) => a.isNotify)) {
+            if (hasNotify)
+                throw new TypeError(`Multiple statements with 'notify' are not allowed in nested procedures`);
+            hasNotify = true;
+        }
+    }
+}
+
 async function typeCheckDeclarationCommon(ast, schemas, scope, classes, useMeta) {
     typeCheckDeclarationArgs(ast.args);
     scope.addLambdaArgs(ast.args);
@@ -1083,12 +1097,8 @@ async function typeCheckDeclarationCommon(ast, schemas, scope, classes, useMeta)
         case 'program':
         case 'procedure':
             await typeCheckProgram(ast.value, schemas, useMeta, classes, scope);
-            if (ast.type === 'procedure') {
-                for (let stmt of ast.value.rules) {
-                    if (stmt.isRule)
-                        throw new TypeError(`Continuous statements are not allowed in nested procedures`);
-                }
-            }
+            if (ast.type === 'procedure')
+                await typeCheckProcedure(ast);
 
             break;
         default:
@@ -1123,14 +1133,28 @@ function makeFunctionSchema(ast) {
     );
 }
 
-function makeProgramSchema(ast) {
-    // a program returns nothing, so the only arguments are input arguments
-    const argdefs = Object.keys(ast.args).map((name) =>
+function makeProgramSchema(ast, isProcedure) {
+    const args = Object.keys(ast.args).map((name) =>
         new Ast.ArgumentDef(ast.location, Ast.ArgDirection.IN_REQ, name, ast.args[name], {}));
 
-    // a program can be called on the action side, so it's an action
+    if (isProcedure) {
+        // add output arguments from the statement that includes a `notify` clause
+        // (there can be at most once)
+        for (const stmt of ast.value.rules) {
+            if (!stmt.isCommand)
+                continue;
+
+            if (!stmt.actions.some((a) => a.isNotify))
+                continue;
+
+            const outargs = Array.from(stmt.table.schema.iterateArguments()).filter((a) => !a.is_input);
+            args.push(...outargs);
+        }
+    }
+
+    // a program/procedure can be called on the action side, so it's an action
     return new Ast.FunctionDef(ast.location, 'action', null, ast.name, [],
-        { is_list: false, is_monitorable: false}, argdefs,
+        { is_list: false, is_monitorable: false}, args,
         { nl: ast.nl_annotations, impl: ast.impl_annotations });
 }
 
@@ -1139,7 +1163,7 @@ async function typeCheckDeclaration(ast, schemas, scope, classes, useMeta) {
     typeCheckMetadata(ast);
 
     if (ast.type === 'program' || ast.type === 'procedure')
-        ast.schema = makeProgramSchema(ast);
+        ast.schema = makeProgramSchema(ast, ast.type === 'procedure');
     else
         ast.schema = makeFunctionSchema(ast);
     scope.addGlobal(ast.name, ast.schema);

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1134,7 +1134,6 @@ now => sort sender_address asc of @com.gmail.inbox() => notify;
 
 let procedure p1 := {
   now => @com.thecatapi.get() => notify;
-  now => @uk.co.thedogapi.get() => notify;
 };
 let program p2 := {
   attimer(time=makeTime(7, 0)) => @com.thecatapi.get() => notify;
@@ -1205,9 +1204,8 @@ let query q := @com.bing.web_search() #_[canonical="bing search"] #[foo=43];
 let action a := \(p_value : String) -> @com.twitter.post(status=p_value) #_[canonical="roast on twitter"];
 
 let procedure p1 := {
-  now => @com.thecatapi.get() => notify;
   now => @uk.co.thedogapi.get() => notify;
-} #_[canonical="cats and dogs"];
+} #_[canonical="cats"];
 
 ====
 

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1903,3 +1903,16 @@ now => @org.schema.full.FoodEstablishment(), true(servesCuisine) => notify;
 // ** typecheck: expect TypeError **
 // the projection is inside and masks the parameter, including inherited ones
 now => compute distance(geo, $context.location.current_location) of ([address] of @org.schema.place()) => notify;
+
+====
+
+// procedures with actions and returned values
+
+let procedure cat_and_twitter := {
+  let result cat := @com.thecatapi.get();
+  now => cat => @com.twitter.post_picture(picture_url=picture_url, caption="cat");
+  now => cat => notify;
+};
+let result cat2 := cat_and_twitter();
+now => cat2 => notify;
+now => cat2 => @com.facebook.post_picture(picture_url=picture_url, caption="cat");

--- a/test/test_compiler.js
+++ b/test/test_compiler.js
@@ -1666,7 +1666,7 @@ const TEST_CASES = [
   let _t_46;
   let _t_47;
   _t_0 = await __env.readState(0);
-  _t_1 = async function(emit) {
+  _t_1 = async function(__emit) {
     _t_2 = await __env.readState(1);
     try {
       _t_3 = {};
@@ -1689,7 +1689,7 @@ const TEST_CASES = [
           await __env.writeState(1, _t_16);
           _t_2 = _t_16;
           if (_t_15) {
-            emit(_t_6, _t_7);
+            __emit(_t_6, _t_7);
           } else {
 
           }
@@ -1700,7 +1700,7 @@ const TEST_CASES = [
       __env.reportError("Failed to invoke trigger", _exc_);
     }
   }
-  _t_17 = async function(emit) {
+  _t_17 = async function(__emit) {
     _t_18 = await __env.readState(2);
     try {
       _t_19 = {};
@@ -1722,7 +1722,7 @@ const TEST_CASES = [
           await __env.writeState(2, _t_30);
           _t_18 = _t_30;
           if (_t_29) {
-            emit(_t_23, _t_24);
+            __emit(_t_23, _t_24);
           } else {
 
           }
@@ -1822,7 +1822,7 @@ const TEST_CASES = [
   let _t_48;
   let _t_49;
   _t_0 = await __env.readState(0);
-  _t_1 = async function(emit) {
+  _t_1 = async function(__emit) {
     _t_2 = await __env.readState(1);
     try {
       _t_3 = {};
@@ -1845,7 +1845,7 @@ const TEST_CASES = [
           await __env.writeState(1, _t_16);
           _t_2 = _t_16;
           if (_t_15) {
-            emit(_t_6, _t_7);
+            __emit(_t_6, _t_7);
           } else {
 
           }
@@ -1856,7 +1856,7 @@ const TEST_CASES = [
       __env.reportError("Failed to invoke trigger", _exc_);
     }
   }
-  _t_17 = async function(emit) {
+  _t_17 = async function(__emit) {
     _t_18 = await __env.readState(2);
     try {
       _t_19 = {};
@@ -1878,7 +1878,7 @@ const TEST_CASES = [
           await __env.writeState(2, _t_30);
           _t_18 = _t_30;
           if (_t_29) {
-            emit(_t_23, _t_24);
+            __emit(_t_23, _t_24);
           } else {
 
           }
@@ -2088,7 +2088,7 @@ const TEST_CASES = [
   let _t_38;
   let _t_39;
   let _t_40;
-  _t_0 = async function(emit) {
+  _t_0 = async function(__emit) {
     try {
       _t_1 = {};
       _t_2 = await __env.invokeQuery("com.twitter", { }, "home_timeline", _t_1, { projection: ["text", "hashtags", "urls", "author", "in_reply_to", "tweet_id"] });
@@ -2106,7 +2106,7 @@ const TEST_CASES = [
           _t_11 = _t_6.author;
           _t_12 = _t_6.in_reply_to;
           _t_13 = _t_6.tweet_id;
-          emit(_t_5, _t_6);
+          __emit(_t_5, _t_6);
           _iter_tmp = await _t_3.next();
         }
       }
@@ -2114,7 +2114,7 @@ const TEST_CASES = [
       __env.reportError("Failed to invoke query", _exc_);
     }
   }
-  _t_14 = async function(emit) {
+  _t_14 = async function(__emit) {
     try {
       _t_15 = {};
       _t_16 = "foo";
@@ -2131,7 +2131,7 @@ const TEST_CASES = [
           _t_23 = _t_21.title;
           _t_24 = _t_21.description;
           _t_25 = _t_21.link;
-          emit(_t_20, _t_21);
+          __emit(_t_20, _t_21);
           _iter_tmp = await _t_18.next();
         }
       }
@@ -2935,7 +2935,7 @@ const TEST_CASES = [
   let _t_55;
   let _t_56;
   let _t_57;
-  _t_0 = async function(emit) {
+  _t_0 = async function(__emit) {
     try {
       _t_1 = {};
       _t_2 = await __env.invokeQuery("com.google.drive", { }, "list_drive_files", _t_1, { projection: ["order_by", "file_size", "file_id", "file_name", "mime_type", "description", "starred", "created_time", "modified_time", "last_modified_by", "link"] });
@@ -2958,7 +2958,7 @@ const TEST_CASES = [
           _t_16 = _t_6.file_size;
           _t_17 = _t_6.last_modified_by;
           _t_18 = _t_6.link;
-          emit(_t_5, _t_6);
+          __emit(_t_5, _t_6);
           _iter_tmp = await _t_3.next();
         }
       }
@@ -2966,7 +2966,7 @@ const TEST_CASES = [
       __env.reportError("Failed to invoke query", _exc_);
     }
   }
-  _t_19 = async function(emit) {
+  _t_19 = async function(__emit) {
     _t_20 = -Infinity;
     try {
       _t_21 = {};
@@ -3001,7 +3001,7 @@ const TEST_CASES = [
     _t_39 = __builtin.aggregateOutputType(_t_40, _t_25);
     _t_41 = {};
     _t_41.file_size = _t_20;
-    emit(_t_39, _t_41);
+    __emit(_t_39, _t_41);
   }
   _t_42 = __builtin.tableCrossJoin(_t_0, _t_19);
   {
@@ -4308,7 +4308,7 @@ const TEST_CASES = [
         _t_8 = _t_6.title;
         _t_9 = _t_6.description;
         _t_10 = _t_6.link;
-        emit(_t_5, _t_6);
+        __emit(_t_5, _t_6);
         _iter_tmp = await _t_3.next();
       }
     }
@@ -4337,6 +4337,16 @@ const TEST_CASES = [
   let _t_11;
   let _t_12;
   let _t_13;
+  let _t_14;
+  let _t_15;
+  let _t_16;
+  let _t_17;
+  let _t_18;
+  let _t_19;
+  let _t_20;
+  let _t_21;
+  let _t_22;
+  let _t_23;
   try {
     _t_0 = __scope.q;
     _t_1 = "foo";
@@ -4354,7 +4364,18 @@ const TEST_CASES = [
         try {
           _t_10 = __scope.a;
           _t_11 = String (_t_9);
-          await _t_10(__env, _t_11);
+          _t_12 = await __builtin.invokeStreamVarRef(__env, _t_10, _t_11);
+          {
+            let _iter_tmp = await _t_12.next();
+            while (!_iter_tmp.done) {
+              _t_13 = _iter_tmp.value;
+              _t_14 = _t_13[0];
+              _t_15 = _t_13[1];
+              _t_16 = _t_15.__response;
+              await __env.output(String(_t_14), _t_15);
+              _iter_tmp = await _t_12.next();
+            }
+          }
         } catch(_exc_) {
           __env.reportError("Failed to invoke action", _exc_);
         }
@@ -4366,9 +4387,20 @@ const TEST_CASES = [
   }
   __env.clearGetCache();
   try {
-    _t_12 = __scope.a;
-    _t_13 = "no";
-    await _t_12(__env, _t_13);
+    _t_17 = __scope.a;
+    _t_18 = "no";
+    _t_19 = await __builtin.invokeStreamVarRef(__env, _t_17, _t_18);
+    {
+      let _iter_tmp = await _t_19.next();
+      while (!_iter_tmp.done) {
+        _t_20 = _iter_tmp.value;
+        _t_21 = _t_20[0];
+        _t_22 = _t_20[1];
+        _t_23 = _t_22.__response;
+        await __env.output(String(_t_21), _t_22);
+        _iter_tmp = await _t_19.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }`]],
@@ -4420,7 +4452,7 @@ const TEST_CASES = [
         await __env.writeState(0, _t_16);
         _t_0 = _t_16;
         if (_t_15) {
-          emit(_t_5, _t_6);
+          __emit(_t_5, _t_6);
         } else {
 
         }
@@ -4775,7 +4807,7 @@ const TEST_CASES = [
           _t_9 = _t_6.description;
           _t_10 = _t_6.link;
           try {
-            await __env.output(String(_t_5), _t_6);
+            __emit(_t_5, _t_6);
           } catch(_exc_) {
             __env.reportError("Failed to invoke action", _exc_);
           }
@@ -4817,33 +4849,115 @@ const TEST_CASES = [
   let _t_5;
   let _t_6;
   let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
+  let _t_16;
+  let _t_17;
+  let _t_18;
+  let _t_19;
+  let _t_20;
+  let _t_21;
+  let _t_22;
+  let _t_23;
+  let _t_24;
+  let _t_25;
+  let _t_26;
+  let _t_27;
+  let _t_28;
+  let _t_29;
+  let _t_30;
+  let _t_31;
+  let _t_32;
+  let _t_33;
+  let _t_34;
+  let _t_35;
+  let _t_36;
   try {
     _t_0 = __scope.p1;
     _t_1 = "one";
-    await _t_0(__env, _t_1);
+    _t_2 = await __builtin.invokeStreamVarRef(__env, _t_0, _t_1);
+    {
+      let _iter_tmp = await _t_2.next();
+      while (!_iter_tmp.done) {
+        _t_3 = _iter_tmp.value;
+        _t_4 = _t_3[0];
+        _t_5 = _t_3[1];
+        _t_6 = _t_5.__response;
+        _t_7 = _t_5.title;
+        _t_8 = _t_5.description;
+        _t_9 = _t_5.link;
+        await __env.output(String(_t_4), _t_5);
+        _iter_tmp = await _t_2.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }
   __env.clearGetCache();
   try {
-    _t_2 = __scope.p1;
-    _t_3 = "two";
-    await _t_2(__env, _t_3);
+    _t_10 = __scope.p1;
+    _t_11 = "two";
+    _t_12 = await __builtin.invokeStreamVarRef(__env, _t_10, _t_11);
+    {
+      let _iter_tmp = await _t_12.next();
+      while (!_iter_tmp.done) {
+        _t_13 = _iter_tmp.value;
+        _t_14 = _t_13[0];
+        _t_15 = _t_13[1];
+        _t_16 = _t_15.__response;
+        _t_17 = _t_15.title;
+        _t_18 = _t_15.description;
+        _t_19 = _t_15.link;
+        await __env.output(String(_t_14), _t_15);
+        _iter_tmp = await _t_12.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }
   __env.clearGetCache();
   try {
-    _t_4 = __scope.p1;
-    _t_5 = "three";
-    await _t_4(__env, _t_5);
+    _t_20 = __scope.p1;
+    _t_21 = "three";
+    _t_22 = await __builtin.invokeStreamVarRef(__env, _t_20, _t_21);
+    {
+      let _iter_tmp = await _t_22.next();
+      while (!_iter_tmp.done) {
+        _t_23 = _iter_tmp.value;
+        _t_24 = _t_23[0];
+        _t_25 = _t_23[1];
+        _t_26 = _t_25.__response;
+        _t_27 = _t_25.title;
+        _t_28 = _t_25.description;
+        _t_29 = _t_25.link;
+        await __env.output(String(_t_24), _t_25);
+        _iter_tmp = await _t_22.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }
   try {
-    _t_6 = __scope.p2;
-    _t_7 = "four";
-    await _t_6(__env, _t_7);
+    _t_30 = __scope.p2;
+    _t_31 = "four";
+    _t_32 = await __builtin.invokeStreamVarRef(__env, _t_30, _t_31);
+    {
+      let _iter_tmp = await _t_32.next();
+      while (!_iter_tmp.done) {
+        _t_33 = _iter_tmp.value;
+        _t_34 = _t_33[0];
+        _t_35 = _t_33[1];
+        _t_36 = _t_35.__response;
+        await __env.output(String(_t_34), _t_35);
+        _iter_tmp = await _t_32.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }`]],
@@ -4928,7 +5042,7 @@ const TEST_CASES = [
         _t_19 = _t_16.description;
         _t_20 = _t_16.link;
         try {
-          await __env.output(String(_t_15), _t_16);
+          __emit(_t_15, _t_16);
         } catch(_exc_) {
           __env.reportError("Failed to invoke action", _exc_);
         }
@@ -4964,18 +5078,62 @@ const TEST_CASES = [
   let _t_1;
   let _t_2;
   let _t_3;
+  let _t_4;
+  let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
+  let _t_16;
+  let _t_17;
+  let _t_18;
+  let _t_19;
   try {
     _t_0 = __scope.p1;
     _t_1 = "one";
-    await _t_0(__env, _t_1);
+    _t_2 = await __builtin.invokeStreamVarRef(__env, _t_0, _t_1);
+    {
+      let _iter_tmp = await _t_2.next();
+      while (!_iter_tmp.done) {
+        _t_3 = _iter_tmp.value;
+        _t_4 = _t_3[0];
+        _t_5 = _t_3[1];
+        _t_6 = _t_5.__response;
+        _t_7 = _t_5.title;
+        _t_8 = _t_5.description;
+        _t_9 = _t_5.link;
+        await __env.output(String(_t_4), _t_5);
+        _iter_tmp = await _t_2.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }
   __env.clearGetCache();
   try {
-    _t_2 = __scope.p1;
-    _t_3 = "two";
-    await _t_2(__env, _t_3);
+    _t_10 = __scope.p1;
+    _t_11 = "two";
+    _t_12 = await __builtin.invokeStreamVarRef(__env, _t_10, _t_11);
+    {
+      let _iter_tmp = await _t_12.next();
+      while (!_iter_tmp.done) {
+        _t_13 = _iter_tmp.value;
+        _t_14 = _t_13[0];
+        _t_15 = _t_13[1];
+        _t_16 = _t_15.__response;
+        _t_17 = _t_15.title;
+        _t_18 = _t_15.description;
+        _t_19 = _t_15.link;
+        await __env.output(String(_t_14), _t_15);
+        _iter_tmp = await _t_12.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }`]],
@@ -5010,7 +5168,7 @@ const TEST_CASES = [
   let _t_28;
   await __env.enterProcedure(0, "p1");
   try {
-    _t_11 = async function(__env, emit) {
+    _t_11 = async function(__env, __emit) {
       "use strict";
       let _t_1;
       let _t_2;
@@ -5037,7 +5195,7 @@ const TEST_CASES = [
             _t_8 = _t_6.title;
             _t_9 = _t_6.description;
             _t_10 = _t_6.link;
-            emit(_t_5, _t_6);
+            __emit(_t_5, _t_6);
             _iter_tmp = await _t_3.next();
           }
         }
@@ -5058,7 +5216,7 @@ const TEST_CASES = [
           _t_18 = _t_15.description;
           _t_19 = _t_15.link;
           try {
-            await __env.output(String(_t_14), _t_15);
+            __emit(_t_14, _t_15);
           } catch(_exc_) {
             __env.reportError("Failed to invoke action", _exc_);
           }
@@ -5101,18 +5259,62 @@ const TEST_CASES = [
   let _t_1;
   let _t_2;
   let _t_3;
+  let _t_4;
+  let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
+  let _t_16;
+  let _t_17;
+  let _t_18;
+  let _t_19;
   try {
     _t_0 = __scope.p1;
     _t_1 = "one";
-    await _t_0(__env, _t_1);
+    _t_2 = await __builtin.invokeStreamVarRef(__env, _t_0, _t_1);
+    {
+      let _iter_tmp = await _t_2.next();
+      while (!_iter_tmp.done) {
+        _t_3 = _iter_tmp.value;
+        _t_4 = _t_3[0];
+        _t_5 = _t_3[1];
+        _t_6 = _t_5.__response;
+        _t_7 = _t_5.title;
+        _t_8 = _t_5.description;
+        _t_9 = _t_5.link;
+        await __env.output(String(_t_4), _t_5);
+        _iter_tmp = await _t_2.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }
   __env.clearGetCache();
   try {
-    _t_2 = __scope.p1;
-    _t_3 = "two";
-    await _t_2(__env, _t_3);
+    _t_10 = __scope.p1;
+    _t_11 = "two";
+    _t_12 = await __builtin.invokeStreamVarRef(__env, _t_10, _t_11);
+    {
+      let _iter_tmp = await _t_12.next();
+      while (!_iter_tmp.done) {
+        _t_13 = _iter_tmp.value;
+        _t_14 = _t_13[0];
+        _t_15 = _t_13[1];
+        _t_16 = _t_15.__response;
+        _t_17 = _t_15.title;
+        _t_18 = _t_15.description;
+        _t_19 = _t_15.link;
+        await __env.output(String(_t_14), _t_15);
+        _iter_tmp = await _t_12.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }`]],
@@ -5132,9 +5334,19 @@ const TEST_CASES = [
   let _t_3;
   let _t_4;
   let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
   await __env.enterProcedure(0, "p1");
   try {
-    _t_3 = async function(__env, _t_1) {
+    _t_3 = async function(__env, __emit, _t_1) {
       "use strict";
       let _t_2;
       await __env.enterProcedure(1, "p2");
@@ -5153,14 +5365,34 @@ const TEST_CASES = [
     };
     try {
       _t_4 = "body one";
-      await _t_3(__env, _t_4);
+      _t_5 = await __builtin.invokeStreamVarRef(__env, _t_3, _t_4);
+      {
+        let _iter_tmp = await _t_5.next();
+        while (!_iter_tmp.done) {
+          _t_6 = _iter_tmp.value;
+          _t_7 = _t_6[0];
+          _t_8 = _t_6[1];
+          _t_9 = _t_8.__response;
+          _iter_tmp = await _t_5.next();
+        }
+      }
     } catch(_exc_) {
       __env.reportError("Failed to invoke action", _exc_);
     }
     __env.clearGetCache();
     try {
-      _t_5 = "body two";
-      await _t_3(__env, _t_5);
+      _t_10 = "body two";
+      _t_11 = await __builtin.invokeStreamVarRef(__env, _t_3, _t_10);
+      {
+        let _iter_tmp = await _t_11.next();
+        while (!_iter_tmp.done) {
+          _t_12 = _iter_tmp.value;
+          _t_13 = _t_12[0];
+          _t_14 = _t_12[1];
+          _t_15 = _t_14.__response;
+          _iter_tmp = await _t_11.next();
+        }
+      }
     } catch(_exc_) {
       __env.reportError("Failed to invoke action", _exc_);
     }
@@ -5171,18 +5403,50 @@ const TEST_CASES = [
   let _t_1;
   let _t_2;
   let _t_3;
+  let _t_4;
+  let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
   try {
     _t_0 = __scope.p1;
     _t_1 = "title one";
-    await _t_0(__env, _t_1);
+    _t_2 = await __builtin.invokeStreamVarRef(__env, _t_0, _t_1);
+    {
+      let _iter_tmp = await _t_2.next();
+      while (!_iter_tmp.done) {
+        _t_3 = _iter_tmp.value;
+        _t_4 = _t_3[0];
+        _t_5 = _t_3[1];
+        _t_6 = _t_5.__response;
+        await __env.output(String(_t_4), _t_5);
+        _iter_tmp = await _t_2.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }
   __env.clearGetCache();
   try {
-    _t_2 = __scope.p1;
-    _t_3 = "title two";
-    await _t_2(__env, _t_3);
+    _t_7 = __scope.p1;
+    _t_8 = "title two";
+    _t_9 = await __builtin.invokeStreamVarRef(__env, _t_7, _t_8);
+    {
+      let _iter_tmp = await _t_9.next();
+      while (!_iter_tmp.done) {
+        _t_10 = _iter_tmp.value;
+        _t_11 = _t_10[0];
+        _t_12 = _t_10[1];
+        _t_13 = _t_12.__response;
+        await __env.output(String(_t_11), _t_12);
+        _iter_tmp = await _t_9.next();
+      }
+    }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
   }`]],
@@ -5201,9 +5465,19 @@ const TEST_CASES = [
   let _t_3;
   let _t_4;
   let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
   await __env.enterProcedure(0, "p1");
   try {
-    _t_3 = async function(__env, _t_1) {
+    _t_3 = async function(__env, __emit, _t_1) {
       "use strict";
       let _t_2;
       await __env.enterProcedure(1, "p2");
@@ -5222,14 +5496,34 @@ const TEST_CASES = [
     };
     try {
       _t_4 = "body one";
-      await _t_3(__env, _t_4);
+      _t_5 = await __builtin.invokeStreamVarRef(__env, _t_3, _t_4);
+      {
+        let _iter_tmp = await _t_5.next();
+        while (!_iter_tmp.done) {
+          _t_6 = _iter_tmp.value;
+          _t_7 = _t_6[0];
+          _t_8 = _t_6[1];
+          _t_9 = _t_8.__response;
+          _iter_tmp = await _t_5.next();
+        }
+      }
     } catch(_exc_) {
       __env.reportError("Failed to invoke action", _exc_);
     }
     __env.clearGetCache();
     try {
-      _t_5 = "body two";
-      await _t_3(__env, _t_5);
+      _t_10 = "body two";
+      _t_11 = await __builtin.invokeStreamVarRef(__env, _t_3, _t_10);
+      {
+        let _iter_tmp = await _t_11.next();
+        while (!_iter_tmp.done) {
+          _t_12 = _iter_tmp.value;
+          _t_13 = _t_12[0];
+          _t_14 = _t_12[1];
+          _t_15 = _t_14.__response;
+          _iter_tmp = await _t_11.next();
+        }
+      }
     } catch(_exc_) {
       __env.reportError("Failed to invoke action", _exc_);
     }
@@ -5242,6 +5536,11 @@ const TEST_CASES = [
   let _t_3;
   let _t_4;
   let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
   try {
     _t_1 = new Date(XNOWX);
     _t_2 = 3600000;
@@ -5253,7 +5552,18 @@ const TEST_CASES = [
         try {
           _t_4 = __scope.p1;
           _t_5 = "title one";
-          await _t_4(__env, _t_5);
+          _t_6 = await __builtin.invokeStreamVarRef(__env, _t_4, _t_5);
+          {
+            let _iter_tmp = await _t_6.next();
+            while (!_iter_tmp.done) {
+              _t_7 = _iter_tmp.value;
+              _t_8 = _t_7[0];
+              _t_9 = _t_7[1];
+              _t_10 = _t_9.__response;
+              await __env.output(String(_t_8), _t_9);
+              _iter_tmp = await _t_6.next();
+            }
+          }
         } catch(_exc_) {
           __env.reportError("Failed to invoke action", _exc_);
         }
@@ -6864,6 +7174,187 @@ const TEST_CASES = [
     }
   } catch(_exc_) {
     __env.reportError("Failed to invoke query", _exc_);
+  }`]],
+
+
+    // 87
+    // procedure with result, called from let result
+    [`
+    let procedure cat_and_twitter := {
+      let result cat := @com.thecatapi.get();
+      now => cat => @com.twitter.post_picture(picture_url=picture_url, caption="cat");
+      now => cat => notify;
+    };
+    let result cat2 := cat_and_twitter();
+    now => cat2 => notify;
+    `,
+    [`"use strict";
+  let _t_0;
+  let _t_1;
+  let _t_2;
+  let _t_3;
+  let _t_4;
+  let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
+  let _t_16;
+  let _t_17;
+  let _t_18;
+  let _t_19;
+  let _t_20;
+  let _t_21;
+  let _t_22;
+  let _t_23;
+  let _t_24;
+  let _t_25;
+  let _t_26;
+  let _t_27;
+  let _t_28;
+  let _t_29;
+  let _t_30;
+  let _t_31;
+  await __env.enterProcedure(0, "cat_and_twitter");
+  try {
+    _t_0 = new Array(0);
+    try {
+      _t_1 = {};
+      _t_2 = await __env.invokeQuery("com.thecatapi", { }, "get", _t_1, { projection: ["image_id", "count", "picture_url", "link"] });
+      _t_3 = _t_2[Symbol.iterator]();
+      {
+        let _iter_tmp = await _t_3.next();
+        while (!_iter_tmp.done) {
+          _t_4 = _iter_tmp.value;
+          _t_5 = _t_4[0];
+          _t_6 = _t_4[1];
+          _t_7 = _t_6.count;
+          _t_8 = _t_6.__response;
+          _t_9 = _t_6.image_id;
+          _t_10 = _t_6.picture_url;
+          _t_11 = _t_6.link;
+          _t_12 = new Array(2);
+          _t_12[0] = _t_5;
+          _t_12[1] = _t_6;
+          _t_0.push(_t_12);
+          _iter_tmp = await _t_3.next();
+        }
+      }
+    } catch(_exc_) {
+      __env.reportError("Failed to invoke query", _exc_);
+    }
+    __env.clearGetCache();
+    _t_13 = _t_0[Symbol.iterator]();
+    {
+      let _iter_tmp = await _t_13.next();
+      while (!_iter_tmp.done) {
+        _t_14 = _iter_tmp.value;
+        _t_15 = _t_14[0];
+        _t_16 = _t_14[1];
+        _t_17 = _t_16.__response;
+        _t_18 = _t_16.image_id;
+        _t_19 = _t_16.picture_url;
+        _t_20 = _t_16.link;
+        try {
+          _t_21 = {};
+          _t_22 = String (_t_19);
+          _t_21.picture_url = _t_22;
+          _t_23 = "cat";
+          _t_21.caption = _t_23;
+          await __env.invokeAction("com.twitter", { }, "post_picture", _t_21);
+        } catch(_exc_) {
+          __env.reportError("Failed to invoke action", _exc_);
+        }
+        _iter_tmp = await _t_13.next();
+      }
+    }
+    __env.clearGetCache();
+    _t_24 = _t_0[Symbol.iterator]();
+    {
+      let _iter_tmp = await _t_24.next();
+      while (!_iter_tmp.done) {
+        _t_25 = _iter_tmp.value;
+        _t_26 = _t_25[0];
+        _t_27 = _t_25[1];
+        _t_28 = _t_27.__response;
+        _t_29 = _t_27.image_id;
+        _t_30 = _t_27.picture_url;
+        _t_31 = _t_27.link;
+        try {
+          __emit(_t_26, _t_27);
+        } catch(_exc_) {
+          __env.reportError("Failed to invoke action", _exc_);
+        }
+        _iter_tmp = await _t_24.next();
+      }
+    }
+  } finally {
+    await __env.exitProcedure(0, "cat_and_twitter");
+  }`, `"use strict";
+  let _t_0;
+  let _t_1;
+  let _t_2;
+  let _t_3;
+  let _t_4;
+  let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
+  let _t_16;
+  let _t_17;
+  let _t_18;
+  _t_0 = new Array(0);
+  _t_1 = __scope.cat_and_twitter;
+  _t_2 = await __builtin.invokeStreamVarRef(__env, _t_1);
+  {
+    let _iter_tmp = await _t_2.next();
+    while (!_iter_tmp.done) {
+      _t_3 = _iter_tmp.value;
+      _t_4 = _t_3[0];
+      _t_5 = _t_3[1];
+      _t_6 = _t_5.__response;
+      _t_7 = _t_5.image_id;
+      _t_8 = _t_5.picture_url;
+      _t_9 = _t_5.link;
+      _t_10 = new Array(2);
+      _t_10[0] = _t_4;
+      _t_10[1] = _t_5;
+      _t_0.push(_t_10);
+      _iter_tmp = await _t_2.next();
+    }
+  }
+  __env.clearGetCache();
+  _t_11 = _t_0[Symbol.iterator]();
+  {
+    let _iter_tmp = await _t_11.next();
+    while (!_iter_tmp.done) {
+      _t_12 = _iter_tmp.value;
+      _t_13 = _t_12[0];
+      _t_14 = _t_12[1];
+      _t_15 = _t_14.__response;
+      _t_16 = _t_14.image_id;
+      _t_17 = _t_14.picture_url;
+      _t_18 = _t_14.link;
+      try {
+        await __env.output(String(_t_13), _t_14);
+      } catch(_exc_) {
+        __env.reportError("Failed to invoke action", _exc_);
+      }
+      _iter_tmp = await _t_11.next();
+    }
   }`]],
 ];
 

--- a/test/test_prettyprint.js
+++ b/test/test_prettyprint.js
@@ -44,16 +44,6 @@ const TEST_CASES = [
 `now => compute ((aggregateRating.reviews) filter { author == "Bob" }) of (@org.schema.restaurants()) => notify;`,
 `now => [foo] of (compute ((aggregateRating.reviews) filter { author == "Bob" }) as foo of (@org.schema.restaurants())) => notify;`,
 
-// macros
-`class @foo.bar {
-  compute isTrue() : Boolean := true;
-
-  compute greaterThanZero(in req x: Number) : Boolean := x >= 0;
-
-  list query q(out num: Number);
-}
-now => (@foo.bar.q()), @for.bar.greaterThanZero(x=num) => notify;`,
-
 // device selectors
 `now => @light-bulb(name="bathroom").set_power(power=enum(on));`,
 `now => @light-bulb(id="io.home-assistant/http://hassio.local:8123-light.hue_bloom_1", name="bathroom").set_power(power=enum(on));`,


### PR DESCRIPTION
The statement with `notify` in a procedure is considered the "return value" of that procedure. Only one such statement is allowed.
(Statements before and after in the procedure are still executed for side effects, if any)

The return value can be displayed to the user directly, by calling the procedure as an action at the top-level, or it can be collected in an assignment statement for further use.