### PR TITLE
Fix allocating repeated measure entities

### DIFF
--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -268,9 +268,6 @@ class EntityRetriever {
         const entity = valueToEntity(entityType, value);
         const candidates = this._findEntityInBag(entityType, entity, this.entities);
 
-        if (ignoreNotFound && candidates.length === 0)
-            return null;
-
         if (candidates.length === 0) {
             // uh oh we don't have the entity we want
             // see if we have an used pile, and try there for an unambiguous one
@@ -281,6 +278,9 @@ class EntityRetriever {
                     throw new Error('Ambiguous entity ' + entity + ' of type ' + entityType);
                 return reuse[0];
             }
+
+            if (ignoreNotFound && candidates.length === 0)
+                return null;
 
             return this._findEntityFromSentence(entityType, entity);
         } else {

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -585,6 +585,10 @@ now => @org.schema.restaurant() => notify;`],
     [`now => ( @com.yelp.restaurant ) filter true param:cuisines:Array(Entity(com.yelp:restaurant_cuisine)) => notify`,
     `i 'm looking for a restaurant , i do n't care what cuisine`, {},
     `now => (@com.yelp.restaurant()), true(cuisines) => notify;`],
+
+    ['now => ( @org.schema.full.Recipe ) filter param:nutrition.fatContent:Measure(kg) >= MEASURE_kg_0 and param:nutrition.sugarContent:Measure(kg) >= MEASURE_kg_0 => notify',
+     `yeah please find a recipe with that fat content and that sugar content`, { MEASURE_kg_0: { value: 13, unit: 'kg' } },
+     `now => (@org.schema.full.Recipe()), (nutrition.fatContent >= 13kg && nutrition.sugarContent >= 13kg) => notify;`]
 ];
 
 function stripTypeAnnotations(program) {

--- a/test/test_nn_syntax_allocator.js
+++ b/test/test_nn_syntax_allocator.js
@@ -140,7 +140,11 @@ const TEST_CASES = [
     ['bookkeeping answer TIME_0',
      { TIME_0: { hour: 18, minute: 0, second: 0 } }],
 
+    ['now => @com.thecatapi.get param:count:Number = NUMBER_0 => notify',
+     { NUMBER_0: 13 }],
 
+    ['now => ( @org.schema.full.Recipe ) filter param:nutrition.fatContent:Measure(kg) >= MEASURE_kg_0 => notify',
+     { MEASURE_kg_0: { value: 13, unit: 'kg' } }]
 ];
 
 async function testCase(test, i) {


### PR DESCRIPTION
If we're trying to allocate a MEASURE_ token (a measure entity
copied from context), try reusing an existing value that was previously
allocated, rather than checking for a NUMBER_ entity and failing.

This was originally reported at https://community.almond.stanford.edu/t/generating-dataset-entity-error/269/8