### PR TITLE
Relax entity check to allow non contiguous tokens

### DIFF
--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -185,18 +185,33 @@ class EntityRetriever {
     }
 
     _sentenceContains(tokens) {
-        for (let i = 0; i <= this.sentence.length-tokens.length; i++) {
-            let found = true;
-            for (let j = 0; j < tokens.length; j++) {
-                if (tokens[j] !== this.sentence[i+j]) {
-                    found = false;
-                    break;
-                }
-            }
-            if (found)
+        // check that the sequence "sentence" contains the subsequence "tokens"
+        // other tokens can be interspersed between the tokens of "tokens"
+        // but the order cannot be changed
+        //
+        // this uses a greedy algorithm
+        // the recurrence is:
+        //  - for a suffix of sentence starting at index i
+        //    - for a suffix of tokens starting at index j
+        //      - if sentence[i] == tokens[j]
+        //         - return recurse(i+1, j+1)
+        //      - else
+        //         - return recurse(i+1, j)
+
+        const sentence = this.sentence;
+        function recursiveHelper(i, j) {
+            if (j === tokens.length) // no tokens left to match (all tokens matched)
                 return true;
+            if (i === sentence.length) // empty sentence suffix
+                return false;
+
+            if (sentence[i] === tokens[j])
+                return recursiveHelper(i+1, j+1);
+            else
+                return recursiveHelper(i+1, j);
         }
-        return false;
+
+        return recursiveHelper(0, 0);
     }
 
     _findEntityFromSentence(entityType, entity) {


### PR DESCRIPTION
In multiwoz one example has "asian or oriental", which needs to
be annotated as "asian oriental" to match the ontology. Relax
the requirement that quoted strings/entities are a substring
of the original sentence, and make it a subsequence instead.