### PR TITLE
Fix nn-syntax for currencies

### DIFF
--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -699,9 +699,9 @@ primary_value = '(' v:value ')' {
 constant_value =
         date_value /
         bool_value /
+        currency_value /
         measure_value /
         number_value /
-        currency_value /
         time_value /
         location_value /
         enum_value /
@@ -736,6 +736,8 @@ undefined_value = '$undefined' remote:('.' _ 'remote')? {
 measure_value = num:literal_number unit:ident { return new Ast.Value.Measure(num, unit); }
 number_value = v:literal_number { return new Ast.Value.Number(v); }
 currency_value = ('makeCurrency' / 'new' __ 'Currency') _ '(' _ num:literal_number _ ',' _ code:ident _ ')' {
+    return new Ast.Value.Currency(num, code);
+} / num:literal_number '$' code:ident {
     return new Ast.Value.Currency(num, code);
 }
 

--- a/lib/nn-syntax/lexer.js
+++ b/lib/nn-syntax/lexer.js
@@ -109,6 +109,8 @@ module.exports = class SequenceLexer {
             let [,paramname,] = next.split(':');
             this._lastparam = paramname;
             next = new TokenWrapper('ATTRIBUTE_NAME', paramname);
+        } else if (next.startsWith('unit:$')) {
+            next = new TokenWrapper('CURRENCY_CODE', next.substring('unit:$'.length));
         } else if (next.startsWith('unit:')) {
             next = new TokenWrapper('UNIT', next.substring('unit:'.length));
         } else if (next.startsWith('device:')) {

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -675,6 +675,7 @@ constant_Number = {
 constant_Currency = {
     tok:CURRENCY => new Ast.Value.Currency(tok.value.value, tok.value.unit);
     'new' 'Currency' '(' num:literal_number ',' unit:UNIT ')' => new Ast.Value.Currency(num, unit.value);
+    num:literal_number tok:CURRENCY_CODE => new Ast.Value.Currency(num, tok.value);
 }
 constant_Location = {
     'location:current_location' => new Ast.Value.Location(new Ast.Location.Relative('current_location'));

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -536,9 +536,9 @@ module.exports = class ToNNConverter {
             if (currency !== null)
                 return List.concat(currency);
             if (isSmallInteger(value.value))
-                return List.concat('new', 'Currency', '(', String(value.value), ',', 'unit:' + value.code, ')');
+                return List.concat(String(value.value), 'unit:$' + value.code);
             else
-                return List.concat('new', 'Currency', '(', this.findEntity('NUMBER', value), ',', 'unit:' + value.code, ')');
+                return List.concat(this.findEntity('NUMBER', value), 'unit:$' + value.code);
         } else if (value.isLocation) {
             if (value.value.isRelative)
                 return 'location:' + value.value.relativeTag;

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -532,7 +532,13 @@ module.exports = class ToNNConverter {
             }
             return this.findEntity('NUMBER', value);
         } else if (value.isCurrency) {
-            return this.findEntity('CURRENCY', value);
+            let currency = this.findEntity('CURRENCY', value, { ignoreNotFound: true });
+            if (currency !== null)
+                return List.concat(currency);
+            if (isSmallInteger(value.value))
+                return List.concat('new', 'Currency', '(', String(value.value), ',', 'unit:' + value.code, ')');
+            else
+                return List.concat('new', 'Currency', '(', this.findEntity('NUMBER', value), ',', 'unit:' + value.code, ')');
         } else if (value.isLocation) {
             if (value.value.isRelative)
                 return 'location:' + value.value.relativeTag;

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -96,7 +96,7 @@ function prettyprintValue(ast) {
     else if (ast.isNumber)
         return String(ast.value);
     else if (ast.isCurrency)
-        return `new Currency(${ast.value}, ${ast.code})`;
+        return `${ast.value}$${ast.code}`;
     else if (ast.isLocation)
         return prettyprintLocation(ast.value);
     else if (ast.isDate)

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -138,7 +138,7 @@ const TEST_CASES = [
 
     ['now => ( @com.uber.price_estimate param:end:Location = location:home param:start:Location = location:work ) filter param:low_estimate:Currency >= CURRENCY_0 => notify',
     `get an uber price estimate from home to work if the low estimate is greater than CURRENCY_0`, {CURRENCY_0: { value: 50, unit: 'usd' } },
-    `now => (@com.uber.price_estimate(end=$context.location.home, start=$context.location.work)), low_estimate >= new Currency(50, usd) => notify;`],
+    `now => (@com.uber.price_estimate(end=$context.location.home, start=$context.location.work)), low_estimate >= 50$usd => notify;`],
 
     ['now => ( @com.uber.price_estimate ) filter param:uber_type:Enum(pool,uber_x,uber_xl,uber_black,select,suv,assist) == enum:uber_x => notify',
     `get a price estimate for uber x`, {},
@@ -590,9 +590,9 @@ now => @org.schema.restaurant() => notify;`],
      `yeah please find a recipe with that fat content and that sugar content`, { MEASURE_kg_0: { value: 13, unit: 'kg' } },
      `now => (@org.schema.full.Recipe()), (nutrition.fatContent >= 13kg && nutrition.sugarContent >= 13kg) => notify;`],
 
-    ['now => ( @com.uber.price_estimate ) filter param:low_estimate:Currency <= new Currency ( NUMBER_0 , unit:usd ) => notify',
+    ['now => ( @com.uber.price_estimate ) filter param:low_estimate:Currency <= NUMBER_0 unit:$usd => notify',
      'is it less than $ NUMBER_0 ?', { NUMBER_0: 1000 },
-     'now => (@com.uber.price_estimate()), low_estimate <= new Currency(1000, usd) => notify;'],
+     'now => (@com.uber.price_estimate()), low_estimate <= 1000$usd => notify;'],
 ];
 
 function stripTypeAnnotations(program) {

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -588,7 +588,11 @@ now => @org.schema.restaurant() => notify;`],
 
     ['now => ( @org.schema.full.Recipe ) filter param:nutrition.fatContent:Measure(kg) >= MEASURE_kg_0 and param:nutrition.sugarContent:Measure(kg) >= MEASURE_kg_0 => notify',
      `yeah please find a recipe with that fat content and that sugar content`, { MEASURE_kg_0: { value: 13, unit: 'kg' } },
-     `now => (@org.schema.full.Recipe()), (nutrition.fatContent >= 13kg && nutrition.sugarContent >= 13kg) => notify;`]
+     `now => (@org.schema.full.Recipe()), (nutrition.fatContent >= 13kg && nutrition.sugarContent >= 13kg) => notify;`],
+
+    ['now => ( @com.uber.price_estimate ) filter param:low_estimate:Currency <= new Currency ( NUMBER_0 , unit:usd ) => notify',
+     'is it less than $ NUMBER_0 ?', { NUMBER_0: 1000 },
+     'now => (@com.uber.price_estimate()), low_estimate <= new Currency(1000, usd) => notify;'],
 ];
 
 function stripTypeAnnotations(program) {


### PR DESCRIPTION
So we can remove currency preprocessing from the tokenizer, and the let the neural network deal with it.