### PR TITLE
Entity definition statements

### DIFF
--- a/lib/ast/class_def.js
+++ b/lib/ast/class_def.js
@@ -36,8 +36,9 @@ class ClassDef extends Statement {
      *        in the source code
      * @param {string} kind - the class identifier in Thingpedia
      * @param {Ast.ClassDef[]|null} _extends - parent classes (if any)
-     * @param {Object.<string, any>} members - the class members including queries, actions, imports
+     * @param {Object.<string, any>} members - the class members including queries, actions, entities, imports
      * @param {Ast.ImportStmt[]} [members.imports=[]] - import statements in this class
+     * @param {Ast.EntityDef[]} [members.entities=[]] - entity declarations in this class
      * @param {Object.<string, Ast.FunctionDef>} [members.queries={}] - query functions in this class
      * @param {Object.<string, Ast.FunctionDef>} [members.actions={}] - action functions in this class
      * @param {Object<string, Object>} annotations - annotations of the class
@@ -57,6 +58,7 @@ class ClassDef extends Statement {
 
         // load class members
         this.imports = members.imports || [];
+        this.entities = members.entities || [];
         this.queries = members.queries || {};
         this.actions = members.actions || {};
         this._adjustParentPointers();
@@ -78,6 +80,8 @@ class ClassDef extends Statement {
         if (visitor.visitClassDef(this)) {
             for (let import_ of this.imports)
                 import_.visit(visitor);
+            for (let entity of this.entities)
+                entity.visit(visitor);
             for (let query in this.queries)
                 this.queries[query].visit(visitor);
             for (let action in this.actions)
@@ -157,13 +161,14 @@ class ClassDef extends Statement {
     clone() {
         // clone members
         const imports = this.imports.map((i) => i.clone());
+        const entities = this.entities.map((e) => e.clone());
         const queries = {};
         const actions = {};
         for (let name in this.queries)
             queries[name] = this.queries[name].clone();
         for (let name in this.actions)
             actions[name] = this.actions[name].clone();
-        const members = { imports, queries, actions };
+        const members = { imports, entities, queries, actions };
 
         // clone annotations
         const nl = {};

--- a/lib/ast/class_def.js
+++ b/lib/ast/class_def.js
@@ -327,7 +327,7 @@ class ClassDef extends Statement {
     }
 
     /**
-     * The implmentation annotations of the class
+     * The implementation annotations of the class
      *
      * @type {Object.<string, any>}
      * @readonly

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -879,7 +879,7 @@ class Example extends Node {
      * and discard examples that do not typecheck without failing the whole dataset.
      *
      * @param {SchemaRetriever} schemas - schema retriever object to retrieve Thingpedia information
-     * @param {boolean} [getMeta=false] - retreive natural language metadata during typecheck
+     * @param {boolean} [getMeta=false] - retrieve natural language metadata during typecheck
      */
     typecheck(schemas, getMeta = false) {
         return Typechecking.typeCheckExample(this, schemas, {}, getMeta);
@@ -962,7 +962,7 @@ ImportStmt.Class.prototype.isClass = true;
 /**
  * A `import` statement that imports a mixin.
  *
- * Mixins add implementation functionality to ThingTalk classes, such as specifing
+ * Mixins add implementation functionality to ThingTalk classes, such as specifying
  * how the class is loaded (which language, which format, which version of the SDK)
  * and how devices are configured.
  *

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -130,15 +130,15 @@ class Declaration extends Statement {
         this.value = value;
 
         /**
-         * The declaration metadata (translatable annotations).
+         * The declaration natural language annotations (translatable annotations).
          * @type {Object.<string, any>}
          */
-        this.metadata = metadata;
+        this.nl_annotations = metadata;
         /**
          * The declaration annotations.
          * @type {Object.<string, Ast.Value>}
          */
-        this.annotations = annotations;
+        this.impl_annotations = annotations;
         /**
          * The type definition corresponding to this declaration.
          *
@@ -146,6 +146,13 @@ class Declaration extends Statement {
          * @type {Ast.FunctionDef|null}
          */
         this.schema = schema;
+    }
+
+    get metadata() {
+        return this.nl_annotations;
+    }
+    get annotations() {
+        return this.impl_annotations;
     }
 
     visit(visitor) {
@@ -177,9 +184,9 @@ class Declaration extends Statement {
         Object.assign(newArgs, this.args);
 
         const newMetadata = {};
-        Object.assign(newMetadata, this.metadata);
+        Object.assign(newMetadata, this.nl_annotations);
         const newAnnotations = {};
-        Object.assign(newAnnotations, this.annotations);
+        Object.assign(newAnnotations, this.impl_annotations);
         return new Declaration(this.location, this.name, this.type, newArgs,
             this.value.clone(), newMetadata, newAnnotations, this.schema);
     }
@@ -403,8 +410,15 @@ class OnInputChoice extends Statement {
         assert(Array.isArray(actions));
         this.actions = actions;
 
-        this.metadata = metadata;
-        this.annotations = annotations;
+        this.nl_annotations = metadata;
+        this.impl_annotations = annotations;
+    }
+
+    get metadata() {
+        return this.nl_annotations;
+    }
+    get annotations() {
+        return this.impl_annotations;
     }
 
     visit(visitor) {
@@ -435,10 +449,10 @@ class OnInputChoice extends Statement {
 
     clone() {
         const newMetadata = {};
-        Object.assign(newMetadata, this.metadata);
+        Object.assign(newMetadata, this.nl_annotations);
 
         const newAnnotations = {};
-        Object.assign(newAnnotations, this.annotations);
+        Object.assign(newAnnotations, this.impl_annotations);
         return new OnInputChoice(
             this.location,
             this.table !== null ? this.table.clone() : null,

--- a/lib/ast/program.js
+++ b/lib/ast/program.js
@@ -1027,3 +1027,91 @@ class MixinImportStmt extends ImportStmt {
 ImportStmt.Mixin = MixinImportStmt;
 ImportStmt.Mixin.prototype.isMixin = true;
 module.exports.ImportStmt = ImportStmt;
+
+/**
+ * An `entity` statement inside a ThingTalk class.
+ *
+ * @alias Ast.EntityDef
+ * @extends Ast~Node
+ * @abstract
+ */
+class EntityDef extends Node {
+    /**
+     * Construct a new entity declaration.
+     *
+     * @param {Ast~SourceRange|null} location - the position of this node
+     *        in the source code
+     * @param {string} name - the entity name (the part after the ':')
+     * @param {Object.<string, Object>} annotations - annotations of the entity type
+     * @param {Object.<string, any>} [annotations.nl={}] - natural-language annotations (translatable annotations)
+     * @param {Object.<string, Ast.Value>} [annotations.impl={}] - implementation annotations
+     */
+    constructor(location, name, annotations, metadata) {
+        super(location);
+        /**
+         * The entity name.
+         * @type {string}
+         */
+        this.name = name;
+        /**
+         * The entity metadata (translatable annotations).
+         * @type {Object.<string,any>}
+         */
+        this.nl_annotations = annotations.nl || {};
+        /**
+         * The entity annotations.
+         * @type {Object.<string,Ast.Value>}
+         */
+        this.impl_annotations = annotations.impl || {};
+    }
+
+    /**
+     * Clone this entity and return a new object with the same properties.
+     *
+     * @return {Ast.EntityDef} the new instance
+     */
+    clone() {
+        const nl = {};
+        Object.assign(nl, this.nl_annotations);
+        const impl = {};
+        Object.assign(impl, this.impl_annotations);
+
+        return new EntityDef(this.location, this.name, { nl, impl });
+    }
+
+    /**
+     * Read and normalize an implementation annotation from this entity definition.
+     *
+     * @param {string} name - the annotation name
+     * @return {any|undefined} the annotation normalized value, or `undefined` if the
+     *         annotation is not present
+     */
+    getImplementationAnnotation(name) {
+        if (Object.prototype.hasOwnProperty.call(this.impl_annotations, name))
+            return this.impl_annotations[name].toJS();
+        else
+            return undefined;
+    }
+
+    /**
+     * Read a natural-language annotation from this entity definition.
+     *
+     * @param {string} name - the annotation name
+     * @return {any|undefined} the annotation value, or `undefined` if the
+     *         annotation is not present
+     */
+    getNaturalLanguageAnnotation(name) {
+        if (Object.prototype.hasOwnProperty.call(this.nl_annotations, name))
+            return this.nl_annotations[name];
+        else
+            return undefined;
+    }
+
+    visit(visitor) {
+        visitor.enter(this);
+        visitor.visitEntityDef(this);
+        visitor.exit(this);
+    }
+}
+EntityDef.prototype.isEntityDef = true;
+module.exports.EntityDef = EntityDef;

--- a/lib/ast/visitor.js
+++ b/lib/ast/visitor.js
@@ -201,6 +201,10 @@ class NodeVisitor {
     visitMixinImportStmt(node) {
         return true;
     }
+    /* istanbul ignore next */
+    visitEntityDef(node) {
+        return true;
+    }
 
     // expressions
     /* istanbul ignore next */

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -846,7 +846,7 @@ arg_map_value = ('makeArgMap' / 'new' __ 'ArgMap') _ '(' _ first:( ident _ ':' _
     return new Ast.Value.ArgMap(map);
 }
 
-object_value = '{' _ first:( ident _ '=' _ value ) _ rest:(',' _ ident _ '=' _ value _ )* _ '}' {
+object_value = '{' _ first:( ident _ '=' _ value ) _ rest:(',' _ ident _ '=' _ value _ )* _ (',' _)? '}' {
     let obj = {};
     obj[first[0]] = first[4];
     if (rest.length !== 0)

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -260,6 +260,7 @@ class_def = is_abstract:('abstract' __ )? 'class' _ name:class_name _ extends_:(
     const queries = {};
     const actions = {};
     const imports = [];
+    const entities = [];
 
     for (var ast of members) {
         if (ast instanceof Ast.FunctionDef) {
@@ -273,12 +274,14 @@ class_def = is_abstract:('abstract' __ )? 'class' _ name:class_name _ extends_:(
           }
         } else if (ast instanceof Ast.ImportStmt) {
           imports.push(ast);
+        } else if (ast instanceof Ast.EntityDef) {
+          entities.push(ast);
         }
     }
 
     const [nl, impl] = splitAnnotations(annotations);
     const options = { is_abstract: !!is_abstract };
-    return new Ast.ClassDef(location(), name, extends_ !== null ? extends_[2] : null, { queries, actions, imports }, { nl, impl }, options);
+    return new Ast.ClassDef(location(), name, extends_ !== null ? extends_[2] : null, { queries, actions, imports, entities }, { nl, impl }, options);
 }
 
 query_modifiers = 'monitorable' __ 'list' !identchar {
@@ -291,13 +294,17 @@ query_modifiers = 'monitorable' __ 'list' !identchar {
   return [true, false];
 }
 
-class_member = v:(function_def / import_class_stmt / import_mixin_stmt) _ { return v; }
+class_member = v:(function_def / import_class_stmt / import_mixin_stmt / entity_def_stmt) _ { return v; }
 
 import_class_stmt = 'import' __ 'class' __ name:class_name _ alias:('as' __ ident)? _ ';' {
   return new Ast.ImportStmt.Class(location(), name, alias !== null ? alias[2] : null);
 }
 import_mixin_stmt = 'import' __ first:ident _ rest:(',' _ ident _)* 'from' __ name:class_name _ in_params:input_param_list _ ';' {
   return new Ast.ImportStmt.Mixin(location(), [first].concat(take(rest, 2)), name, in_params);
+}
+entity_def_stmt = 'entity' __ name:ident annotations: (_ annotation _)* ';' _ {
+  const [nl_annotations, impl_annotations] = splitAnnotations(annotations);
+  return new Ast.EntityDef(location(), name, { nl:nl_annotations, impl:impl_annotations });
 }
 
 function_name_list = first:ident _ rest:(',' _ ident _)* {

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -353,11 +353,11 @@ function prettyprintAnnotations(ast, prefix = '  ', linebreak = true) {
     let annotations = '';
     if (linebreak)
         prefix = '\n' + prefix;
-    Object.entries(ast.metadata).forEach(([name, value]) => {
+    Object.entries(ast.nl_annotations).forEach(([name, value]) => {
         if (typeof value === 'object' && Object.keys(value).length > 0 || value && value.length > 0)
             annotations += `${prefix}#_[${name}=${prettyprintJson(value)}]`;
     });
-    Object.entries(ast.annotations).forEach(([name, value]) => {
+    Object.entries(ast.impl_annotations).forEach(([name, value]) => {
         if (Array.isArray(value))
             annotations += `${prefix}#[${name}=[${(value.filter(isValidAnnotation).map((v) => prettyprintValue(v))).join(', ')}]]`;
         else if (isValidAnnotation(value))
@@ -366,14 +366,19 @@ function prettyprintAnnotations(ast, prefix = '  ', linebreak = true) {
     return annotations;
 }
 
+function prettyprintEntityDef(ast, prefix = '  ') {
+    return `${prefix}entity ${ast.name}${prettyprintAnnotations(ast, prefix + '  ')};`; //`
+}
+
 function prettyprintClassDef(ast, prefix = '  ') {
     let imports = ast.imports.map((i) => prefix + prettyprintImportStmt(i) + '\n').join('');
+    let entities = ast.entities.map((i) => prefix + prettyprintEntityDef(i) + '\n').join('');
     let queries = Object.keys(ast.queries).map((q) => ast.queries[q].toString(prefix + '  ') + '\n').join('\n');
     let actions = Object.keys(ast.actions).map((q) => ast.actions[q].toString(prefix + '  ') + '\n').join('\n');
     let annotations = prettyprintAnnotations(ast, prefix);
 
     let class_members = [];
-    [imports, queries, actions].forEach((member) => {
+    [imports, entities, queries, actions].forEach((member) => {
         if (member.length > 0)
             class_members.push(member);
     });

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1928,3 +1928,24 @@ let procedure cat_and_twitter := {
 let result cat2 := cat_and_twitter();
 now => cat2 => notify;
 now => cat2 => @com.facebook.post_picture(picture_url=picture_url, caption="cat");
+
+====
+
+// entity declarations
+class @com.example {
+  entity restaurant #_[description="Restaurant"] #[has_ner=true];
+
+  query restaurant(out id : Entity(com.example:restaurant),
+                   out geo : Location);
+
+  entity movie #_[description="Movie"] #[has_ner=true];
+  entity person #_[description="Person"] #[has_ner=true];
+  query movie(out id : Entity(com.example:movie),
+              out actors : Array(Entity(com.example:person)),
+              out director : Entity(com.example:person));
+
+  entity email #_[description="Email Message"] #[has_ner=false];
+  query email(out id : Entity(com.example:email),
+              out subject : String,
+              out sender : Entity(tt:email_address));
+}

--- a/test/test_prettyprint.js
+++ b/test/test_prettyprint.js
@@ -36,6 +36,18 @@ const TEST_CASES = [
 }
 `,
 
+// entity def
+`class @com.example {
+  entity restaurant
+    #_[description="Restaurant"]
+    #[has_ner=true];
+
+  query restaurant(out id: Entity(com.example:restaurant),
+                   out geo: Location)
+  #[minimal_projection=["id"]];
+}
+`,
+
 // aggregate filter
 `now => (@org.schema.restaurant()), count(review) >= 1 => notify;`,
 


### PR DESCRIPTION
This PR introduces a new "entity" statement inside a ThingTalk class.

The goal is to make classes self-contained, and eliminate the need for entities.json (except for well-known entities like tt:stock_id or tt:country).
This in particular solves a chicken-and-egg problem we have today: you cannot upload a device to Thingpedia that uses an entity type not defined in Thingpedia, but you cannot upload an entity to Thingpedia unless you own that device first. So you have to upload an empty placeholder device, upload the entity, and then upload the final device. It's convoluted and messy.
(String values have the same problem - for strings, we should demote the error to a warning)
It also helps with using Genie, as we can make the starter code download the standard entities from Thingpedia and not have to explain how to modify it.

Entity definitions have three properties:
- the name, which is concatenated with the class name to form the full entity ID
- NL annotations, which are used in Thingpedia and in some error messages from the agent
- impl annotations, the most important of which is `has_ner` which corresponds to the `has_ner_support` bit in entities.json, and indicates whether an entity can appear in the sentence or not; the name is not great but I could not think of a better name. Defaults to `true` if unspecified, which is almost always what you want, and not too harmful if incorrect.