### PR TITLE
compiler: fix compiling projections on functions with input params

### DIFF
--- a/lib/compiler/ops-to-jsir.js
+++ b/lib/compiler/ops-to-jsir.js
@@ -144,6 +144,7 @@ module.exports = class OpCompiler {
                 type: 'scalar',
                 reg: element,
                 tt_type: elementtype,
+                direction: 'output',
                 isInVarScopeNames: false,
             });
         }
@@ -309,11 +310,13 @@ module.exports = class OpCompiler {
         this._currentScope.set('$outputType', {
             type: 'scalar',
             tt_type: null,
+            direction: 'special',
             register: outputType
         });
         this._currentScope.set('$output', {
             type: 'scalar',
             tt_type: null,
+            direction: 'special',
             register: result
         });
 
@@ -323,6 +326,7 @@ module.exports = class OpCompiler {
                     type: 'scalar',
                     tt_type: schema.inReq[arg] || schema.inOpt[arg],
                     register: argmap[arg],
+                    direction: 'input',
                     isInVarScopeNames: false
                 });
                 // note: input parameters && __result do not participate in varScopeNames (which is used to
@@ -398,12 +402,14 @@ module.exports = class OpCompiler {
         this._currentScope.set('$outputType', {
             type: 'scalar',
             tt_type: null,
-            register: null
+            register: null,
+            direction: 'special',
         });
         this._currentScope.set('$output', {
             type: 'scalar',
             tt_type: null,
-            register: result
+            register: result,
+            direction: 'special',
         });
     }
 
@@ -435,12 +441,14 @@ module.exports = class OpCompiler {
         this._currentScope.set('$outputType', {
             type: 'scalar',
             tt_type: null,
-            register: null
+            register: null,
+            direction: 'special',
         });
         this._currentScope.set('$output', {
             type: 'scalar',
             tt_type: null,
-            register: result
+            register: result,
+            direction: 'special',
         });
     }
 
@@ -668,6 +676,13 @@ module.exports = class OpCompiler {
         // track them as we create them
         let newCompounds = new Set;
 
+        // copy-over input parameters
+        for (let [name, value] of this._currentScope) {
+            if (value.direction !== 'input')
+                continue;
+            this._irBuilder.add(new JSIr.SetKey(newOutput, name, value.register));
+        }
+
         for (let name of proj.args) {
             if (name.indexOf('.') >= 0) {
                 const parts = name.split('.');
@@ -692,7 +707,8 @@ module.exports = class OpCompiler {
         newScope.set('$output', {
             type: 'scalar',
             tt_type: null,
-            register: newOutput
+            register: newOutput,
+            direction: 'special',
         });
 
         this._currentScope = newScope;

--- a/lib/compiler/reduceop.js
+++ b/lib/compiler/reduceop.js
@@ -46,16 +46,19 @@ class AggregationOp extends ReduceOp {
         newScope.set(this.field, {
             type: 'scalar',
             tt_type: this.type,
+            direction: 'output',
             register: value
         });
         newScope.set('$outputType', {
             type: 'scalar',
             tt_type: null,
+            direction: 'special',
             register: newOutputType
         });
         newScope.set('$output', {
             type: 'scalar',
             tt_type: null,
+            direction: 'special',
             register: newTuple
         });
         return [newScope, [this.field]];
@@ -193,6 +196,7 @@ function setScopeFromResult(currentScope, newScope, tuple, irBuilder, prefix = '
             type: 'scalar',
             tt_type: currentScopeObj.tt_type,
             register: value,
+            direction: currentScopeObj.direction,
             isInVarScopeNames: currentScopeObj.isInVarScopeNames
         });
 
@@ -248,12 +252,14 @@ ReduceOp.SimpleArgMinMax = class SimpleArgMinMax extends ReduceOp {
             type: 'scalar',
             tt_type: null,
             register: outputType,
+            direction: 'special',
             isInVarScopeNames: false
         });
         newScope.set('$output', {
             type: 'scalar',
             tt_type: null,
             register: tuple,
+            direction: 'special',
             isInVarScopeNames: false
         });
 
@@ -314,12 +320,14 @@ ReduceOp.ComplexArgMinMax = class ComplexArgMinMax extends ReduceOp {
             type: 'scalar',
             tt_type: null,
             register: outputType,
+            direction: 'special',
             isInVarScopeNames: false
         });
         newScope.set('$output', {
             type: 'scalar',
             tt_type: null,
             register: result,
+            direction: 'special',
             isInVarScopeNames: false
         });
 
@@ -408,12 +416,14 @@ class ArrayReduceOp extends ReduceOp {
             type: 'scalar',
             tt_type: null,
             register: outputType,
+            direction: 'special',
             isInVarScopeNames: false
         });
         newScope.set('$output', {
             type: 'scalar',
             tt_type: null,
             register: result,
+            direction: 'special',
             isInVarScopeNames: false
         });
 

--- a/lib/compiler/utils.js
+++ b/lib/compiler/utils.js
@@ -127,6 +127,7 @@ function readResultKey(irBuilder, currentScope, result, key, fullName, type, isI
         type: 'scalar',
         tt_type: type,
         register: reg,
+        direction: 'output',
         isInVarScopeNames
     });
 
@@ -160,12 +161,14 @@ function readScopeVariables(irBuilder, currentScope, outputType, resultReg) {
         type: 'scalar',
         tt_type: null,
         register: outputType,
+        direction: 'special',
         isInVarScopeNames: false
     });
     newScope.set('$output', {
         type: 'scalar',
         tt_type: null,
         register: resultReg,
+        direction: 'special',
         isInVarScopeNames: false
     });
 

--- a/test/test_compiler.js
+++ b/test/test_compiler.js
@@ -7656,7 +7656,61 @@ const TEST_CASES = [
     }
   } catch(_exc_) {
     __env.reportError("Failed to invoke action", _exc_);
-  }`]]
+  }`]],
+
+    // projection on a function with input parameters: the input parameters are carried over
+    [`now => [temperature] of @org.thingpedia.weather.current(location=new Location(37.442156, -122.1634471, "Palo Alto, California")) => notify;`,
+    [`"use strict";
+  let _t_0;
+  let _t_1;
+  let _t_2;
+  let _t_3;
+  let _t_4;
+  let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
+  try {
+    _t_0 = {};
+    _t_1 = new __builtin.Location(37.442156, -122.1634471, "Palo Alto, California");
+    _t_0.location = _t_1;
+    _t_2 = await __env.invokeQuery("org.thingpedia.weather", { }, "current", _t_0, { projection: ["temperature"] });
+    _t_3 = _t_2[Symbol.iterator]();
+    {
+      let _iter_tmp = await _t_3.next();
+      while (!_iter_tmp.done) {
+        _t_4 = _iter_tmp.value;
+        _t_5 = _t_4[0];
+        _t_6 = _t_4[1];
+        _t_7 = _t_6.__response;
+        _t_8 = _t_6.temperature;
+        _t_9 = _t_6.wind_speed;
+        _t_10 = _t_6.humidity;
+        _t_11 = _t_6.cloudiness;
+        _t_12 = _t_6.fog;
+        _t_13 = _t_6.status;
+        _t_14 = _t_6.icon;
+        _t_15 = {};
+        _t_15.location = _t_1;
+        _t_15.temperature = _t_8;
+        try {
+          await __env.output(String(_t_5), _t_15);
+        } catch(_exc_) {
+          __env.reportError("Failed to invoke action", _exc_);
+        }
+        _iter_tmp = await _t_3.next();
+      }
+    }
+  } catch(_exc_) {
+    __env.reportError("Failed to invoke query", _exc_);
+  }`]],
 ];
 
 // eslint-disable-next-line prefer-arrow-callback


### PR DESCRIPTION
Carry over the input parameters in the projected result object,
so they can be used in the result phrase.