### PR TITLE
typecheck: allow undefined mixin input parameters

### DIFF
--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -889,18 +889,20 @@ async function typeCheckClass(klass, schemas, classes, useMeta, isLibrary) {
 async function typeCheckMixin(import_stmt, mixin, schemas, classes, useMeta) {
     let presentParams = new Set();
     for (let in_param of import_stmt.in_params) {
-        if (!in_param.value.isConstant())
-            throw new TypeError(`Mixin parameter ${in_param.name} must be a constant`);
         let i = mixin.args.indexOf(in_param.name);
         if (i === -1 || !mixin.is_input[i])
             throw new TypeError(`Invalid parameter ${in_param.name} for mixin ${mixin.kind}`);
+        if (presentParams.has(in_param.name))
+            throw new TypeError(`Duplicate input parameter ${in_param.name}`);
+        presentParams.add(in_param.name);
+        if (in_param.value.isUndefined)
+            continue;
+        if (!in_param.value.isConstant())
+            throw new TypeError(`Mixin parameter ${in_param.name} must be a constant`);
         let inParamType = mixin.types[i];
         const valueType = await typeCheckValue(in_param.value, new Scope, schemas, classes, useMeta);
         if (!Type.isAssignable(valueType, inParamType, {}, true))
             throw new TypeError(`Invalid type for parameter ${in_param.name}, have ${valueType}, need ${inParamType}`);
-        if (presentParams.has(in_param.name))
-            throw new TypeError(`Duplicate input parameter ${in_param.name}`);
-        presentParams.add(in_param.name);
     }
     for (let i = 0; i < mixin.args.length; i ++ ) {
         if (mixin.required[i] && !presentParams.has(mixin.args[i]))


### PR DESCRIPTION
It's a way to hide secrets from public repositories compatible
with the test code in thingpedia-cli