### PR TITLE
Add NN-syntax to select a device ID

### DIFF
--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -339,12 +339,15 @@ selector = {
 
     selector attr:device_attribute => {
         const [sel,] = selector;
-        if (attr.name === 'id')
-            sel.id = attr.value.toJS();
-        else if (attr.name === 'all')
+        if (attr.name === 'id') {
+            sel.id = String(attr.value.toJS());
+            if (attr.value.display)
+                sel.attributes.push(new Ast.InputParam(null, 'name', new Ast.Value.String(attr.value.display)));
+        } else if (attr.name === 'all') {
             sel.all = attr.value.toJS();
-        else
+        } else {
             sel.attributes.push(attr);
+        }
         return selector;
     };
 }

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -553,22 +553,38 @@ module.exports = class ToNNConverter {
     }
 
     _invocationToNN(invocation) {
-        let fn = `@${invocation.selector.kind}.${invocation.channel}`;
-        if (invocation.selector.all) {
+        const selector = invocation.selector;
+        let fn = `@${selector.kind}.${invocation.channel}`;
+        if (selector.all) {
             if (this.typeAnnotations)
                 fn = List.concat(fn, 'attribute:all:Boolean', '=', 'true');
             else
                 fn = List.concat(fn, 'attribute:all', '=', 'true');
+        } else if (selector.id && selector.id !== selector.kind) {
+            // note: we omit the device ID if it is identical to the kind (which indicates there can only be
+            // one device of this type in the system)
+            // this reduces the amount of stuff we have to encode/predict for the common cases
+
+            const name = selector.attributes.find((attr) => attr.name === 'name');
+            const id = new Ast.Value.Entity(selector.id, 'tt:device_id', name ? name.value.toJS() : null);
+            if (this.typeAnnotations)
+                fn = List.concat(fn, 'attribute:id:Entity(tt:device_id)', '=', this.valueToNN(id, null));
+            else
+                fn = List.concat(fn, 'attribute:id', '=', this.valueToNN(id, null));
         }
-        invocation.selector.attributes.sort((p1, p2) => {
+
+        selector.attributes.sort((p1, p2) => {
             if (p1.name < p2.name)
                 return -1;
             if (p1.name > p2.name)
                 return 1;
             return 0;
         });
-        for (let attr of invocation.selector.attributes) {
+
+        for (let attr of selector.attributes) {
             if (attr.value.isUndefined && attr.value.local)
+                continue;
+            if (attr.name === 'name' && selector.id)
                 continue;
 
             // explicitly pass null to valueToNN because there should be no parameter passing in NN-syntax

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -603,6 +603,16 @@ now => @org.schema.restaurant() => notify;`],
     ['now => ( @com.uber.price_estimate ) filter param:low_estimate:Currency <= NUMBER_0 unit:$usd => notify',
      'is it less than $ NUMBER_0 ?', { NUMBER_0: 1000 },
      'now => (@com.uber.price_estimate()), low_estimate <= 1000$usd => notify;'],
+
+    ['now => @com.twitter.post attribute:id:Entity(tt:device_id) = GENERIC_ENTITY_tt:device_id_0 param:status:String = QUOTED_STRING_0',
+     'post QUOTED_STRING_0 on it', { 'GENERIC_ENTITY_tt:device_id_0': { value: 'twitter-account-foo', display: "Twitter Account foo" },
+                                     QUOTED_STRING_0: 'hello' },
+     `now => @com.twitter(id="twitter-account-foo", name="Twitter Account foo").post(status="hello");`],
+
+    ['now => @com.twitter.post attribute:id:Entity(tt:device_id) = GENERIC_ENTITY_tt:device_id_0 param:status:String = QUOTED_STRING_0',
+     'post QUOTED_STRING_0 on it', { 'GENERIC_ENTITY_tt:device_id_0': { value: 'twitter-account-foo' },
+                                     QUOTED_STRING_0: 'hello' },
+     `now => @com.twitter(id="twitter-account-foo").post(status="hello");`],
 ];
 
 function stripTypeAnnotations(program) {


### PR DESCRIPTION
This is necessary to carry over the selection of a device ID
across the state representation in the neural network, which
in turn is a prereq to support multiple devices of the same
type (most commonly for IoT)