### PR TITLE
Add DatePiece class

### DIFF
--- a/lib/ast/values.js
+++ b/lib/ast/values.js
@@ -121,6 +121,9 @@ class DatePiece {
     constructor(year, month, day, time) {
         assert(year > 0 || month > 0 || day > 0);
         assert(year === -1 || month === -1 || day === -1);
+        // Before processing the year, we need to save the original for the
+        // NNSyntax, as it might be copied from the utterance.
+        this.originalYear = year;
         this.year = year;
         if (year > 0 && year < 100) { // then assume 1950-2050
             if (year >= 50)
@@ -135,7 +138,7 @@ class DatePiece {
 
     equals(other) {
         return (other instanceof DatePiece
-                && this.year === other.year
+                && this.originalYear === other.originalYear
                 && this.month === other.month
                 && this.day === other.day
                 && this.time === other.time);

--- a/lib/ast/values.js
+++ b/lib/ast/values.js
@@ -118,17 +118,29 @@ DateEdge.prototype.isDateEdge = true;
 module.exports.DateEdge = DateEdge;
 
 class DatePiece {
-    constructor(piece, value) {
-        assert(piece === 'day' || piece === 'month' || piece === 'year');
-        this.piece = piece;
-        assert(Number.isInteger(value) && value > 0);
-        this.value = value;
+    constructor(year, month, day, hours, minutes) {
+        assert(year > 0 || month > 0 || day > 0 || hours >= 0 || minutes >= 0);
+        assert(year === -1 || month === -1 || day === -1 || hours === -1 || minutes === -1);
+        this.year = year;
+        if (year > 0 && year < 100) { // then assume 1950-2050
+            if (year >= 50)
+                this.year = 1900 + year;
+            else
+                this.year = 2000 + year;
+        }
+        this.month = month;
+        this.day = day;
+        this.hours = hours;
+        this.minutes = minutes;
     }
 
     equals(other) {
         return (other instanceof DatePiece
-                && this.piece === other.piece
-                && this.value === other.value);
+                && this.year === other.year
+                && this.month === other.month
+                && this.day === other.day
+                && this.hours === other.hours
+                && this.minutes === other.minutes);
     }
 }
 DatePiece.prototype.isDatePiece = true;

--- a/lib/ast/values.js
+++ b/lib/ast/values.js
@@ -118,9 +118,9 @@ DateEdge.prototype.isDateEdge = true;
 module.exports.DateEdge = DateEdge;
 
 class DatePiece {
-    constructor(year, month, day, hours, minutes) {
-        assert(year > 0 || month > 0 || day > 0 || hours >= 0 || minutes >= 0);
-        assert(year === -1 || month === -1 || day === -1 || hours === -1 || minutes === -1);
+    constructor(year, month, day, time) {
+        assert(year > 0 || month > 0 || day > 0);
+        assert(year === -1 || month === -1 || day === -1);
         this.year = year;
         if (year > 0 && year < 100) { // then assume 1950-2050
             if (year >= 50)
@@ -130,8 +130,7 @@ class DatePiece {
         }
         this.month = month;
         this.day = day;
-        this.hours = hours;
-        this.minutes = minutes;
+        this.time = time;
     }
 
     equals(other) {
@@ -139,8 +138,7 @@ class DatePiece {
                 && this.year === other.year
                 && this.month === other.month
                 && this.day === other.day
-                && this.hours === other.hours
-                && this.minutes === other.minutes);
+                && this.time === other.time);
     }
 }
 DatePiece.prototype.isDatePiece = true;

--- a/lib/ast/values.js
+++ b/lib/ast/values.js
@@ -120,7 +120,7 @@ module.exports.DateEdge = DateEdge;
 class DatePiece {
     constructor(year, month, day, time) {
         assert(year > 0 || month > 0 || day > 0);
-        assert(year === -1 || month === -1 || day === -1);
+        assert(year === null || month === null || day === null);
         // Before processing the year, we need to save the original for the
         // NNSyntax, as it might be copied from the utterance.
         this.originalYear = year;

--- a/lib/ast/values.js
+++ b/lib/ast/values.js
@@ -117,6 +117,23 @@ class DateEdge {
 DateEdge.prototype.isDateEdge = true;
 module.exports.DateEdge = DateEdge;
 
+class DatePiece {
+    constructor(piece, value) {
+        assert(piece === 'day' || piece === 'month' || piece === 'year');
+        this.piece = piece;
+        assert(Number.isInteger(value) && value > 0);
+        this.value = value;
+    }
+
+    equals(other) {
+        return (other instanceof DatePiece
+                && this.piece === other.piece
+                && this.value === other.value);
+    }
+}
+DatePiece.prototype.isDatePiece = true;
+module.exports.DatePiece = DatePiece;
+
 class Time {
 }
 module.exports.Time = Time;
@@ -854,7 +871,10 @@ Value.Location = LocationValue;
 class DateValue extends Value {
     constructor(value) {
         super(null);
-        assert(value === null || value instanceof Date || value instanceof DateEdge);
+        assert(value === null
+               || value instanceof Date
+               || value instanceof DateEdge
+               || value instanceof DatePiece);
         this.value = value;
     }
 

--- a/lib/ast/values.js
+++ b/lib/ast/values.js
@@ -121,9 +121,6 @@ class DatePiece {
     constructor(year, month, day, time) {
         assert(year > 0 || month > 0 || day > 0);
         assert(year === null || month === null || day === null);
-        // Before processing the year, we need to save the original for the
-        // NNSyntax, as it might be copied from the utterance.
-        this.originalYear = year;
         this.year = year;
         if (year > 0 && year < 100) { // then assume 1950-2050
             if (year >= 50)
@@ -138,7 +135,7 @@ class DatePiece {
 
     equals(other) {
         return (other instanceof DatePiece
-                && this.originalYear === other.originalYear
+                && this.year === other.year
                 && this.month === other.month
                 && this.day === other.day
                 && this.time === other.time);

--- a/lib/date_utils.js
+++ b/lib/date_utils.js
@@ -88,12 +88,32 @@ function createEdgeDate(edge, unit) {
     return date;
 }
 
+function createDatePiece(piece, value) {
+    const date = new Date;
+    date.setHours(0, 0, 0, 0);
+    switch(piece) {
+        case 'year':
+            date.setMonth(0, 1); // 1st of Jan
+            date.setYear(value);
+            break;
+        case 'month':
+            date.setMonth(value - 1, 1); // 1st of Jan, this year
+            break;
+        case 'day':
+            date.setDate(value); // this day in the month
+            break;
+    }
+    return date;
+}
+
 module.exports = {
     normalizeDate(value) {
         if (value === null)
             return new Date;
         else if (value instanceof Date)
             return value;
+        else if (typeof value.edge === 'undefined')
+            return createDatePiece(value.piece, value.value);
         else
             return createEdgeDate(value.edge, value.unit);
     },

--- a/lib/date_utils.js
+++ b/lib/date_utils.js
@@ -107,7 +107,7 @@ function createDatePiece(year, month, day, time) {
         date.setHours(0, 0, 0, 0);
     }
     if (time !== null)
-        date.setHours(time.hour, time.minute, 0, 0);
+        date.setHours(time.hour, time.minute, time.second);
     return date;
 }
 

--- a/lib/date_utils.js
+++ b/lib/date_utils.js
@@ -106,7 +106,7 @@ function createDatePiece(year, month, day, time) {
         date.setDate(day);
         date.setHours(0, 0, 0, 0);
     }
-    if (time !== -1)
+    if (time !== null)
         date.setHours(time.hour, time.minute, 0, 0);
     return date;
 }

--- a/lib/date_utils.js
+++ b/lib/date_utils.js
@@ -88,7 +88,7 @@ function createEdgeDate(edge, unit) {
     return date;
 }
 
-function createDatePiece(year, month, day, hours, minutes) {
+function createDatePiece(year, month, day, time) {
     // All non-supplied values to the left of the largest supplied
     // value are set to the present. All non-supplied values to the
     // right of the largest supplied value are set to the minimum.
@@ -106,10 +106,8 @@ function createDatePiece(year, month, day, hours, minutes) {
         date.setDate(day);
         date.setHours(0, 0, 0, 0);
     }
-    if (hours >= 0)
-        date.setHours(hours, 0, 0, 0);
-    if (minutes >= 0)
-        date.setHours(date.getHours(), minutes, 0, 0);
+    if (time !== -1)
+        date.setHours(time.hour, time.minute, 0, 0);
     return date;
 }
 
@@ -120,7 +118,7 @@ module.exports = {
         else if (value instanceof Date)
             return value;
         else if (typeof value.edge === 'undefined')
-            return createDatePiece(value.year, value.month, value.day, value.hours, value.minutes);
+            return createDatePiece(value.year, value.month, value.day, value.time);
         else
             return createEdgeDate(value.edge, value.unit);
     },

--- a/lib/date_utils.js
+++ b/lib/date_utils.js
@@ -88,21 +88,28 @@ function createEdgeDate(edge, unit) {
     return date;
 }
 
-function createDatePiece(piece, value) {
+function createDatePiece(year, month, day, hours, minutes) {
+    // All non-supplied values to the left of the largest supplied
+    // value are set to the present. All non-supplied values to the
+    // right of the largest supplied value are set to the minimum.
     const date = new Date;
-    date.setHours(0, 0, 0, 0);
-    switch(piece) {
-        case 'year':
-            date.setMonth(0, 1); // 1st of Jan
-            date.setYear(value);
-            break;
-        case 'month':
-            date.setMonth(value - 1, 1); // 1st of Jan, this year
-            break;
-        case 'day':
-            date.setDate(value); // this day in the month
-            break;
+    if (year > 0) {
+        date.setYear(year);
+        date.setMonth(0, 1); // 1st of Jan
+        date.setHours(0, 0, 0, 0);
     }
+    if (month > 0) {
+        date.setMonth(month - 1, 1);
+        date.setHours(0, 0, 0, 0);
+    }
+    if (day > 0) {
+        date.setDate(day);
+        date.setHours(0, 0, 0, 0);
+    }
+    if (hours >= 0)
+        date.setHours(hours, 0, 0, 0);
+    if (minutes >= 0)
+        date.setHours(date.getHours(), minutes, 0, 0);
     return date;
 }
 
@@ -113,7 +120,7 @@ module.exports = {
         else if (value instanceof Date)
             return value;
         else if (typeof value.edge === 'undefined')
-            return createDatePiece(value.piece, value.value);
+            return createDatePiece(value.year, value.month, value.day, value.hours, value.minutes);
         else
             return createEdgeDate(value.edge, value.unit);
     },

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -117,19 +117,20 @@ class Describer {
         if (date === null) {
             base = this._("now");
         } else if (date.isDatePiece) {
+            const monthNames = ["january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december" ];
             let year = this._(date.year === null ?
-                              "????" :
-                              date.year.toString().padStart(4, '0'));
+                              "this year" :
+                              date.year.toString());
             let month = this._(date.month === null ?
-                               "??" :
-                               date.month.toString().padStart(2, '0'));
+                               (date.day === null ? "january" : "this month") :
+                               monthNames[date.month - 1]);
             let day = this._(date.day === null ?
-                             "??" :
-                             date.day.toString().padStart(2, '0'));
+                             "1" :
+                             date.day.toString());
             let time = this._(date.time === null ?
-                              "??:??" :
+                              "start of day" :
                               this._describeTime(date.time));
-            base = this._interp(this._("${year}-${month}-${day} ${time}"),
+            base = this._interp(this._("${time} on day ${day} of ${month}, ${year}"),
                                 { year, month, day, time });
         } else if (date.isDateEdge) {
             let unit;

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -86,6 +86,24 @@ class Describer {
 
         if (date === null) {
             base = this._("now");
+        } else if (date.isDatePiece) {
+            let strValue = date.value.toString();
+            let year = this._("this year");
+            let month = this._("this month");
+            let day = this._("day 1");
+            switch (date.piece) {
+            case 'year':
+                year = this._interp(this._("in ${strValue}"), { strValue });
+                month = this._("month 1");
+                break;
+            case 'month':
+                month = this._interp(this._("month ${strValue}"), { strValue });
+                break;
+            case 'day':
+                day = this._interp(this._("day ${strValue}"), { strValue });
+                break;
+            }
+            base = this._interp(this._("${day} of ${month} in ${year}"), { day, month, year });
         } else if (date.isDateEdge) {
             let unit;
             switch (date.unit) {

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -117,16 +117,16 @@ class Describer {
         if (date === null) {
             base = this._("now");
         } else if (date.isDatePiece) {
-            let year = this._(date.year === -1 ?
+            let year = this._(date.year === null ?
                               "????" :
                               date.year.toString().padStart(4, '0'));
-            let month = this._(date.month === -1 ?
+            let month = this._(date.month === null ?
                                "??" :
                                date.month.toString().padStart(2, '0'));
-            let day = this._(date.day === -1 ?
+            let day = this._(date.day === null ?
                              "??" :
                              date.day.toString().padStart(2, '0'));
-            let time = this._(date.time === -1 ?
+            let time = this._(date.time === null ?
                               "??:??" :
                               this._describeTime(date.time));
             base = this._interp(this._("${year}-${month}-${day} ${time}"),

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -81,29 +81,56 @@ class Describer {
         }
     }
 
+    _describeTime(time) {
+        if (time.isAbsolute) {
+            const date = new Date;
+            date.setHours(time.hour);
+            date.setMinutes(time.minute);
+            date.setSeconds(time.second);
+            if (time.second !== 0) {
+                return this._format.timeToString(date, {
+                    hour: 'numeric',
+                    minute: '2-digit',
+                    second: '2-digit'
+                });
+            } else {
+                return this._format.timeToString(date, {
+                    hour: 'numeric',
+                    minute: '2-digit'
+                });
+            }
+        } else {
+            switch (time.relativeTag) {
+                case 'morning':
+                    return this._('the morning');
+                case 'evening':
+                    return this._('the evening');
+                default:
+                    return time.relativeTag;
+            }
+        }
+    }
+
     _describeDate(date, operator, offset) {
         let base;
 
         if (date === null) {
             base = this._("now");
         } else if (date.isDatePiece) {
-            let year = this._(date.year > 0 ?
-                              date.year.toString().padStart(4, '0') :
-                              "????");
-            let month = this._(date.month > 0 ?
-                               date.month.toString().padStart(2, '0') :
-                               "??");
-            let day = this._(date.day > 0 ?
-                             date.day.toString().padStart(2, '0') :
-                             "??");
-            let hours = this._(date.hours >= 0 ?
-                               date.hours.toString().padStart(2, '0') :
-                               "??");
-            let minutes = this._(date.minutes >= 0 ?
-                                date.minutes.toString().padStart(2, '0') :
-                                "??");
-            base = this._interp(this._("${year}-${month}-${day} ${hours}:${minutes}"),
-                                { year, month, day, hours, minutes });
+            let year = this._(date.year === -1 ?
+                              "????" :
+                              date.year.toString().padStart(4, '0'));
+            let month = this._(date.month === -1 ?
+                               "??" :
+                               date.month.toString().padStart(2, '0'));
+            let day = this._(date.day === -1 ?
+                             "??" :
+                             date.day.toString().padStart(2, '0'));
+            let time = this._(date.time === -1 ?
+                              "??:??" :
+                              this._describeTime(date.time));
+            base = this._interp(this._("${year}-${month}-${day} ${time}"),
+                                { year, month, day, time });
         } else if (date.isDateEdge) {
             let unit;
             switch (date.unit) {
@@ -144,36 +171,6 @@ class Describer {
         }
 
         return base;
-    }
-
-    _describeTime(time) {
-        if (time.isAbsolute) {
-            const date = new Date;
-            date.setHours(time.hour);
-            date.setMinutes(time.minute);
-            date.setSeconds(time.second);
-            if (time.second !== 0) {
-                return this._format.timeToString(date, {
-                    hour: 'numeric',
-                    minute: '2-digit',
-                    second: '2-digit'
-                });
-            } else {
-                return this._format.timeToString(date, {
-                    hour: 'numeric',
-                    minute: '2-digit'
-                });
-            }
-        } else {
-            switch (time.relativeTag) {
-                case 'morning':
-                    return this._('the morning');
-                case 'evening':
-                    return this._('the evening');
-                default:
-                    return time.relativeTag;
-            }
-        }
     }
 
     // public API that always returns a string

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -87,23 +87,23 @@ class Describer {
         if (date === null) {
             base = this._("now");
         } else if (date.isDatePiece) {
-            let strValue = date.value.toString();
-            let year = this._("this year");
-            let month = this._("this month");
-            let day = this._("day 1");
-            switch (date.piece) {
-            case 'year':
-                year = this._interp(this._("in ${strValue}"), { strValue });
-                month = this._("month 1");
-                break;
-            case 'month':
-                month = this._interp(this._("month ${strValue}"), { strValue });
-                break;
-            case 'day':
-                day = this._interp(this._("day ${strValue}"), { strValue });
-                break;
-            }
-            base = this._interp(this._("${day} of ${month} in ${year}"), { day, month, year });
+            let year = this._(date.year > 0 ?
+                              date.year.toString().padStart(4, '0') :
+                              "????");
+            let month = this._(date.month > 0 ?
+                               date.month.toString().padStart(2, '0') :
+                               "??");
+            let day = this._(date.day > 0 ?
+                             date.day.toString().padStart(2, '0') :
+                             "??");
+            let hours = this._(date.hours >= 0 ?
+                               date.hours.toString().padStart(2, '0') :
+                               "??");
+            let minutes = this._(date.minutes >= 0 ?
+                                date.minutes.toString().padStart(2, '0') :
+                                "??");
+            base = this._interp(this._("${year}-${month}-${day} ${hours}:${minutes}"),
+                                { year, month, day, hours, minutes });
         } else if (date.isDateEdge) {
             let unit;
             switch (date.unit) {

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -802,7 +802,7 @@ edge_date_value = edge:('start_of' / 'end_of') _ '(' _ unit:time_unit _ ')' {
         error(`${edge}(${unit}) is not allowed (not enough resolution)`);
     return new Ast.Value.Date(new Ast.DateEdge(edge, unit));
 }
-piece_date_value = 'datePiece' _ '(' _ year:literal_number _  ',' _ month:literal_number _ ',' _ day:literal_number _ ',' _ hours:literal_number _ ',' minutes:literal_number _ ')' {
+piece_date_value = ('makeDatePiece' / 'new' __ 'DatePiece') _ '(' _ year:literal_number _ ',' _ month:literal_number _ ',' _ day:literal_number _ ',' _ hours:literal_number _ ',' _ minutes:literal_number _ ')' {
     return new Ast.Value.Date(new Ast.DatePiece(year, month, day, hours, minutes));
 }
 now = ('makeDate' / 'new' __ 'Date') _ '(' _ ')' {

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -810,12 +810,11 @@ time_value = ('makeTime' / 'new' __ 'Time') _ '(' hour:literal_number _ ',' _ mi
 } / '$context' _ '.' _ 'time' _ '.' _ ctx:('morning' / 'evening') {
     return new Ast.Value.Time(new Ast.Time.Relative(ctx));
 }
-piece_date_value = ('makeDatePiece' / 'new' __ 'DatePiece') _ '(' _ year:(literal_number / 'null') _ ',' _ month:(literal_number / 'null') _ ',' _ day:(literal_number / 'null') _ ',' _ time:(time_value / 'null') _ ')' {
-    year = year === 'null' ? null : year;
-    month = month === 'null' ? null : month;
-    day = day === 'null' ? null : day;
-    time = time === 'null' ? null : time;
-    return new Ast.Value.Date(new Ast.DatePiece(year, month, day, time));
+piece_date_value = ('makeDatePiece' / 'new' __ 'DatePiece') _ '(' _ year:(literal_number _)? ',' _ month:(literal_number _)? ',' _ day:(literal_number _)? ',' _ time:(time_value _)? ')' {
+    return new Ast.Value.Date(new Ast.DatePiece(year !== null ? year[0] : null,
+                                                month !== null ? month[0] : null,
+                                                day !== null ? day[0] : null,
+                                                time !== null ? time[0] : null));
 }
 bool_value = v:literal_bool { return new Ast.Value.Boolean(v); }
 location_value = ('makeLocation' / 'new' __ 'Location') _ '(' _ lat:literal_number _ ',' _ lon:literal_number _ display:(',' _ literal_string _)?')' {

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -816,12 +816,6 @@ time_value = ('makeTime' / 'new' __ 'Time') _ '(' hour:literal_number _ ',' _ mi
 } / '$context' _ '.' _ 'time' _ '.' _ ctx:('morning' / 'evening') {
     return new Ast.Value.Time(new Ast.Time.Relative(ctx));
 }
-piece_date_value = ('makeDatePiece' / 'new' __ 'DatePiece') _ '(' _ year:(literal_number _)? ',' _ month:(literal_number _)? ',' _ day:(literal_number _)? ',' _ time:(time_value _)? ')' {
-    return new Ast.Value.Date(new Ast.DatePiece(year !== null ? year[0] : null,
-                                                month !== null ? month[0] : null,
-                                                day !== null ? day[0] : null,
-                                                time !== null ? time[0] : null));
-}
 bool_value = v:literal_bool { return new Ast.Value.Boolean(v); }
 location_value = ('makeLocation' / 'new' __ 'Location') _ '(' _ lat:literal_number _ ',' _ lon:literal_number _ display:(',' _ literal_string _)?')' {
     return new Ast.Value.Location(new Ast.Location.Absolute(lat, lon, display !== null ? display[2] : null));

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -667,7 +667,7 @@ primary_bool_expr = '(' _ or:or_expr _ ')' { return or; } /
 
 // Values (Primary Expressions)
 
-date_value = absolute_date_value / edge_date_value / now
+date_value = absolute_date_value / edge_date_value / piece_date_value / now
 
 add_expr = first:mul_expr _ rest:(('+' / '-') _ mul_expr _)* {
   return rest.reduce(((x, y) => new Ast.Value.Computation(y[0], [x, y[2]])), first);
@@ -797,10 +797,13 @@ time_unit = unit:ident {
     return unit;
 }
 
-edge_date_value = edge:('start_of' / 'end_of') _ '(' unit:time_unit _ ')' {
+edge_date_value = edge:('start_of' / 'end_of') _ '(' _ unit:time_unit _ ')' {
     if (unit === 'ms' || unit === 's')
         error(`${edge}(${unit}) is not allowed (not enough resolution)`);
     return new Ast.Value.Date(new Ast.DateEdge(edge, unit));
+}
+piece_date_value = piece:('day' / 'month' / 'year') _ '(' _ v:literal_number _ ')' {
+    return new Ast.Value.Date(new Ast.DatePiece(piece, v));
 }
 now = ('makeDate' / 'new' __ 'Date') _ '(' _ ')' {
     return new Ast.Value.Date(null);

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -802,8 +802,8 @@ edge_date_value = edge:('start_of' / 'end_of') _ '(' _ unit:time_unit _ ')' {
         error(`${edge}(${unit}) is not allowed (not enough resolution)`);
     return new Ast.Value.Date(new Ast.DateEdge(edge, unit));
 }
-piece_date_value = piece:('day' / 'month' / 'year') _ '(' _ v:literal_number _ ')' {
-    return new Ast.Value.Date(new Ast.DatePiece(piece, v));
+piece_date_value = 'datePiece' _ '(' _ year:literal_number _  ',' _ month:literal_number _ ',' _ day:literal_number _ ',' _ hours:literal_number _ ',' minutes:literal_number _ ')' {
+    return new Ast.Value.Date(new Ast.DatePiece(year, month, day, hours, minutes));
 }
 now = ('makeDate' / 'new' __ 'Date') _ '(' _ ')' {
     return new Ast.Value.Date(null);

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -667,7 +667,7 @@ primary_bool_expr = '(' _ or:or_expr _ ')' { return or; } /
 
 // Values (Primary Expressions)
 
-date_value = absolute_date_value / edge_date_value / piece_date_value / now
+date_value = absolute_date_value / edge_date_value / now
 
 add_expr = first:mul_expr _ rest:(('+' / '-') _ mul_expr _)* {
   return rest.reduce(((x, y) => new Ast.Value.Computation(y[0], [x, y[2]])), first);
@@ -759,7 +759,11 @@ currency_value = ('makeCurrency' / 'new' __ 'Currency') _ '(' _ num:literal_numb
 // certain keywords are also valid as unit names
 unit_ident = ident / 'in'
 
-long_date_value = ('makeDate' / 'new' __ 'Date') _ '(' _ year:literal_number _ ',' _ month:literal_number _ ',' _ day:literal_number _ ',' _ hours:literal_number _ ',' _ minutes:literal_number _ ',' _ seconds:literal_number _ ')' {
+long_date_value = ('makeDate' / 'new' __ 'Date') _ '(' _ year:literal_number? _ ',' _ month:literal_number? _ ',' _ day:literal_number? _ ',' _ hours:literal_number _ ',' _ minutes:literal_number _ ',' _ seconds:literal_number _ ')' {
+    if (year === null || month === null || day === null) {
+        let time = new Ast.Value.Time(new Ast.Time.Absolute(hours, minutes, seconds));
+        return new Ast.Value.Date(new Ast.DatePiece(year, month, day, time));
+    }
     var d = new Date;
     d.setFullYear(year);
     d.setMonth(month-1);
@@ -770,7 +774,9 @@ long_date_value = ('makeDate' / 'new' __ 'Date') _ '(' _ year:literal_number _ '
     d.setMilliseconds(0);
     return new Ast.Value.Date(d);
 }
-short_date_value = ('makeDate' / 'new' __ 'Date') _ '(' _ year:literal_number _ ',' _ month:literal_number _ ',' _ day:literal_number _ ')' {
+short_date_value = ('makeDate' / 'new' __ 'Date') _ '(' _ year:literal_number? _ ',' _ month:literal_number? _ ',' _ day:literal_number? _ ')' {
+    if (year === null || month === null || day === null)
+        return new Ast.Value.Date(new Ast.DatePiece(year, month, day, null));
     var d = new Date;
     d.setFullYear(year);
     d.setMonth(month-1);

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -802,9 +802,6 @@ edge_date_value = edge:('start_of' / 'end_of') _ '(' _ unit:time_unit _ ')' {
         error(`${edge}(${unit}) is not allowed (not enough resolution)`);
     return new Ast.Value.Date(new Ast.DateEdge(edge, unit));
 }
-piece_date_value = ('makeDatePiece' / 'new' __ 'DatePiece') _ '(' _ year:literal_number _ ',' _ month:literal_number _ ',' _ day:literal_number _ ',' _ hours:literal_number _ ',' _ minutes:literal_number _ ')' {
-    return new Ast.Value.Date(new Ast.DatePiece(year, month, day, hours, minutes));
-}
 now = ('makeDate' / 'new' __ 'Date') _ '(' _ ')' {
     return new Ast.Value.Date(null);
 }
@@ -812,6 +809,11 @@ time_value = ('makeTime' / 'new' __ 'Time') _ '(' hour:literal_number _ ',' _ mi
     return new Ast.Value.Time(new Ast.Time.Absolute(hour, minute, second !== null ? second[2] : 0));
 } / '$context' _ '.' _ 'time' _ '.' _ ctx:('morning' / 'evening') {
     return new Ast.Value.Time(new Ast.Time.Relative(ctx));
+}
+piece_date_value = ('makeDatePiece' / 'new' __ 'DatePiece') _ '(' _
+year:literal_number _ ',' _ month:literal_number _ ',' _ day:literal_number _
+',' _ time:(literal_number / time_value) _ ')' {
+    return new Ast.Value.Date(new Ast.DatePiece(year, month, day, time));
 }
 bool_value = v:literal_bool { return new Ast.Value.Boolean(v); }
 location_value = ('makeLocation' / 'new' __ 'Location') _ '(' _ lat:literal_number _ ',' _ lon:literal_number _ display:(',' _ literal_string _)?')' {

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -810,9 +810,11 @@ time_value = ('makeTime' / 'new' __ 'Time') _ '(' hour:literal_number _ ',' _ mi
 } / '$context' _ '.' _ 'time' _ '.' _ ctx:('morning' / 'evening') {
     return new Ast.Value.Time(new Ast.Time.Relative(ctx));
 }
-piece_date_value = ('makeDatePiece' / 'new' __ 'DatePiece') _ '(' _
-year:literal_number _ ',' _ month:literal_number _ ',' _ day:literal_number _
-',' _ time:(literal_number / time_value) _ ')' {
+piece_date_value = ('makeDatePiece' / 'new' __ 'DatePiece') _ '(' _ year:(literal_number / 'null') _ ',' _ month:(literal_number / 'null') _ ',' _ day:(literal_number / 'null') _ ',' _ time:(time_value / 'null') _ ')' {
+    year = year === 'null' ? null : year;
+    month = month === 'null' ? null : month;
+    day = day === 'null' ? null : day;
+    time = time === 'null' ? null : time;
     return new Ast.Value.Date(new Ast.DatePiece(year, month, day, time));
 }
 bool_value = v:literal_bool { return new Ast.Value.Boolean(v); }

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -673,6 +673,7 @@ literal_number = {
     num:LITERAL_INTEGER => num.value;
     '1' => 1;
     '0' => 0;
+    '-1' => -1;
 }
 
 constant_Measure = {
@@ -748,9 +749,9 @@ constant_Date = {
     'start_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('start_of', unit.value));
     'end_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('end_of', unit.value));
 
-    'datePiece' '(' year:literal_number ',' month:literal_number ','
-                    day:literal_number ',' hours:literal_number ','
-                    minutes:literal_number ')' => {
+    'new' 'DatePiece' '(' year:literal_number ',' month:literal_number ','
+                          day:literal_number ',' hours:literal_number ','
+                          minutes:literal_number ')' => {
         return new Ast.Value.Date(new Ast.DatePiece(year, month, day, hours, minutes));
     };
 

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -673,7 +673,6 @@ literal_number = {
     num:LITERAL_INTEGER => num.value;
     '1' => 1;
     '0' => 0;
-    '-1' => -1;
 }
 
 constant_Measure = {
@@ -719,7 +718,6 @@ constant_Time = {
     };
     'time:morning' => new Ast.Value.Time(new Ast.Time.Relative('morning'));
     'time:evening' => new Ast.Value.Time(new Ast.Time.Relative('evening'));
-    'time:-1' => new Ast.Value.Number(-1);
 }
 
 // start_of/end_of with less than 1h are not supported
@@ -764,6 +762,11 @@ constant_Date = {
 
     'new' 'DatePiece' '(' year:constant_Number ',' month:constant_Number ','
                           day:constant_Number ',' time:constant_Time ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, day.value, time.value));
+    };
+
+    'new' 'DatePiece' '(' year:constant_Number ',' month:constant_Number ','
+                          day:constant_Number ',' time:constant_Number ')' => {
         return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, day.value, time.value));
     };
 

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -725,32 +725,32 @@ constant_Time = {
 constant_Date = {
     'now' => new Ast.Value.Date(null);
     'new' 'Date' '(' ')' => new Ast.Value.Date(null);
-    'new' 'Date' '(' year:literal_number ',' month:literal_number ',' day:literal_number ')' => {
+    'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' day:constant_Number ')' => {
         const d = new Date;
-        d.setFullYear(year);
-        d.setMonth(month-1);
-        d.setDate(day);
+        d.setFullYear(year.value);
+        d.setMonth(month.value-1);
+        d.setDate(day.value);
         d.setHours(0);
         d.setMinutes(0);
         d.setSeconds(0);
         d.setMilliseconds(0);
         return new Ast.Value.Date(d);
     };
-    'new' 'Date' '(' year:literal_number ',' month:literal_number ',' day:literal_number ','
-                     hours:literal_number ',' minutes:literal_number ',' seconds:literal_number ')' => {
+    'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' day:constant_Number ','
+                     hours:constant_Number ',' minutes:constant_Number ',' seconds:constant_Number ')' => {
         const d = new Date;
-        d.setFullYear(year);
-        d.setMonth(month-1);
-        d.setDate(day);
-        d.setHours(hours);
-        d.setMinutes(minutes);
-        d.setSeconds(seconds);
+        d.setFullYear(year.value);
+        d.setMonth(month.value-1);
+        d.setDate(day.value);
+        d.setHours(hours.value);
+        d.setMinutes(minutes.value);
+        d.setSeconds(seconds.value);
         d.setMilliseconds(0);
         return new Ast.Value.Date(d);
     };
-    'new' 'Date' '(' unix:literal_number ')' => {
+    'new' 'Date' '(' unix:constant_Number ')' => {
         const d = new Date;
-        d.setTime(unix);
+        d.setTime(unix.value);
         return new Ast.Value.Date(d);
     };
     'new' 'Date' '(' '"' iso:word_list '"' ')' => {
@@ -760,35 +760,29 @@ constant_Date = {
     'start_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('start_of', unit.value));
     'end_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('end_of', unit.value));
 
-    'new' 'DatePiece' '(' year:constant_Number ',' ',' ',' ')' => {
+    abs:DATE => new Ast.Value.Date(parseDate(abs.value));
+
+    'new' 'Date' '(' year:constant_Number ',' ',' ',' ')' => {
         return new Ast.Value.Date(new Ast.DatePiece(year.value, null, null, null));
     };
-
-    'new' 'DatePiece' '(' ',' month:constant_Number ',' ',' ')' => {
+    'new' 'Date' '(' ',' month:constant_Number ',' ',' ')' => {
         return new Ast.Value.Date(new Ast.DatePiece(null, month.value, null, null));
     };
-
-    'new' 'DatePiece' '(' ',' ',' day:constant_Number ',' ')' => {
+    'new' 'Date' '(' ',' ',' day:constant_Number ',' ')' => {
         return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value, null));
     };
-
-    'new' 'DatePiece' '(' year:constant_Number ',' month:constant_Number ',' ',' ')' => {
+    'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' ',' ')' => {
         return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, null, null));
     };
-
-    'new' 'DatePiece' '(' ',' month:constant_Number ',' day:constant_Number ',' ')' => {
+    'new' 'Date' '(' ',' month:constant_Number ',' day:constant_Number ',' ')' => {
         return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value, null));
     };
-
-    'new' 'DatePiece' '(' ',' ',' day:constant_Number ',' time:constant_Time ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value, time.value));
+    'new' 'Date' '(' ',' ',' day:constant_Number ',' time:constant_Time ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value, time));
     };
-
-    'new' 'DatePiece' '(' ',' month:constant_Number ',' day:constant_Number ',' time:constant_Time ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value, time.value));
+    'new' 'Date' '(' ',' month:constant_Number ',' day:constant_Number ',' time:constant_Time ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value, time));
     };
-
-    abs:DATE => new Ast.Value.Date(parseDate(abs.value));
 }
 
 // luinet expands this into the various enums in the right

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -709,6 +709,19 @@ constant_Location = {
     };
 }
 
+// Note that while keeping digits in ranges [0-23],[0-59],[0-59] is not enforced
+// here, it is enforced in tonn_converter, rendering it unnecessary to do so here
+constant_Time = {
+    time:TIME => new Ast.Value.Time(new Ast.Time.Absolute(time.value.hour, time.value.minute, time.value.second||0));
+    time:LITERAL_TIME => {
+        let tokens = time.value.split(':');
+        return new Ast.Value.Time(new Ast.Time.Absolute(parseInt(tokens[0]), parseInt(tokens[1]), parseInt(tokens[2])));
+    };
+    'time:morning' => new Ast.Value.Time(new Ast.Time.Relative('morning'));
+    'time:evening' => new Ast.Value.Time(new Ast.Time.Relative('evening'));
+    'time:-1' => new Ast.Value.Number(-1);
+}
+
 // start_of/end_of with less than 1h are not supported
 // (they don't make sense)
 constant_Date = {
@@ -749,25 +762,12 @@ constant_Date = {
     'start_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('start_of', unit.value));
     'end_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('end_of', unit.value));
 
-    'new' 'DatePiece' '(' year:literal_number ',' month:literal_number ','
-                          day:literal_number ',' hours:literal_number ','
-                          minutes:literal_number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(year, month, day, hours, minutes));
+    'new' 'DatePiece' '(' year:constant_Number ',' month:constant_Number ','
+                          day:constant_Number ',' time:constant_Time ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, day.value, time.value));
     };
 
     abs:DATE => new Ast.Value.Date(parseDate(abs.value));
-}
-
-// Note that while keeping digits in ranges [0-23],[0-59],[0-59] is not enforced
-// here, it is enforced in tonn_converter, rendering it unnecessary to do so here
-constant_Time = {
-    time:TIME => new Ast.Value.Time(new Ast.Time.Absolute(time.value.hour, time.value.minute, time.value.second||0));
-    time:LITERAL_TIME => {
-        let tokens = time.value.split(':');
-        return new Ast.Value.Time(new Ast.Time.Absolute(parseInt(tokens[0]), parseInt(tokens[1]), parseInt(tokens[2])));
-    };
-    'time:morning' => new Ast.Value.Time(new Ast.Time.Relative('morning'));
-    'time:evening' => new Ast.Value.Time(new Ast.Time.Relative('evening'));
 }
 
 // luinet expands this into the various enums in the right

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -760,14 +760,32 @@ constant_Date = {
     'start_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('start_of', unit.value));
     'end_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('end_of', unit.value));
 
-    'new' 'DatePiece' '(' year:constant_Number ',' month:constant_Number ','
-                          day:constant_Number ',' time:constant_Time ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, day.value, time.value));
+    'new' 'DatePiece' '(' year:constant_Number ',' ',' ',' ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(year.value, null, null, null));
     };
 
-    'new' 'DatePiece' '(' year:constant_Number ',' month:constant_Number ','
-                          day:constant_Number ',' time:constant_Number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, day.value, time.value));
+    'new' 'DatePiece' '(' ',' month:constant_Number ',' ',' ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, null, null));
+    };
+
+    'new' 'DatePiece' '(' ',' ',' day:constant_Number ',' ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value, null));
+    };
+
+    'new' 'DatePiece' '(' year:constant_Number ',' month:constant_Number ',' ',' ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, null, null));
+    };
+
+    'new' 'DatePiece' '(' ',' month:constant_Number ',' day:constant_Number ',' ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value, null));
+    };
+
+    'new' 'DatePiece' '(' ',' ',' day:constant_Number ',' time:constant_Time ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value, time.value));
+    };
+
+    'new' 'DatePiece' '(' ',' month:constant_Number ',' day:constant_Number ',' time:constant_Time ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value, time.value));
     };
 
     abs:DATE => new Ast.Value.Date(parseDate(abs.value));

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -747,9 +747,13 @@ constant_Date = {
 
     'start_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('start_of', unit.value));
     'end_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('end_of', unit.value));
-    'day' value:VALUE => new Ast.Value.Date(new Ast.DatePiece('day', value.value));
-    'month' value:VALUE => new Ast.Value.Date(new Ast.DatePiece('month', value.value));
-    'year' value:VALUE => new Ast.Value.Date(new Ast.DatePiece('year', value.value));
+
+    'datePiece' '(' year:literal_number ',' month:literal_number ','
+                    day:literal_number ',' hours:literal_number ','
+                    minutes:literal_number ')' => {
+        return new Ast.Value.Date(new Ast.DatePiece(year, month, day, hours, minutes));
+    };
+
     abs:DATE => new Ast.Value.Date(parseDate(abs.value));
 }
 

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -747,6 +747,9 @@ constant_Date = {
 
     'start_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('start_of', unit.value));
     'end_of' unit:UNIT => new Ast.Value.Date(new Ast.DateEdge('end_of', unit.value));
+    'day' value:VALUE => new Ast.Value.Date(new Ast.DatePiece('day', value.value));
+    'month' value:VALUE => new Ast.Value.Date(new Ast.DatePiece('month', value.value));
+    'year' value:VALUE => new Ast.Value.Date(new Ast.DatePiece('year', value.value));
     abs:DATE => new Ast.Value.Date(parseDate(abs.value));
 }
 

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -286,6 +286,8 @@ module.exports = class ToNNConverter {
                 return 'now';
             else if (value.value instanceof Ast.DateEdge)
                 return List.concat(value.value.edge, 'unit:' + value.value.unit);
+            else if (value.value instanceof Ast.DatePiece)
+                return List.concat(value.value.piece, 'value:' + value.value.value);
             else
                 return this.findEntity('DATE', value);
         } else if (value.isTime) {

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -287,31 +287,28 @@ module.exports = class ToNNConverter {
             } else if (value.value instanceof Ast.DateEdge) {
                 return List.concat(value.value.edge, 'unit:' + value.value.unit);
             } else if (value.value instanceof Ast.DatePiece) {
-                let year;
-                if (value.value.originalYear === -1)
-                    year = List.concat('-', '1');
-                else if (isSmallInteger(value.value.originalYear))
-                    year = String(value.value.originalYear);
-                else
-                    year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.originalYear));
-                let month;
-                if (value.value.month === -1)
-                    month = List.concat('-', '1');
-                else
-                    month = String(value.value.month);
-                let day;
-                if (value.value.day === -1)
-                    day = List.concat('-', '1');
-                else if (isSmallInteger(value.value.day))
-                    day = String(value.value.day);
-                else
-                    day = this.findEntity('NUMBER', new Ast.Value.Number(value.value.day));
-                let time;
-                if (value.value.time === -1)
-                    time = List.concat('-', '1');
-                else
-                    time = this.findEntity('TIME', new Ast.Value.Time(value.value.time));
-                return List.concat('new', 'DatePiece', '(', year, ',', month, ',', day, ',', time, ')');
+                let toConcat = ['new', 'DatePiece', '('];
+                if (value.value.originalYear !== null) {
+                    if (isSmallInteger(value.value.originalYear))
+                        toConcat.push(String(value.value.originalYear));
+                    else
+                        toConcat.push(this.findEntity('NUMBER', new Ast.Value.Number(value.value.originalYear)));
+                }
+                toConcat.push(',');
+                if (value.value.month !== null)
+                    toConcat.push(String(value.value.month));
+                toConcat.push(',');
+                if (value.value.day !== null) {
+                    if (isSmallInteger(value.value.day))
+                        toConcat.push(String(value.value.day));
+                    else
+                        toConcat.push(this.findEntity('NUMBER', new Ast.Value.Number(value.value.day)));
+                }
+                toConcat.push(',');
+                if (value.value.time !== null)
+                    toConcat.push(this.findEntity('TIME', new Ast.Value.Time(value.value.time)));
+                toConcat.push(')');
+                return List.concat(...toConcat);
             }
             else {
                 return this.findEntity('DATE', value);

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -287,7 +287,7 @@ module.exports = class ToNNConverter {
             else if (value.value instanceof Ast.DateEdge)
                 return List.concat(value.value.edge, 'unit:' + value.value.unit);
             else if (value.value instanceof Ast.DatePiece)
-                return List.concat('datePiece', '(', value.value.year, ',', value.value.month, ',', value.value.day, ',', value.value.hours, ',', value.value.minutes, ')');
+                return List.concat('new', 'DatePiece', '(', String(value.value.year), ',', String(value.value.month), ',', String(value.value.day), ',', String(value.value.hours), ',', String(value.value.minutes), ')');
             else
                 return this.findEntity('DATE', value);
         } else if (value.isTime) {

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -309,9 +309,8 @@ module.exports = class ToNNConverter {
                 let time;
                 if (value.value.time === -1)
                     time = List.concat('-', '1');
-                else {
+                else
                     time = this.findEntity('TIME', new Ast.Value.Time(value.value.time));
-                }
                 return List.concat('new', 'DatePiece', '(', year, ',', month, ',', day, ',', time, ')');
             }
             else {

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -287,28 +287,37 @@ module.exports = class ToNNConverter {
             } else if (value.value instanceof Ast.DateEdge) {
                 return List.concat(value.value.edge, 'unit:' + value.value.unit);
             } else if (value.value instanceof Ast.DatePiece) {
-                let toConcat = ['new', 'DatePiece', '('];
-                if (value.value.originalYear !== null) {
-                    if (isSmallInteger(value.value.originalYear))
-                        toConcat.push(String(value.value.originalYear));
-                    else
-                        toConcat.push(this.findEntity('NUMBER', new Ast.Value.Number(value.value.originalYear)));
+                let toReturn = List.concat('new', 'Date', '(');
+                if (value.value.year !== null) {
+                    let year;
+                    if (value.value.year < 1950)
+                        year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year));
+                    else {
+                        year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year), { ignoreNotFound: true });
+                        if (year === null) { // look for the last two digits only
+                            if (isSmallInteger(value.value.year % 100))
+                                year = String(value.value.year % 100);
+                            else
+                                year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year % 100))
+                        }
+                    }
+                    toReturn = List.concat(toReturn, year);
                 }
-                toConcat.push(',');
+                toReturn = List.concat(toReturn, ',');
                 if (value.value.month !== null)
-                    toConcat.push(String(value.value.month));
-                toConcat.push(',');
+                    toReturn = List.concat(toReturn, String(value.value.month));
+                toReturn = List.concat(toReturn, ',');
                 if (value.value.day !== null) {
                     if (isSmallInteger(value.value.day))
-                        toConcat.push(String(value.value.day));
+                        toReturn = List.concat(toReturn, String(value.value.day));
                     else
-                        toConcat.push(this.findEntity('NUMBER', new Ast.Value.Number(value.value.day)));
+                        toReturn = List.concat(toReturn, this.findEntity('NUMBER', new Ast.Value.Number(value.value.day)));
                 }
-                toConcat.push(',');
+                toReturn = List.concat(toReturn, ',');
                 if (value.value.time !== null)
-                    toConcat.push(this.findEntity('TIME', new Ast.Value.Time(value.value.time)));
-                toConcat.push(')');
-                return List.concat(...toConcat);
+                    toReturn = List.concat(toReturn, this.findEntity('TIME', new Ast.Value.Time(value.value.time.value)));
+                toReturn = List.concat(toReturn, ')');
+                return toReturn;
             }
             else {
                 return this.findEntity('DATE', value);

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -288,12 +288,12 @@ module.exports = class ToNNConverter {
                 return List.concat(value.value.edge, 'unit:' + value.value.unit);
             } else if (value.value instanceof Ast.DatePiece) {
                 let year;
-                if (value.value.year === -1)
+                if (value.value.originalYear === -1)
                     year = List.concat('-', '1');
-                else if (isSmallInteger(value.value.year))
-                    year = String(value.value.year);
+                else if (isSmallInteger(value.value.originalYear))
+                    year = String(value.value.originalYear);
                 else
-                    year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year));
+                    year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.originalYear));
                 let month;
                 if (value.value.month === -1)
                     month = List.concat('-', '1');
@@ -309,8 +309,9 @@ module.exports = class ToNNConverter {
                 let time;
                 if (value.value.time === -1)
                     time = List.concat('-', '1');
-                else
-                    time = this.valueToNN(value.value.time, scope);
+                else {
+                    time = this.findEntity('TIME', new Ast.Value.Time(value.value.time));
+                }
                 return List.concat('new', 'DatePiece', '(', year, ',', month, ',', day, ',', time, ')');
             }
             else {

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -287,7 +287,7 @@ module.exports = class ToNNConverter {
             else if (value.value instanceof Ast.DateEdge)
                 return List.concat(value.value.edge, 'unit:' + value.value.unit);
             else if (value.value instanceof Ast.DatePiece)
-                return List.concat(value.value.piece, 'value:' + value.value.value);
+                return List.concat('datePiece', '(', value.value.year, ',', value.value.month, ',', value.value.day, ',', value.value.hours, ',', value.value.minutes, ')');
             else
                 return this.findEntity('DATE', value);
         } else if (value.isTime) {

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -290,7 +290,7 @@ module.exports = class ToNNConverter {
                 let toReturn = List.concat('new', 'Date', '(');
                 if (value.value.year !== null) {
                     let year;
-                    if (value.value.year < 1950) {
+                    if (value.value.year < 1950 || value.value.year >= 2050) {
                         year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year));
                     }
                     else {

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -286,8 +286,16 @@ module.exports = class ToNNConverter {
                 return 'now';
             else if (value.value instanceof Ast.DateEdge)
                 return List.concat(value.value.edge, 'unit:' + value.value.unit);
-            else if (value.value instanceof Ast.DatePiece)
-                return List.concat('new', 'DatePiece', '(', String(value.value.year), ',', String(value.value.month), ',', String(value.value.day), ',', String(value.value.hours), ',', String(value.value.minutes), ')');
+            else if (value.value instanceof Ast.DatePiece) {
+                let year = (value.value.year === -1 || isSmallInteger(value.value.year)) ?
+                           String(value.value.year) : this.findEntity('NUMBER', new Ast.Value.Number(value.value.year));
+                let month = String(value.value.month);
+                let day = (value.value.day === -1 || isSmallInteger(value.value.day)) ?
+                          String(value.value.day) : this.findEntity('NUMBER', new Ast.Value.Number(value.value.day));
+                let time = value.value.time === -1 ?
+                           'time:-1' : this.valueToNN(value.value.time, scope);
+                return List.concat('new', 'DatePiece', '(', year, ',', month, ',', day, ',', time, ')');
+            }
             else
                 return this.findEntity('DATE', value);
         } else if (value.isTime) {

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -290,15 +290,16 @@ module.exports = class ToNNConverter {
                 let toReturn = List.concat('new', 'Date', '(');
                 if (value.value.year !== null) {
                     let year;
-                    if (value.value.year < 1950)
+                    if (value.value.year < 1950) {
                         year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year));
+                    }
                     else {
                         year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year), { ignoreNotFound: true });
                         if (year === null) { // look for the last two digits only
                             if (isSmallInteger(value.value.year % 100))
                                 year = String(value.value.year % 100);
                             else
-                                year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year % 100))
+                                year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year % 100));
                         }
                     }
                     toReturn = List.concat(toReturn, year);

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -282,22 +282,40 @@ module.exports = class ToNNConverter {
             else
                 return this.findEntity('LOCATION', value);
         } else if (value.isDate) {
-            if (value.value === null)
+            if (value.value === null) {
                 return 'now';
-            else if (value.value instanceof Ast.DateEdge)
+            } else if (value.value instanceof Ast.DateEdge) {
                 return List.concat(value.value.edge, 'unit:' + value.value.unit);
-            else if (value.value instanceof Ast.DatePiece) {
-                let year = (value.value.year === -1 || isSmallInteger(value.value.year)) ?
-                           String(value.value.year) : this.findEntity('NUMBER', new Ast.Value.Number(value.value.year));
-                let month = String(value.value.month);
-                let day = (value.value.day === -1 || isSmallInteger(value.value.day)) ?
-                          String(value.value.day) : this.findEntity('NUMBER', new Ast.Value.Number(value.value.day));
-                let time = value.value.time === -1 ?
-                           'time:-1' : this.valueToNN(value.value.time, scope);
+            } else if (value.value instanceof Ast.DatePiece) {
+                let year;
+                if (value.value.year === -1)
+                    year = List.concat('-', '1');
+                else if (isSmallInteger(value.value.year))
+                    year = String(value.value.year);
+                else
+                    year = this.findEntity('NUMBER', new Ast.Value.Number(value.value.year));
+                let month;
+                if (value.value.month === -1)
+                    month = List.concat('-', '1');
+                else
+                    month = String(value.value.month);
+                let day;
+                if (value.value.day === -1)
+                    day = List.concat('-', '1');
+                else if (isSmallInteger(value.value.day))
+                    day = String(value.value.day);
+                else
+                    day = this.findEntity('NUMBER', new Ast.Value.Number(value.value.day));
+                let time;
+                if (value.value.time === -1)
+                    time = List.concat('-', '1');
+                else
+                    time = this.valueToNN(value.value.time, scope);
                 return List.concat('new', 'DatePiece', '(', year, ',', month, ',', day, ',', time, ')');
             }
-            else
+            else {
                 return this.findEntity('DATE', value);
+            }
         } else if (value.isTime) {
             if (value.value.isRelative) {
                 return 'time:' + value.value.relativeTag;

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -54,7 +54,7 @@ function prettyprintDate(value) {
     else if (value.isDateEdge)
         return `${value.edge}(${value.unit})`;
     else if (value.isDatePiece)
-        return `datePiece(${value.year}, ${value.month}, ${value.day}, ${value.hours}, ${value.minutes})`;
+        return `new DatePiece(${value.year}, ${value.month}, ${value.day}, ${value.hours}, ${value.minutes})`;
     else
         return `new Date(${stringEscape(value.toISOString())})`;
 }

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -48,22 +48,26 @@ function prettyprintLocation(ast) {
         return '$context.location.' + ast.relativeTag;
 }
 
-function prettyprintDate(value) {
-    if (value === null)
-        return 'new Date()';
-    else if (value.isDateEdge)
-        return `${value.edge}(${value.unit})`;
-    else if (value.isDatePiece)
-        return `new DatePiece(${value.year}, ${value.month}, ${value.day}, ${value.hours}, ${value.minutes})`;
-    else
-        return `new Date(${stringEscape(value.toISOString())})`;
-}
-
 function prettyprintTime(ast) {
     if (ast.isAbsolute)
         return `new Time(${ast.hour}, ${ast.minute})`;
     else
         return '$context.time.' + ast.relativeTag;
+}
+
+function prettyprintDate(value) {
+    if (value === null)
+        return 'new Date()';
+    else if (value.isDateEdge)
+        return `${value.edge}(${value.unit})`;
+    else if (value.isDatePiece) {
+        if (value.time === -1)
+            return `new DatePiece(${value.year}, ${value.month}, ${value.day}, ${value.time})`;
+        else
+            return `new DatePiece(${value.year}, ${value.month}, ${value.day}, ${prettyprintTime(value.time)})`;
+    }
+    else
+        return `new Date(${stringEscape(value.toISOString())})`;
 }
 
 const INFIX_OPERATORS = new Set(['+', '-', '/', '*', '%', '**']);

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -62,9 +62,9 @@ function prettyprintDate(value) {
         return `${value.edge}(${value.unit})`;
     } else if (value.isDatePiece) {
         if (value.time === -1)
-            return `new DatePiece(${value.year}, ${value.month}, ${value.day}, ${value.time})`;
+            return `new DatePiece(${value.originalYear}, ${value.month}, ${value.day}, ${value.time})`;
         else
-            return `new DatePiece(${value.year}, ${value.month}, ${value.day}, ${prettyprintTime(value.time)})`;
+            return `new DatePiece(${value.originalYear}, ${value.month}, ${value.day}, ${prettyprintTime(value.time)})`;
     } else {
         return `new Date(${stringEscape(value.toISOString())})`;
     }

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -62,9 +62,9 @@ function prettyprintDate(value) {
         return `${value.edge}(${value.unit})`;
     } else if (value.isDatePiece) {
         if (value.time === null)
-            return `new DatePiece(${value.originalYear}, ${value.month}, ${value.day}, ${value.time})`;
+            return `new DatePiece(${value.originalYear || ''}, ${value.month || ''}, ${value.day || ''}, ${value.time || ''})`;
         else
-            return `new DatePiece(${value.originalYear}, ${value.month}, ${value.day}, ${prettyprintTime(value.time)})`;
+            return `new DatePiece(${value.originalYear || ''}, ${value.month || ''}, ${value.day || ''}, ${prettyprintTime(value.time)})`;
     } else {
         return `new Date(${stringEscape(value.toISOString())})`;
     }

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -53,6 +53,8 @@ function prettyprintDate(value) {
         return 'new Date()';
     else if (value.isDateEdge)
         return `${value.edge}(${value.unit})`;
+    else if (value.isDatePiece)
+        return `${value.piece}(${value.value})`;
     else
         return `new Date(${stringEscape(value.toISOString())})`;
 }

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -61,7 +61,7 @@ function prettyprintDate(value) {
     } else if (value.isDateEdge) {
         return `${value.edge}(${value.unit})`;
     } else if (value.isDatePiece) {
-        if (value.time === -1)
+        if (value.time === null)
             return `new DatePiece(${value.originalYear}, ${value.month}, ${value.day}, ${value.time})`;
         else
             return `new DatePiece(${value.originalYear}, ${value.month}, ${value.day}, ${prettyprintTime(value.time)})`;

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -54,7 +54,7 @@ function prettyprintDate(value) {
     else if (value.isDateEdge)
         return `${value.edge}(${value.unit})`;
     else if (value.isDatePiece)
-        return `${value.piece}(${value.value})`;
+        return `datePiece(${value.year}, ${value.month}, ${value.day}, ${value.hours}, ${value.minutes})`;
     else
         return `new Date(${stringEscape(value.toISOString())})`;
 }

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -62,9 +62,9 @@ function prettyprintDate(value) {
         return `${value.edge}(${value.unit})`;
     } else if (value.isDatePiece) {
         if (value.time === null)
-            return `new DatePiece(${value.originalYear || ''}, ${value.month || ''}, ${value.day || ''}, ${value.time || ''})`;
+            return `new Date(${value.year || ''}, ${value.month || ''}, ${value.day || ''})`;
         else
-            return `new DatePiece(${value.originalYear || ''}, ${value.month || ''}, ${value.day || ''}, ${prettyprintTime(value.time)})`;
+            return `new Date(${value.year || ''}, ${value.month || ''}, ${value.day || ''}, ${value.time.value.hour}, ${value.time.value.minute}, ${value.time.value.second})`;
     } else {
         return `new Date(${stringEscape(value.toISOString())})`;
     }

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -56,18 +56,18 @@ function prettyprintTime(ast) {
 }
 
 function prettyprintDate(value) {
-    if (value === null)
+    if (value === null) {
         return 'new Date()';
-    else if (value.isDateEdge)
+    } else if (value.isDateEdge) {
         return `${value.edge}(${value.unit})`;
-    else if (value.isDatePiece) {
+    } else if (value.isDatePiece) {
         if (value.time === -1)
             return `new DatePiece(${value.year}, ${value.month}, ${value.day}, ${value.time})`;
         else
             return `new DatePiece(${value.year}, ${value.month}, ${value.day}, ${prettyprintTime(value.time)})`;
-    }
-    else
+    } else {
         return `new Date(${stringEscape(value.toISOString())})`;
+    }
 }
 
 const INFIX_OPERATORS = new Set(['+', '-', '/', '*', '%', '**']);

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1954,5 +1954,5 @@ class @com.example {
 
 // date piece
 {
-    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(null, 6, null, null) => notify;
+    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(, 6, , ) => notify;
 }

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1949,3 +1949,10 @@ class @com.example {
               out subject : String,
               out sender : Entity(tt:email_address));
 }
+
+====
+
+// date piece
+{
+    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= datePiece(-1, 6, -1, -1, -1) => notify;
+}

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1954,5 +1954,5 @@ class @com.example {
 
 // date piece
 {
-    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(-1, 6, -1, -1) => notify;
+    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(null, 6, null, null) => notify;
 }

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1954,5 +1954,5 @@ class @com.example {
 
 // date piece
 {
-    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(, 6, , ) => notify;
+    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new Date(, 6, ) => notify;
 }

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1954,5 +1954,5 @@ class @com.example {
 
 // date piece
 {
-    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= datePiece(-1, 6, -1, -1, -1) => notify;
+    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(-1, 6, -1, -1, -1) => notify;
 }

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -1954,5 +1954,5 @@ class @com.example {
 
 // date piece
 {
-    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(-1, 6, -1, -1, -1) => notify;
+    now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(-1, 6, -1, -1) => notify;
 }

--- a/test/test_ast.js
+++ b/test/test_ast.js
@@ -70,7 +70,7 @@ const IS_CONSTANT_TESTS = [
     [new Ast.Value.Event('program_id'), false],
     [new Ast.Value.Date(new Date('2020-01-29')), true],
     [new Ast.Value.Date(new Ast.DateEdge('start_of', 'week')), true],
-    [new Ast.Value.Date(new Ast.DatePiece('day', 11)), true],
+    [new Ast.Value.Date(new Ast.DatePiece(-1, -1, 11, -1, -1)), true],
     [new Ast.Value.Date(null), true],
     [new Ast.Value.VarRef('foo'), false],
     [new Ast.Value.VarRef('__const_QUOTED_STRING_0'), true],

--- a/test/test_ast.js
+++ b/test/test_ast.js
@@ -70,6 +70,7 @@ const IS_CONSTANT_TESTS = [
     [new Ast.Value.Event('program_id'), false],
     [new Ast.Value.Date(new Date('2020-01-29')), true],
     [new Ast.Value.Date(new Ast.DateEdge('start_of', 'week')), true],
+    [new Ast.Value.Date(new Ast.DatePiece('day', 11)), true],
     [new Ast.Value.Date(null), true],
     [new Ast.Value.VarRef('foo'), false],
     [new Ast.Value.VarRef('__const_QUOTED_STRING_0'), true],

--- a/test/test_ast.js
+++ b/test/test_ast.js
@@ -70,7 +70,7 @@ const IS_CONSTANT_TESTS = [
     [new Ast.Value.Event('program_id'), false],
     [new Ast.Value.Date(new Date('2020-01-29')), true],
     [new Ast.Value.Date(new Ast.DateEdge('start_of', 'week')), true],
-    [new Ast.Value.Date(new Ast.DatePiece(-1, -1, 11, -1, -1)), true],
+    [new Ast.Value.Date(new Ast.DatePiece(-1, -1, 11, -1)), true],
     [new Ast.Value.Date(null), true],
     [new Ast.Value.VarRef('foo'), false],
     [new Ast.Value.VarRef('__const_QUOTED_STRING_0'), true],

--- a/test/test_ast.js
+++ b/test/test_ast.js
@@ -70,7 +70,7 @@ const IS_CONSTANT_TESTS = [
     [new Ast.Value.Event('program_id'), false],
     [new Ast.Value.Date(new Date('2020-01-29')), true],
     [new Ast.Value.Date(new Ast.DateEdge('start_of', 'week')), true],
-    [new Ast.Value.Date(new Ast.DatePiece(-1, -1, 11, -1)), true],
+    [new Ast.Value.Date(new Ast.DatePiece(null, null, 11, null)), true],
     [new Ast.Value.Date(null), true],
     [new Ast.Value.VarRef('foo'), false],
     [new Ast.Value.VarRef('__const_QUOTED_STRING_0'), true],

--- a/test/test_date_utils.js
+++ b/test/test_date_utils.js
@@ -72,7 +72,7 @@ function main() {
     the_11th.setMinutes(0);
     the_11th.setSeconds(0);
     the_11th.setMilliseconds(0);
-    test(new DatePiece(-1, -1, 11, -1), the_11th);
+    test(new DatePiece(null, null, 11, null), the_11th);
 
     const february = new Date;
     february.setDate(1);
@@ -81,7 +81,7 @@ function main() {
     february.setSeconds(0);
     february.setMilliseconds(0);
     february.setMonth(1);
-    test(new DatePiece(-1, 2, -1, -1), february);
+    test(new DatePiece(null, 2, null, null), february);
 
     const the_80s = new Date;
     the_80s.setMonth(0);
@@ -91,7 +91,7 @@ function main() {
     the_80s.setSeconds(0);
     the_80s.setMilliseconds(0);
     the_80s.setYear(1980);
-    test(new DatePiece(80, -1, -1, -1), the_80s);
+    test(new DatePiece(80, null, null, null), the_80s);
 
     const the_10s = new Date;
     the_10s.setMonth(0);
@@ -101,9 +101,9 @@ function main() {
     the_10s.setSeconds(0);
     the_10s.setMilliseconds(0);
     the_10s.setYear(2010);
-    test(new DatePiece(10, -1, -1, -1), the_10s);
+    test(new DatePiece(10, null, null, null), the_10s);
 
-    assert(!(new DatePiece(10, -1, -1, -1)).equals(new DatePiece(80, -1, -1, -1)));
+    assert(!(new DatePiece(10, null, null, null)).equals(new DatePiece(80, null, null, null)));
 
     const eleven_thirty = new Date;
     eleven_thirty.setDate(25);
@@ -111,7 +111,7 @@ function main() {
     eleven_thirty.setMinutes(30);
     eleven_thirty.setSeconds(0);
     eleven_thirty.setMilliseconds(0);
-    test(new DatePiece(-1, -1, 25, new Time.Absolute(11, 30, 0)), eleven_thirty);
+    test(new DatePiece(null, null, 25, new Time.Absolute(11, 30, 0)), eleven_thirty);
 }
 module.exports = main;
 if (!module.parent)

--- a/test/test_date_utils.js
+++ b/test/test_date_utils.js
@@ -103,7 +103,14 @@ function main() {
     the_10s.setYear(2010);
     test(new DatePiece(10, -1, -1, -1, -1), the_10s);
 
-    assert(the_80s !== the_10s);
+    assert(!(new DatePiece(10, -1, -1, -1, -1)).equals(new DatePiece(80, -1, -1, -1, -1)));
+
+    const eleven_thirty = new Date;
+    eleven_thirty.setHours(11);
+    eleven_thirty.setMinutes(30);
+    eleven_thirty.setSeconds(0);
+    eleven_thirty.setMilliseconds(0);
+    test(new DatePiece(-1, -1, -1, 11, 30), eleven_thirty);
 }
 module.exports = main;
 if (!module.parent)

--- a/test/test_date_utils.js
+++ b/test/test_date_utils.js
@@ -92,6 +92,18 @@ function main() {
     the_80s.setMilliseconds(0);
     the_80s.setYear(1980);
     test(new DatePiece(80, -1, -1, -1, -1), the_80s);
+
+    const the_10s = new Date;
+    the_10s.setMonth(0);
+    the_10s.setDate(1);
+    the_10s.setHours(0);
+    the_10s.setMinutes(0);
+    the_10s.setSeconds(0);
+    the_10s.setMilliseconds(0);
+    the_10s.setYear(2010);
+    test(new DatePiece(10, -1, -1, -1, -1), the_10s);
+
+    assert(the_80s !== the_10s);
 }
 module.exports = main;
 if (!module.parent)

--- a/test/test_date_utils.js
+++ b/test/test_date_utils.js
@@ -72,7 +72,7 @@ function main() {
     the_11th.setMinutes(0);
     the_11th.setSeconds(0);
     the_11th.setMilliseconds(0);
-    test(new DatePiece('day', 11), the_11th);
+    test(new DatePiece(-1, -1, 11, -1, -1), the_11th);
 
     const february = new Date;
     february.setDate(1);
@@ -81,7 +81,7 @@ function main() {
     february.setSeconds(0);
     february.setMilliseconds(0);
     february.setMonth(1);
-    test(new DatePiece('month', 2), february);
+    test(new DatePiece(-1, 2, -1, -1, -1), february);
 
     const the_80s = new Date;
     the_80s.setMonth(0);
@@ -91,7 +91,7 @@ function main() {
     the_80s.setSeconds(0);
     the_80s.setMilliseconds(0);
     the_80s.setYear(1980);
-    test(new DatePiece('year', 1980), the_80s);
+    test(new DatePiece(80, -1, -1, -1, -1), the_80s);
 }
 module.exports = main;
 if (!module.parent)

--- a/test/test_date_utils.js
+++ b/test/test_date_utils.js
@@ -20,7 +20,7 @@
 const assert = require('assert');
 
 const { parseDate, normalizeDate } = require('../lib/date_utils');
-const { DateEdge, DatePiece } = require('../lib/ast');
+const { DateEdge, DatePiece, Time } = require('../lib/ast');
 
 function test(value, expected) {
     expected = parseDate(expected);
@@ -72,7 +72,7 @@ function main() {
     the_11th.setMinutes(0);
     the_11th.setSeconds(0);
     the_11th.setMilliseconds(0);
-    test(new DatePiece(-1, -1, 11, -1, -1), the_11th);
+    test(new DatePiece(-1, -1, 11, -1), the_11th);
 
     const february = new Date;
     february.setDate(1);
@@ -81,7 +81,7 @@ function main() {
     february.setSeconds(0);
     february.setMilliseconds(0);
     february.setMonth(1);
-    test(new DatePiece(-1, 2, -1, -1, -1), february);
+    test(new DatePiece(-1, 2, -1, -1), february);
 
     const the_80s = new Date;
     the_80s.setMonth(0);
@@ -91,7 +91,7 @@ function main() {
     the_80s.setSeconds(0);
     the_80s.setMilliseconds(0);
     the_80s.setYear(1980);
-    test(new DatePiece(80, -1, -1, -1, -1), the_80s);
+    test(new DatePiece(80, -1, -1, -1), the_80s);
 
     const the_10s = new Date;
     the_10s.setMonth(0);
@@ -101,16 +101,17 @@ function main() {
     the_10s.setSeconds(0);
     the_10s.setMilliseconds(0);
     the_10s.setYear(2010);
-    test(new DatePiece(10, -1, -1, -1, -1), the_10s);
+    test(new DatePiece(10, -1, -1, -1), the_10s);
 
-    assert(!(new DatePiece(10, -1, -1, -1, -1)).equals(new DatePiece(80, -1, -1, -1, -1)));
+    assert(!(new DatePiece(10, -1, -1, -1)).equals(new DatePiece(80, -1, -1, -1)));
 
     const eleven_thirty = new Date;
+    eleven_thirty.setDate(25);
     eleven_thirty.setHours(11);
     eleven_thirty.setMinutes(30);
     eleven_thirty.setSeconds(0);
     eleven_thirty.setMilliseconds(0);
-    test(new DatePiece(-1, -1, -1, 11, 30), eleven_thirty);
+    test(new DatePiece(-1, -1, 25, new Time.Absolute(11, 30, 0)), eleven_thirty);
 }
 module.exports = main;
 if (!module.parent)

--- a/test/test_date_utils.js
+++ b/test/test_date_utils.js
@@ -20,7 +20,7 @@
 const assert = require('assert');
 
 const { parseDate, normalizeDate } = require('../lib/date_utils');
-const { DateEdge } = require('../lib/ast');
+const { DateEdge, DatePiece } = require('../lib/ast');
 
 function test(value, expected) {
     expected = parseDate(expected);
@@ -65,6 +65,33 @@ function main() {
     next_month.setMilliseconds(0);
     next_month.setMonth(next_month.getMonth()+1);
     test(new DateEdge('end_of', 'mon'), next_month);
+
+    const the_11th = new Date;
+    the_11th.setDate(11);
+    the_11th.setHours(0);
+    the_11th.setMinutes(0);
+    the_11th.setSeconds(0);
+    the_11th.setMilliseconds(0);
+    test(new DatePiece('day', 11), the_11th);
+
+    const february = new Date;
+    february.setDate(1);
+    february.setHours(0);
+    february.setMinutes(0);
+    february.setSeconds(0);
+    february.setMilliseconds(0);
+    february.setMonth(1);
+    test(new DatePiece('month', 2), february);
+
+    const the_80s = new Date;
+    the_80s.setMonth(0);
+    the_80s.setDate(1);
+    the_80s.setHours(0);
+    the_80s.setMinutes(0);
+    the_80s.setSeconds(0);
+    the_80s.setMilliseconds(0);
+    the_80s.setYear(1980);
+    test(new DatePiece('year', 1980), the_80s);
 }
 module.exports = main;
 if (!module.parent)

--- a/test/test_describe.js
+++ b/test/test_describe.js
@@ -371,7 +371,7 @@ var TEST_CASES = [
     `get restaurants on Yelp that have Mexican food near Palo Alto and then notify you`,
     `Yelp`],
 
-    [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(null, 6, null, null) => notify;`,
+    [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(, 6, , ) => notify;`,
      `get today's date such that the date is after ????-06-?? ??:?? and then notify you`,
      `Get Date`],
 ];

--- a/test/test_describe.js
+++ b/test/test_describe.js
@@ -371,7 +371,7 @@ var TEST_CASES = [
     `get restaurants on Yelp that have Mexican food near Palo Alto and then notify you`,
     `Yelp`],
 
-    [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(-1, 6, -1, -1, -1) => notify;`,
+    [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(-1, 6, -1, -1) => notify;`,
      `get today's date such that the date is after ????-06-?? ??:?? and then notify you`,
      `Get Date`],
 ];

--- a/test/test_describe.js
+++ b/test/test_describe.js
@@ -370,6 +370,10 @@ var TEST_CASES = [
     [`now => (@com.yelp.restaurant()), geo == new Location("Palo Alto") && contains(cuisines, "mexican"^^com.yelp:restaurant_cuisine("Mexican")) => notify;`,
     `get restaurants on Yelp that have Mexican food near Palo Alto and then notify you`,
     `Yelp`],
+
+    [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(-1, 6, -1, -1, -1) => notify;`,
+     `get today's date such that the date is after ????-06-?? ??:?? and then notify you`,
+     `Get Date`],
 ];
 
 const gettext = {

--- a/test/test_describe.js
+++ b/test/test_describe.js
@@ -371,7 +371,7 @@ var TEST_CASES = [
     `get restaurants on Yelp that have Mexican food near Palo Alto and then notify you`,
     `Yelp`],
 
-    [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(-1, 6, -1, -1) => notify;`,
+    [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(null, 6, null, null) => notify;`,
      `get today's date such that the date is after ????-06-?? ??:?? and then notify you`,
      `Get Date`],
 ];

--- a/test/test_describe.js
+++ b/test/test_describe.js
@@ -371,8 +371,8 @@ var TEST_CASES = [
     `get restaurants on Yelp that have Mexican food near Palo Alto and then notify you`,
     `Yelp`],
 
-    [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new DatePiece(, 6, , ) => notify;`,
-     `get today's date such that the date is after ????-06-?? ??:?? and then notify you`,
+    [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new Date(, 6, ) => notify;`,
+     `get today's date such that the date is after start of day on day 1 of june, this year and then notify you`,
      `Get Date`],
 ];
 

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -614,21 +614,21 @@ now => @org.schema.restaurant() => notify;`],
                                      QUOTED_STRING_0: 'hello' },
      `now => @com.twitter(id="twitter-account-foo").post(status="hello");`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( , , NUMBER_0 , ) => notify`,
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new Date ( , , NUMBER_0 , ) => notify`,
      `get sunrise sunset on the NUMBER_0 th`, { NUMBER_0: 25 },
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(, , 25, )) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new Date(, , 25)) => notify;`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( , , 10 , TIME_0 ) => notify`,
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new Date ( , , 10 , TIME_0 ) => notify`,
      `get sunrise sunset on the 10 th at TIME_0`, { TIME_0: { hour: 5, minute: 0 } },
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(, , 10, new Time(5, 0))) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new Date(, , 10, 5, 0, 0)) => notify;`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( NUMBER_0 , 3 , , ) => notify`,
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new Date ( NUMBER_0 , 3 , , ) => notify`,
      `get sunrise sunset on March, NUMBER_0`, { NUMBER_0: 2020 },
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(2020, 3, , )) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new Date(2020, 3, )) => notify;`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( 10 , , , ) => notify`,
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new Date ( 10 , , , ) => notify`,
      `get sunrise sunset in the 10s`, {},
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(10, , , )) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new Date(2010, , )) => notify;`],
 ];
 
 function stripTypeAnnotations(program) {

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -616,19 +616,19 @@ now => @org.schema.restaurant() => notify;`],
 
     [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( , , NUMBER_0 , ) => notify`,
      `get sunrise sunset on the NUMBER_0 th`, { NUMBER_0: 25 },
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(null, null, 25, null)) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(, , 25, )) => notify;`],
 
     [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( , , 10 , TIME_0 ) => notify`,
      `get sunrise sunset on the 10 th at TIME_0`, { TIME_0: { hour: 5, minute: 0 } },
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(null, null, 10, new Time(5, 0))) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(, , 10, new Time(5, 0))) => notify;`],
 
     [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( NUMBER_0 , 3 , , ) => notify`,
      `get sunrise sunset on March, NUMBER_0`, { NUMBER_0: 2020 },
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(2020, 3, null, null)) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(2020, 3, , )) => notify;`],
 
     [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( 10 , , , ) => notify`,
      `get sunrise sunset in the 10s`, {},
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(10, null, null, null)) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(10, , , )) => notify;`],
 ];
 
 function stripTypeAnnotations(program) {

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -618,6 +618,17 @@ now => @org.schema.restaurant() => notify;`],
      `get sunrise sunset on the NUMBER_0 th`, { NUMBER_0: 25 },
      `now => @org.thingpedia.weather.sunrise(date=new DatePiece(-1, -1, 25, -1)) => notify;`],
 
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( - 1 , - 1 , 10 , TIME_0 ) => notify`,
+     `get sunrise sunset on the 10 th at TIME_0`, { TIME_0: { hour: 5, minute: 0 } },
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(-1, -1, 10, new Time(5, 0))) => notify;`],
+
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( NUMBER_0 , 3 , - 1 , - 1 ) => notify`,
+     `get sunrise sunset on March, NUMBER_0`, { NUMBER_0: 2020 },
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(2020, 3, -1, -1)) => notify;`],
+
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( 10 , - 1 , - 1 , - 1 ) => notify`,
+     `get sunrise sunset in the 10s`, {},
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(10, -1, -1, -1)) => notify;`],
 ];
 
 function stripTypeAnnotations(program) {

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -614,8 +614,9 @@ now => @org.schema.restaurant() => notify;`],
                                      QUOTED_STRING_0: 'hello' },
      `now => @com.twitter(id="twitter-account-foo").post(status="hello");`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( -1 , -1 , 12 , -1 , -1 ) => notify`, `get sunrise sunset on the twelfth`, {},
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(-1, -1, 12, -1, -1)) => notify;`],
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( -1 , -1 , NUMBER_0 , time:-1 ) => notify`,
+     `get sunrise sunset on the NUMBER_0 th`, { NUMBER_0: 25 },
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(-1, -1, 25, -1)) => notify;`],
 
 ];
 

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -613,6 +613,10 @@ now => @org.schema.restaurant() => notify;`],
      'post QUOTED_STRING_0 on it', { 'GENERIC_ENTITY_tt:device_id_0': { value: 'twitter-account-foo' },
                                      QUOTED_STRING_0: 'hello' },
      `now => @com.twitter(id="twitter-account-foo").post(status="hello");`],
+
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = datePiece ( LITERAL_INTEGER_0 , LITERAL_INTEGER_0 , LITERAL_INTEGER_1 , LITERAL_INTEGER_0 , LITERAL_INTEGER_0 ) => notify`, `get sunrise sunset on the twelfth`, { LITERAL_INTEGER_0: -1, LITERAL_INTEGER_1: 12 },
+     `now => @org.thingpedia.weather.sunrise(date=datePiece( -1, -1, 12, -1, -1 )) => notify;`],
+
 ];
 
 function stripTypeAnnotations(program) {

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -614,8 +614,8 @@ now => @org.schema.restaurant() => notify;`],
                                      QUOTED_STRING_0: 'hello' },
      `now => @com.twitter(id="twitter-account-foo").post(status="hello");`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = datePiece ( LITERAL_INTEGER_0 , LITERAL_INTEGER_0 , LITERAL_INTEGER_1 , LITERAL_INTEGER_0 , LITERAL_INTEGER_0 ) => notify`, `get sunrise sunset on the twelfth`, { LITERAL_INTEGER_0: -1, LITERAL_INTEGER_1: 12 },
-     `now => @org.thingpedia.weather.sunrise(date=datePiece( -1, -1, 12, -1, -1 )) => notify;`],
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( -1 , -1 , 12 , -1 , -1 ) => notify`, `get sunrise sunset on the twelfth`, {},
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(-1, -1, 12, -1, -1)) => notify;`],
 
 ];
 

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -614,7 +614,7 @@ now => @org.schema.restaurant() => notify;`],
                                      QUOTED_STRING_0: 'hello' },
      `now => @com.twitter(id="twitter-account-foo").post(status="hello");`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( -1 , -1 , NUMBER_0 , time:-1 ) => notify`,
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( - 1 , - 1 , NUMBER_0 , - 1 ) => notify`,
      `get sunrise sunset on the NUMBER_0 th`, { NUMBER_0: 25 },
      `now => @org.thingpedia.weather.sunrise(date=new DatePiece(-1, -1, 25, -1)) => notify;`],
 

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -614,21 +614,21 @@ now => @org.schema.restaurant() => notify;`],
                                      QUOTED_STRING_0: 'hello' },
      `now => @com.twitter(id="twitter-account-foo").post(status="hello");`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( - 1 , - 1 , NUMBER_0 , - 1 ) => notify`,
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( , , NUMBER_0 , ) => notify`,
      `get sunrise sunset on the NUMBER_0 th`, { NUMBER_0: 25 },
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(-1, -1, 25, -1)) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(null, null, 25, null)) => notify;`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( - 1 , - 1 , 10 , TIME_0 ) => notify`,
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( , , 10 , TIME_0 ) => notify`,
      `get sunrise sunset on the 10 th at TIME_0`, { TIME_0: { hour: 5, minute: 0 } },
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(-1, -1, 10, new Time(5, 0))) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(null, null, 10, new Time(5, 0))) => notify;`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( NUMBER_0 , 3 , - 1 , - 1 ) => notify`,
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( NUMBER_0 , 3 , , ) => notify`,
      `get sunrise sunset on March, NUMBER_0`, { NUMBER_0: 2020 },
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(2020, 3, -1, -1)) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(2020, 3, null, null)) => notify;`],
 
-    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( 10 , - 1 , - 1 , - 1 ) => notify`,
+    [`now => @org.thingpedia.weather.sunrise param:date:Date = new DatePiece ( 10 , , , ) => notify`,
      `get sunrise sunset in the 10s`, {},
-     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(10, -1, -1, -1)) => notify;`],
+     `now => @org.thingpedia.weather.sunrise(date=new DatePiece(10, null, null, null)) => notify;`],
 ];
 
 function stripTypeAnnotations(program) {


### PR DESCRIPTION
DatePiece is a way to construct Date values when only one of [year,
month, day] is specified. The big-end non-supplied values get set
to the present and the little-end non-supplied values get set to the
smallest possible. For example: DatePiece('month', 3) gets compiled to
the Date corresponding to the first of April in the present year
(January is month 0). This is useful for disambiguating a reference
such as "the 11th" in the context of dates.

TODO: parser functionalities for DatePiece