### PR TITLE
remove accents for substring matching

### DIFF
--- a/lib/builtin/primitive_ops.js
+++ b/lib/builtin/primitive_ops.js
@@ -138,7 +138,9 @@ function likeTest(a, b) {
 
     if (typeof a === 'string' && typeof b === 'string') {
         a = a.toLowerCase();
+        a = a.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
         b = b.toLowerCase();
+        b = b.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
         if (a.indexOf(b) >= 0)
             return true;
         if (a.replace(/'/g, ' ').indexOf(b.replace(/'/g, ' ')) >= 0)


### PR DESCRIPTION
If I search for songs by beyonce in spotify, the request fails because the correct spelling is beyoncé, so the substring match fails on the accent. 