### PR TITLE
Fix normalization of nested compute tables

### DIFF
--- a/lib/ast/primitive.js
+++ b/lib/ast/primitive.js
@@ -33,7 +33,6 @@ const {
 } = require('./slots');
 const { isUnaryStreamToStreamOp,
         isUnaryTableToTableOp,
-        isUnaryStreamToTableOp,
         isUnaryTableToStreamOp } = require('../utils');
 const Type = require('../type');
 const Builtin = require('../builtin/defs');
@@ -89,8 +88,6 @@ class Table extends Node {
             return [prim, newScope];
         } else if (isUnaryTableToTableOp(this)) {
             return yield* this.table.iterateSlots(scope);
-        } else if (isUnaryStreamToTableOp(this)) {
-            return yield* this.stream.iterateSlots(scope);
         } else if (this.isJoin) {
             let [, leftScope] = yield* this.lhs.iterateSlots(scope);
             let [, rightScope] = yield* this.rhs.iterateSlots(scope);
@@ -144,8 +141,6 @@ class Table extends Node {
             return [prim, innerScope];
         } else if (isUnaryTableToTableOp(this)) {
             return yield* this.table.iterateSlots2(scope);
-        } else if (isUnaryStreamToTableOp(this)) {
-            return yield* this.stream.iterateSlots2(scope);
         } else if (this.isJoin) {
             let [, leftScope] = yield* this.lhs.iterateSlots2(scope);
             let [, rightScope] = yield* this.rhs.iterateSlots2(scope);

--- a/lib/nn-syntax/entity-retriever.js
+++ b/lib/nn-syntax/entity-retriever.js
@@ -288,7 +288,9 @@ class SequentialEntityAllocator extends AbstractEntityRetriever {
     findEntity(entityType, value, { ignoreNotFound = false }) {
         const entity = valueToEntity(entityType, value);
 
-        if (this.explicitStrings) {
+        if (this.explicitStrings &&
+            (entityType === 'QUOTED_STRING' || entityType === 'HASHTAG' || entityType === 'USERNAME' ||
+            entityType === 'LOCATION' || entityType.startsWith('GENERIC_ENTITY_'))) {
             const entityString = entityToString(entityType, entity);
 
             if (entityType === 'QUOTED_STRING')

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -23,7 +23,8 @@ const assert = require('assert');
 const Ast = require('./ast');
 
 const { isUnaryStreamToStreamOp,
-        isUnaryTableToTableOp } = require('./utils');
+        isUnaryTableToTableOp,
+        getScalarExpressionName } = require('./utils');
 
 function flattenAnd(expr) {
     let flattened = [];
@@ -286,6 +287,34 @@ function optimizeStream(stream, allow_projection=true) {
     return stream;
 }
 
+function findComputeTable(table) {
+    if (table.isCompute)
+        return table;
+    if (table.isInvocation || table.isVarRef)
+        return null;
+
+    // do not traverse joins or aliases, as those
+    // change the meaning of parameters and therefore the expressions
+    if (table.isJoin || table.isAlias)
+        return null;
+
+    if (isUnaryTableToTableOp(table))
+        return findComputeTable(table.table);
+
+    throw new TypeError(table.constructor.name);
+}
+
+function expressionUsesParam(expr, pname) {
+    let used = false;
+    expr.visit(new class extends Ast.NodeVisitor {
+        visitVarRefValue(value) {
+            used = used || value.name === pname;
+            return true;
+        }
+    });
+    return used;
+}
+
 function optimizeTable(table, allow_projection=true) {
     if (table.isVarRef || table.isInvocation)
         return table;
@@ -306,6 +335,39 @@ function optimizeTable(table, allow_projection=true) {
         return new Ast.Table.Projection(table.location, optimized, table.args, table.schema);
     }
 
+    if (table.isCompute) {
+        if (table.expression.isVarRef) // entirely redundant
+            return optimizeTable(table.table);
+
+        // look for a nested compute table and find one that has the same
+        // expression (note that joins and aliases stop the traversal)
+        // if so, we remove this compute expression entirely
+        let inner = findComputeTable(table.table);
+        while (inner) {
+            // check that our expression doesn't depend on the result of the computation
+            // (if it does, the computation is not redundant)
+            const innerOutputName = inner.alias || getScalarExpressionName(inner.expression);
+
+            if (expressionUsesParam(table.expression, innerOutputName))
+                break;
+
+            // check that our expression is equal to the inner expression,
+            if (inner.expression.equals(table.expression)) {
+                // yep, found it!
+                return optimizeTable(table.table);
+            }
+
+            // try going deeper
+            inner = findComputeTable(inner.table);
+        }
+
+        // nope, no optimization here
+        inner = optimizeTable(table.table, allow_projection);
+        if (!inner)
+            return null;
+        table.table = inner;
+        return table;
+    }
 
     if (table.isFilter) {
         table.filter = optimizeFilter(table.filter);

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -23,8 +23,7 @@ const assert = require('assert');
 const Ast = require('./ast');
 
 const { isUnaryStreamToStreamOp,
-        isUnaryTableToTableOp,
-        isUnaryStreamToTableOp } = require('./utils');
+        isUnaryTableToTableOp } = require('./utils');
 
 function flattenAnd(expr) {
     let flattened = [];
@@ -362,14 +361,6 @@ function optimizeTable(table, allow_projection=true) {
         table.table = inner;
         return table;
     }
-    if (isUnaryStreamToTableOp(table)) {
-        let inner = optimizeStream(table.stream, allow_projection);
-        if (!inner)
-            return null;
-        table.stream = inner;
-        return table;
-    }
-
     if (table.isJoin) {
         let lhs = optimizeTable(table.lhs, allow_projection);
         if (!lhs)

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -805,8 +805,6 @@ function addRequiredInputParamsTable(table, extrainparams) {
         addRequiredInputParamsInvocation(table, extrainparams);
     else if (table.isInvocation)
         addRequiredInputParamsInvocation(table.invocation, extrainparams);
-    else if (Utils.isUnaryStreamToTableOp(table))
-        addRequiredInputParamsStream(table.stream);
     else if (Utils.isUnaryTableToTableOp(table))
         addRequiredInputParamsTable(table.table, extrainparams);
     else

--- a/test/test_optimize.js
+++ b/test/test_optimize.js
@@ -146,6 +146,41 @@ now => [distance] of (compute (distance(geo, $context.location.current_location)
     [`now => [aggregateRating.ratingValue] of ((sort distance asc of (compute (distance(geo, new Location("foo"))) of ((@org.schema.restaurant()), name =~ $context.selection : String)))[1]) => notify;`,
     `now => [aggregateRating.ratingValue] of ((sort distance asc of (compute (distance(geo, new Location("foo"))) of ((@org.schema.restaurant()), name =~ $context.selection : String)))[1]) => notify;`
     ],
+
+    [`now => compute distance(geo, $context.location.current_location) of compute distance(geo, $context.location.current_location) of @com.yelp.restaurant() => notify;`,
+     `now => compute (distance(geo, $context.location.current_location)) of (@com.yelp.restaurant()) => notify;`],
+
+    [`now => compute distance(geo, $context.location.current_location) of compute distance(geo, $context.location.home) of @com.yelp.restaurant() => notify;`,
+     `now => compute (distance(geo, $context.location.current_location)) of (compute (distance(geo, $context.location.home)) of (@com.yelp.restaurant())) => notify;`],
+
+    [`now => compute distance(geo, $context.location.current_location) of compute rating + 2 of @com.yelp.restaurant() => notify;`,
+     `now => compute (distance(geo, $context.location.current_location)) of (compute (rating + 2) of (@com.yelp.restaurant())) => notify;`],
+
+    [`now => compute distance(geo, $context.location.current_location) of compute rating + 2 of compute distance(geo, $context.location.current_location) of @com.yelp.restaurant() => notify;`,
+     `now => compute (rating + 2) of (compute (distance(geo, $context.location.current_location)) of (@com.yelp.restaurant())) => notify;`],
+
+    [`now => compute result + 2 of compute rating + 2 of @com.yelp.restaurant() => notify;`,
+     `now => compute (result + 2) of (compute (rating + 2) of (@com.yelp.restaurant())) => notify;`],
+
+    [`now => compute result + 2 of compute result + 2 of compute rating + 2 of @com.yelp.restaurant() => notify;`,
+     `now => compute (result + 2) of (compute (result + 2) of (compute (rating + 2) of (@com.yelp.restaurant()))) => notify;`],
+
+    [`now => compute result + 2 of compute distance(geo, $context.location.current_location) of compute result + 2 of compute rating + 2 of @com.yelp.restaurant() => notify;`,
+     `now => compute (result + 2) of (compute (distance(geo, $context.location.current_location)) of (compute (result + 2) of (compute (rating + 2) of (@com.yelp.restaurant())))) => notify;`],
+
+    [`now => compute result of compute rating + 2 of @com.yelp.restaurant() => notify;`,
+     `now => compute (rating + 2) of (@com.yelp.restaurant()) => notify;`],
+
+    [`now => compute rating of @com.yelp.restaurant() => notify;`,
+     `now => @com.yelp.restaurant() => notify;`],
+
+    [`now => compute distance(geo, $context.location.current_location) of (sort distance asc of compute distance(geo, $context.location.current_location) of @com.yelp.restaurant()) => notify;`,
+    `now => sort distance asc of (compute (distance(geo, $context.location.current_location)) of (@com.yelp.restaurant())) => notify;`],
+
+    [`$dialogue @org.thingpedia.dialogue.transaction.execute; now => compute distance(geo, $context.location.current_location) of (sort distance asc of compute distance(geo, $context.location.current_location) of @com.yelp.restaurant()) => notify;`,
+    `$dialogue @org.thingpedia.dialogue.transaction.execute;
+now => sort distance asc of (compute (distance(geo, $context.location.current_location)) of (@com.yelp.restaurant())) => notify;`]
+
 ];
 
 


### PR DESCRIPTION
Especially useful for "how far is the closest restaurant", where the neural network might interpret "how far" to create a proj + compute, and "closest" to create a "index + sort + compute" so we end up with two compute tables (in training and/or in testing).

Fixes #238 