### PR TITLE
nn-converter: add support for "numeric dates"

### DIFF
--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -325,7 +325,15 @@ module.exports = class ToNNConverter {
                 toReturn = List.concat(toReturn, ')');
                 return toReturn;
             } else {
-                return this.findEntity('DATE', value);
+                const found = this.findEntity('DATE', value, { ignoreNotFound: true });
+                if (found)
+                    return found;
+
+                const str = this.findEntity('QUOTED_STRING', new Ast.Value.String(value.value.toISOString()), { ignoreNotFound: true });
+                if (str)
+                    return List.concat('new', 'Date', '(', str, ')');
+
+                return List.concat('new', 'Date', '(', this.valueToNN(new Ast.Value.Number(value.value.getTime())), ')');
             }
         } else if (value.isTime) {
             if (value.value.isRelative) {


### PR DESCRIPTION
The neural network might decide to generate "new Date ( number )"
because that's valid syntax. Later, when we normalize we fail
because there is no DATE token. The syntax generated by the neural
network is incorrect, but we don't want to crash.