### PR TITLE
Improve readability of argument annotations

### DIFF
--- a/lib/ast/function_def.js
+++ b/lib/ast/function_def.js
@@ -249,7 +249,7 @@ class ArgumentDef extends Node {
      * @return {string} - the ThingTalk code that corresponds to this argument definition
      */
     toString(prefix = '') {
-        return `${this.direction} ${this.name}: ${prettyprintType(this.type, prefix)}${prettyprintAnnotations(this, ' ', false)}`;
+        return `${this.direction} ${this.name}: ${prettyprintType(this.type, prefix)}${prettyprintAnnotations(this, prefix, true)}`;
     }
 
     /**

--- a/lib/prettyprint.js
+++ b/lib/prettyprint.js
@@ -30,7 +30,7 @@ function prettyprintType(ast, prefix='') {
     } else if (ast.isCompound) {
         const fields = Object.keys(ast.fields)
             .filter((f) => !f.includes('.')) // filter out fields flattened from compound
-            .map((f) => `${f}: ${prettyprintType(ast.fields[f].type, prefix + '  ')}${prettyprintAnnotations(ast.fields[f], ' ', false)}`);
+            .map((f) => `${f}: ${prettyprintType(ast.fields[f].type, prefix + '  ')}${prettyprintAnnotations(ast.fields[f], prefix + '  ', true)}`);
         return `{\n${prefix}  ${fields.join(',\n' + prefix + '  ')}\n${prefix}}`;
     } else {
         return ast.toString();
@@ -376,11 +376,24 @@ function prettyprintImportStmt(ast) {
         throw new TypeError();
 }
 
-function prettyprintJson(value) {
+function prettyprintJson(value, prefix='', linebreak=false) {
     if (Array.isArray(value))
-        return '[' + value.map((v) => prettyprintJson(v)).join(', ') + ']';
-    if (typeof value === 'object')
-        return '{' + Object.entries(value).map(([key, value]) => `${key}=${prettyprintJson(value)}`).join(',') + '}';
+        return '[' + value.map((v) => prettyprintJson(v, prefix)).join(', ') + ']';
+    if (typeof value === 'object') {
+        let start, end, linebreakPrefix;
+        if (linebreak) {
+            start = `{\n${prefix}  `;
+            end = `\n${prefix}}`;
+            linebreakPrefix = `\n${prefix}  `;
+        } else {
+            start = '{';
+            end = '}';
+            linebreakPrefix = ' ';
+        }
+        return start + Object.entries(value).map(([key, value]) =>
+            `${key}=${prettyprintJson(value, prefix)}`
+        ).join(`,${linebreakPrefix}`) + end;
+    }
     if (typeof value === 'string')
         return stringEscape(value);
     return value.toString();
@@ -388,17 +401,16 @@ function prettyprintJson(value) {
 
 function prettyprintAnnotations(ast, prefix = '  ', linebreak = true) {
     let annotations = '';
-    if (linebreak)
-        prefix = '\n' + prefix;
+    const linebreakPrefix = linebreak ? '\n' + prefix : prefix;
     Object.entries(ast.nl_annotations).forEach(([name, value]) => {
         if (typeof value === 'object' && Object.keys(value).length > 0 || value && value.length > 0)
-            annotations += `${prefix}#_[${name}=${prettyprintJson(value)}]`;
+            annotations += `${linebreakPrefix}#_[${name}=${prettyprintJson(value, prefix, true)}]`;
     });
     Object.entries(ast.impl_annotations).forEach(([name, value]) => {
         if (Array.isArray(value))
-            annotations += `${prefix}#[${name}=[${(value.map((v) => prettyprintValue(v))).join(', ')}]]`;
+            annotations += `${linebreakPrefix}#[${name}=[${(value.map((v) => prettyprintValue(v))).join(', ')}]]`;
         else
-            annotations += `${prefix}#[${name}=${prettyprintValue(value)}]`;
+            annotations += `${linebreakPrefix}#[${name}=${prettyprintValue(value)}]`;
     });
     return annotations;
 }

--- a/test/test_class_to_manifest.js
+++ b/test/test_class_to_manifest.js
@@ -41,11 +41,12 @@ const TEST_CASES = [
     '  monitorable query get_power(out power: Enum(on,off))\n' +
     '  #_[canonical="power status of foo"]\n' +
     '  #_[confirmation="status of foo"]\n' +
-    '  #_[formatted=["Here is something for you", {type="rdl",displayTitle="$title",webCallback="$url"}]]\n' +
+    '  #_[formatted=["Here is something for you", {type="rdl", displayTitle="$title", webCallback="$url"}]]\n' +
     '  #[poll_interval=600000ms]\n' +
     '  #[minimal_projection=[]];\n' +
     '\n' +
-    '  action set_power(in req power: Enum(on,off) #_[prompt="do you want turn on or off?"])\n' +
+    '  action set_power(in req power: Enum(on,off)\n' +
+    '                   #_[prompt="do you want turn on or off?"])\n' +
     '  #_[canonical="set power of foo"]\n' +
     '  #_[confirmation="turn $power foo"]\n' +
     '  #[minimal_projection=[]];\n' +
@@ -323,7 +324,8 @@ const TEST_CASES = [
     '\n' +
     '  query bar(out title: String,\n' +
     '            out description: String,\n' +
-    '            out url: Entity(tt:url) #[unique=true])\n' +
+    '            out url: Entity(tt:url)\n' +
+    '            #[unique=true])\n' +
     '  #_[canonical="foo"]\n' +
     '  #_[confirmation="bar"]\n' +
     '  #[require_filter=true]\n' +

--- a/test/test_prettyprint.js
+++ b/test/test_prettyprint.js
@@ -26,10 +26,17 @@ const { prettyprint } = require('../lib/prettyprint');
 const TEST_CASES = [
 // compound type
 `class @org.schema {
-  list query local_business(out name: String,
+  list query local_business(out name: String
+                            #_[canonical={
+                              base=["name"],
+                              passive_verb=["called"]
+                            }]
+                            #[filterable=false],
                             out rating: {
-                              value: Number #_[canonical="v"],
-                              count: Number #[foo=true]
+                              value: Number
+                              #_[canonical="v"],
+                              count: Number
+                              #[foo=true]
                             })
   #[minimal_projection=[]];
 }

--- a/test/test_schema_retriever.js
+++ b/test/test_schema_retriever.js
@@ -51,14 +51,15 @@ async function testInjectManifest() {
   import loader from @org.thingpedia.v2();
   import config from @org.thingpedia.config.none();
 
-  monitorable query get_comic(in opt number: Number #_[prompt="What Xkcd comic do you want?"],
+  monitorable query get_comic(in opt number: Number
+                              #_[prompt="What Xkcd comic do you want?"],
                               out title: String,
                               out picture_url: Entity(tt:picture),
                               out link: Entity(tt:url),
                               out alt_text: String)
   #_[canonical="xkcd comic"]
   #_[confirmation="an Xkcd comic"]
-  #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}"}, {type="picture",url="${'${picture_url}'}"}, {type="text",text="${'${alt_text}'}"}]]
+  #_[formatted=[{type="rdl", webCallback="${'${link}'}", displayTitle="${'${title}'}"}, {type="picture", url="${'${picture_url}'}"}, {type="text", text="${'${alt_text}'}"}]]
   #[poll_interval=86400000ms]
   #[doc="retrieve the comic with a given number, or the latest comit"]
   #[minimal_projection=[]];
@@ -70,7 +71,7 @@ async function testInjectManifest() {
                      out alt_text: String)
   #_[canonical="random xkcd comic"]
   #_[confirmation="a random Xkcd comic"]
-  #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}"}, {type="picture",url="${'${picture_url}'}"}, {type="text",text="${'${alt_text}'}"}]]
+  #_[formatted=[{type="rdl", webCallback="${'${link}'}", displayTitle="${'${title}'}"}, {type="picture", url="${'${picture_url}'}"}, {type="text", text="${'${alt_text}'}"}]]
   #[doc="retrieve a random xkcd"]
   #[minimal_projection=[]];
 
@@ -79,7 +80,7 @@ async function testInjectManifest() {
                                  out updated_time: Date)
   #_[canonical="xkcd what if blog posts"]
   #_[confirmation="Xkcd's What If blog posts"]
-  #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}"}]]
+  #_[formatted=[{type="rdl", webCallback="${'${link}'}", displayTitle="${'${title}'}"}]]
   #[poll_interval=86400000ms]
   #[doc="retrieve the latest posts on Xkcd's What If blog"]
   #[minimal_projection=[]];


### PR DESCRIPTION
The current prettyprint format is really not readable especially when we have
a long list of canonical annotations for arguments, to improve readability:
- linebreak for all argument annotations
- linebreak for first level items of json for argument annotations