### PR TITLE
Introduce * projections

### DIFF
--- a/lib/ast/expression2.ts
+++ b/lib/ast/expression2.ts
@@ -397,6 +397,8 @@ export class ProjectionExpression extends Expression {
         this.expression = expression;
 
         assert(Array.isArray(args));
+        // if there is a *, it's the only name projected
+        assert(args.every((x) => x !== '*') || args.length === 1);
         this.args = args;
 
         this.computations = computations;
@@ -425,7 +427,7 @@ export class ProjectionExpression extends Expression {
             addParenthesis(this.priority, this.expression.priority, this.expression.toSource()));
     }
 
-    toLegacy(into_params : InputParam[] = []) : legacy.ProjectionTable|legacy.ProjectionStream {
+    toLegacy(into_params : InputParam[] = []) : legacy.Table|legacy.Stream {
         const schema = this.schema!;
         assert(schema.functionType !== 'action');
 
@@ -441,6 +443,8 @@ export class ProjectionExpression extends Expression {
                     names.push(alias || getScalarExpressionName(value));
                 }
             }
+            if (names[0] === '*')
+                return table;
             return new legacy.ProjectionTable(this.location, table, names, this.schema);
         } else {
             let stream = inner as legacy.Stream;
@@ -452,6 +456,8 @@ export class ProjectionExpression extends Expression {
                     names.push(alias || getScalarExpressionName(value));
                 }
             }
+            if (names[0] === '*')
+                return stream;
             return new legacy.ProjectionStream(this.location, stream, names, this.schema);
         }
     }

--- a/lib/ast/primitive.ts
+++ b/lib/ast/primitive.ts
@@ -380,7 +380,7 @@ export class ComputeTable extends Table {
     }
 
     toExpression(extra_in_params : InputParam[]) {
-        return new ProjectionExpression(this.location, this.table.toExpression(extra_in_params), [], [this.expression], [this.alias], this.schema);
+        return new ProjectionExpression(this.location, this.table.toExpression(extra_in_params), ['*'], [this.expression], [this.alias], this.schema);
     }
 
     visit(visitor : NodeVisitor) : void {

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -888,9 +888,18 @@ projection_expression : Ast.Expression = {
 }
 
 projection_param_list : Array<[Ast.Value, string|null]> = {
+    '*' => [[new Ast.VarRefValue('*'), null]];
+    '*' ',' list:projection_nonstar_param_list => {
+        const arr : Array<[Ast.Value, string|null]> = [[new Ast.VarRefValue('*'), null]];
+        return arr.concat(list);
+    };
+    projection_nonstar_param_list;
+}
+
+projection_nonstar_param_list : Array<[Ast.Value, string|null]> = {
     p:projection_param => [p];
 
-    list:projection_param_list ',' p:projection_param => {
+    list:projection_nonstar_param_list ',' p:projection_param => {
         list.push(p);
         return list;
     };

--- a/lib/new-syntax/pretty.ts
+++ b/lib/new-syntax/pretty.ts
@@ -198,11 +198,17 @@ export function prettyprint(tokens : TokenStream) : string {
             buffer += ')';
             break;
 
+        case '*':
+            if (buffer.endsWith('[')) // projection
+                buffer += token;
+            else // multiplication
+                buffer += ' ' + token + ' ';
+            break;
+
         // add a space before and after certain operators
         case ':':
         case '+':
         case '-':
-        case '*':
         case '/':
         case '%':
         case '**':

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -1700,12 +1700,7 @@ $dialogue @org.thingpedia.dialogue.transaction.sys_search_question(serveCuisine)
 
 // explicit dontcare
 @org.schema.full.FoodEstablishment() filter true(servesCuisine);
-====
 
-// regression test for bug in projection with function inheritance
-// ** expect TypeError **
-// the projection is inside and masks the parameter, including inherited ones
-[distance(geo, $location.current_location)] of [address] of @org.schema.place();
 ====
 
 // procedures with actions and returned values


### PR DESCRIPTION
A projection of the form [*, foo] where foo is a computations
adds the computation value without removing any output parameter.

This feature is necessary to translate old compute tables correctly,
which in turn is necessary to deal with existing datasets in Genie,
in particular around sort of computations.

Also, expand the normalizations around projections and computes,
and add tests.