### PR TITLE
Fix makefile target dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-%.ts : %.lr tools/generate-parser/*.js tools/generate-parser/grammar.js
+%.ts : %.lr tools/generate-parser/*.ts tools/generate-parser/grammar.js
 	ts-node tools/generate-parser $@ $<
 
 %.js : %.pegjs


### PR DESCRIPTION
Build only completes successfully on the second execution. This prevents installing `genie-toolkit#next` as well.

Not a Make expert so there may be a better way to address this dependency problem.