### PR TITLE
Make empty parenthesis optional in Thingpedia function calls

### DIFF
--- a/lib/ast/expression.ts
+++ b/lib/ast/expression.ts
@@ -312,8 +312,12 @@ export class Invocation extends Node {
             });
         }
 
-        return List.concat(this.selector.toSource(), '.', this.channel,
-            '(', List.join(filteredParams.map((ip) => ip.toSource()), ','), ')');
+        if (filteredParams.length > 0) {
+            return List.concat(this.selector.toSource(), '.', this.channel,
+                '(', List.join(filteredParams.map((ip) => ip.toSource()), ','), ')');
+        } else {
+            return List.concat(this.selector.toSource(), '.', this.channel);
+        }
     }
 
     clone() : Invocation {

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -999,6 +999,40 @@ thingpedia_call : Ast.Invocation = {
         const selector = new Ast.DeviceSelector($.location, className.value, id, null, other, all);
         return new Ast.Invocation($.location, selector, functionName, in_params, null);
     };
+
+    name:CLASS_OR_FUNCTION_REF => {
+        const lastDot = name.value.lastIndexOf('.');
+        const className = name.value.substring(0, lastDot);
+        const functionName = name.value.substring(lastDot+1);
+
+        // we check that the function name is a valid identifier because the lexer will greedly parse through things
+        // that are not identifiers but are allowed in the class name
+        if (!isIdentifier(functionName))
+            $.error(`${name.value} is not a valid function name`); //`
+        return new Ast.Invocation($.location, new Ast.DeviceSelector($.location, className, null, null), functionName, [], null);
+    };
+
+    className:CLASS_OR_FUNCTION_REF '.' functionName:function_name
+        => new Ast.Invocation($.location, new Ast.DeviceSelector($.location, className.value, null, null), functionName, [], null);
+
+    className:CLASS_OR_FUNCTION_REF device_params:in_param_list '.' functionName:function_name => {
+        let id : string|null = null, all = false;
+        const other = [];
+        for (const attr of device_params) {
+            if (attr.name === 'id') {
+                id = String(attr.value.toJS());
+                const value = attr.value;
+                if (value instanceof Ast.EntityValue && value.display)
+                    other.push(new Ast.InputParam($.location, 'name', new Ast.Value.String(value.display)));
+            } else if (attr.name === 'all') {
+                all = !!attr.value.toJS();
+            } else {
+                other.push(attr);
+            }
+        }
+        const selector = new Ast.DeviceSelector($.location, className.value, id, null, other, all);
+        return new Ast.Invocation($.location, selector, functionName, [], null);
+    };
 }
 
 in_param_list : Ast.InputParam[] = {

--- a/test/test_declaration_program.js
+++ b/test/test_declaration_program.js
@@ -27,19 +27,19 @@ const schemaRetriever = new SchemaRetriever(_mockSchemaDelegate, null, true);
 let TEST_CASES = [
     // manually written test cases
     ['function x() { @com.twitter.post(); }',
-     '@com.twitter.post();'],
+     '@com.twitter.post;'],
     [`function x(p_status : String) { @com.twitter.post(status=p_status); }`,
      '@com.twitter.post(status=__const_SLOT_0);'],
 
     ['function x() { @com.bing.web_search(); }',
-     '@com.bing.web_search();'],
+     '@com.bing.web_search;'],
     [`function x(p_query : String) { @com.bing.web_search(query=p_query); }`,
      '@com.bing.web_search(query=__const_SLOT_0);'],
     [`function x(p_query : String, p_width : Number) { @com.bing.image_search(query=p_query), width >= p_width; }`,
      '@com.bing.image_search(query=__const_SLOT_0) filter width >= __const_SLOT_1;'],
 
     [`function x(p_author : Entity(tt:username)) { monitor (@com.twitter.search()), author == p_author; }`,
-     `monitor(@com.twitter.search()) filter author == __const_SLOT_0;`],
+     `monitor(@com.twitter.search) filter author == __const_SLOT_0;`],
 
     ['function x(p_song1 : String, p_song2 : String) { @com.spotify.play_songs(songs=[p_song1, p_song2]); }',
     '@com.spotify.play_songs(songs=[__const_SLOT_0, __const_SLOT_1]);'],

--- a/test/test_example_program.js
+++ b/test/test_example_program.js
@@ -27,22 +27,22 @@ const schemaRetriever = new SchemaRetriever(_mockSchemaDelegate, null, true);
 let TEST_CASES = [
     // manually written test cases
     [`dataset @foo { action := @com.twitter.post() #_[utterances=['post']]; }`,
-     '@com.twitter.post();'],
+     '@com.twitter.post;'],
     [`dataset @foo { action (p_status : String) := @com.twitter.post(status=p_status) #_[utterances=['post $p_status']]; }`,
      '@com.twitter.post(status=__const_SLOT_0);'],
 
     [`dataset @foo { query () := @com.bing.web_search() #_[utterances=['bing search']]; }`,
-     '@com.bing.web_search();'],
+     '@com.bing.web_search;'],
     [`dataset @foo { query (p_query : String) := @com.bing.web_search(query=p_query) #_[utterances=['search $p_query']]; }`,
      '@com.bing.web_search(query=__const_SLOT_0);'],
     [`dataset @foo { query (p_query : String, p_width : Number) := @com.bing.image_search(query=p_query), width >= p_width #_[utterances=['search $p_query pictures with width greater than $p_width']]; }`,
      '@com.bing.image_search(query=__const_SLOT_0) filter width >= __const_SLOT_1;'],
 
     [`dataset @foo { stream (p_author : Entity(tt:username)) := monitor (@com.twitter.search(), author == p_author) #_[utterances=['monitor tweets from $p_author']]; }`,
-     `monitor(@com.twitter.search() filter author == __const_SLOT_0);`],
+     `monitor(@com.twitter.search filter author == __const_SLOT_0);`],
 
     [`dataset @foo { program := @com.twitter.post() #_[utterances=['post']]; }`,
-     '@com.twitter.post();'],
+     '@com.twitter.post;'],
 
     ['dataset @foo { action (p_song1 : String, p_song2 : String) := @com.spotify.play_songs(songs=[p_song1, p_song2]); }',
      '@com.spotify.play_songs(songs=[__const_SLOT_0, __const_SLOT_1]);'],

--- a/test/test_legacy_nn_syntax.js
+++ b/test/test_legacy_nn_syntax.js
@@ -56,7 +56,7 @@ const schemaRetriever = new SchemaRetriever(_mockSchemaDelegate, null, true);
 const TEST_CASES = [
     [`monitor ( @com.xkcd.get_comic ) => notify`,
      `monitor xkcd`, {},
-     `monitor(@com.xkcd.get_comic());`
+     `monitor(@com.xkcd.get_comic);`
     ],
 
     [`now => @com.twitter.post param:status:String = QUOTED_STRING_0`,
@@ -99,35 +99,35 @@ const TEST_CASES = [
 
     [`monitor ( @thermostat.get_temperature ) => notify`,
     `monitor thermostat`, {},
-    `monitor(@thermostat.get_temperature());`],
+    `monitor(@thermostat.get_temperature);`],
 
     [`monitor ( ( @thermostat.get_temperature ) filter param:value:Measure(C) >= NUMBER_0 unit:F ) => notify`,
     `notify me if the temperature is above NUMBER_0 degrees`, {'NUMBER_0': 70},
-    `monitor(@thermostat.get_temperature() filter value >= 70F);`],
+    `monitor(@thermostat.get_temperature filter value >= 70F);`],
 
     [`now => ( @com.bing.image_search ) filter param:height:Number >= NUMBER_1 or param:width:Number >= NUMBER_0 => notify`,
     `search images wider than NUMBER_0 pixels or taller than NUMBER_1 pixels`, {NUMBER_0: 100, NUMBER_1:200},
-    `@com.bing.image_search() filter height >= 200 || width >= 100;`],
+    `@com.bing.image_search filter height >= 200 || width >= 100;`],
 
     [`now => ( @com.bing.image_search ) filter param:height:Number >= NUMBER_1 or param:width:Number >= NUMBER_0 and param:width:Number <= NUMBER_2 => notify`,
     `search images wider than NUMBER_0 pixels or taller than NUMBER_1 pixels and narrower than NUMBER_2 pixels`, {NUMBER_0: 100, NUMBER_1:200, NUMBER_2: 500},
-    `@com.bing.image_search() filter (height >= 200 || width >= 100) && width <= 500;`],
+    `@com.bing.image_search filter (height >= 200 || width >= 100) && width <= 500;`],
 
     [`now => ( @com.bing.image_search ) filter param:height:Number >= NUMBER_0 or param:width:Number >= NUMBER_0 => notify`,
     `search images larger than NUMBER_0 pixels in either dimension`, {NUMBER_0: 100},
-    `@com.bing.image_search() filter height >= 100 || width >= 100;`],
+    `@com.bing.image_search filter height >= 100 || width >= 100;`],
 
     [`now => ( @com.bing.image_search ) filter param:width:Number >= NUMBER_0 => notify`,
     `search images wider than NUMBER_0 pixels`, {NUMBER_0: 100 },
-    `@com.bing.image_search() filter width >= 100;`],
+    `@com.bing.image_search filter width >= 100;`],
 
     ['monitor ( @com.xkcd.get_comic ) on new param:title:String => notify',
     `monitor xkcd if the title changes`, {},
-    `monitor(title of @com.xkcd.get_comic());`],
+    `monitor(title of @com.xkcd.get_comic);`],
 
     ['monitor ( @com.xkcd.get_comic ) on new [ param:alt_text:String , param:title:String ] => notify',
     `monitor xkcd if the title or alt text changes`, {},
-    `monitor(alt_text, title of @com.xkcd.get_comic());`],
+    `monitor(alt_text, title of @com.xkcd.get_comic);`],
 
     ['monitor ( ( @com.instagram.get_pictures param:count:Number = NUMBER_0 ) filter param:caption:String in_array [ QUOTED_STRING_0 , QUOTED_STRING_1 ] ) => notify',
     `monitor my last NUMBER_0 instagram pics if the caption is either QUOTED_STRING_0 or QUOTED_STRING_1`, {NUMBER_0: 100, QUOTED_STRING_0: 'abc', QUOTED_STRING_1: 'def'},
@@ -139,7 +139,7 @@ const TEST_CASES = [
 
     ['monitor ( ( @com.phdcomics.get_post ) filter not param:title:String =~ QUOTED_STRING_0 ) => notify',
     `monitor phd comics post that do n't have QUOTED_STRING_0 in the title`, {QUOTED_STRING_0: 'abc'}, //'
-    `monitor(@com.phdcomics.get_post() filter !(title =~ "abc"));`],
+    `monitor(@com.phdcomics.get_post filter !(title =~ "abc"));`],
 
     ['now => ( @com.uber.price_estimate param:end:Location = location:home param:start:Location = location:work ) filter param:low_estimate:Currency >= CURRENCY_0 => notify',
     `get an uber price estimate from home to work if the low estimate is greater than CURRENCY_0`, {CURRENCY_0: { value: 50, unit: 'usd' } },
@@ -147,7 +147,7 @@ const TEST_CASES = [
 
     ['now => ( @com.uber.price_estimate ) filter param:uber_type:Enum(pool,uber_x,uber_xl,uber_black,select,suv,assist) == enum:uber_x => notify',
     `get a price estimate for uber x`, {},
-    `@com.uber.price_estimate() filter uber_type == enum uber_x;`],
+    `@com.uber.price_estimate filter uber_type == enum uber_x;`],
 
     ['now => @org.thingpedia.builtin.thingengine.builtin.configure param:device:Entity(tt:device) = device:com.google',
     `configure google`, {},
@@ -155,21 +155,21 @@ const TEST_CASES = [
 
     ['now => ( @com.nytimes.get_front_page ) filter param:updated:Date >= now - DURATION_0 => notify',
      `get new york times articles published in the last DURATION_0`, { DURATION_0: { value: 15, unit: 'min' } },
-     `@com.nytimes.get_front_page() filter updated >= $now - 15min;`],
+     `@com.nytimes.get_front_page filter updated >= $now - 15min;`],
 
     [`executor = USERNAME_0 : now => @com.twitter.post`,
      `ask USERNAME_0 to post on twitter`, { USERNAME_0: 'bob' },
      `#[executor="bob"^^tt:username]
-@com.twitter.post();`],
+@com.twitter.post;`],
 
     [`executor = USERNAME_0 : now => @com.xkcd.get_comic => notify`,
      `ask USERNAME_0 to get xkcd`, { USERNAME_0: 'bob' },
      `#[executor="bob"^^tt:username]
-@com.xkcd.get_comic();`],
+@com.xkcd.get_comic;`],
 
     [`now => ( @security-camera.current_event ) filter @org.thingpedia.builtin.thingengine.builtin.get_gps { not param:location:Location == location:home } => notify`,
      `show me my security camera if i 'm not home`, {}, //'
-     `@security-camera.current_event() filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps() filter !(location == $location.home));`],
+     `@security-camera.current_event filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps filter !(location == $location.home));`],
 
     [`policy true : now => @com.twitter.post`,
     `anyone can post on twitter`, {},
@@ -222,13 +222,13 @@ const TEST_CASES = [
     [`policy true : @com.bing.web_search filter @org.thingpedia.builtin.thingengine.builtin.get_gps { not param:location:Location == location:home } and param:description:String =~ QUOTED_STRING_0 => notify`,
     `anyone can search on bing if i am not at home and the description contains QUOTED_STRING_0`, { QUOTED_STRING_0: 'foo' },
     `$policy {
-  true : @com.bing.web_search filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps() filter !(location == $location.home)) && description =~ "foo" => notify;
+  true : @com.bing.web_search filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps filter !(location == $location.home)) && description =~ "foo" => notify;
 }`],
 
     [`executor = USERNAME_0 : now => @com.twitter.post_picture`,
      `USERNAME_0 can post pictures on twitter`, { USERNAME_0: 'mom' },
      `#[executor="mom"^^tt:username]
-@com.twitter.post_picture();`],
+@com.twitter.post_picture;`],
 
     [`now => @org.thingpedia.weather.sunrise param:date:Date = DATE_0 => notify`,
      `get sunrise sunset on date DATE_0`, { DATE_0: { year: 2018, month: 5, day: 23, hour: -1, minute: -1, second: -1 } },
@@ -252,11 +252,11 @@ const TEST_CASES = [
 
     ['now => ( @com.bing.web_search ) join ( @com.yandex.translate.translate param:target_language:Entity(tt:iso_lang_code) = GENERIC_ENTITY_tt:iso_lang_code_0 ) on param:text:String = event => notify',
     `translate web searches to GENERIC_ENTITY_tt:iso_lang_code_0`, { 'GENERIC_ENTITY_tt:iso_lang_code_0': { value: 'it', display: "Italian" } },
-    `@com.bing.web_search() => @com.yandex.translate.translate(target_language="it"^^tt:iso_lang_code("Italian"), text=$result);`],
+    `@com.bing.web_search => @com.yandex.translate.translate(target_language="it"^^tt:iso_lang_code("Italian"), text=$result);`],
 
     ['now => ( @com.bing.web_search ) join ( @com.yandex.translate.translate param:target_language:Entity(tt:iso_lang_code) = " italian " ^^tt:iso_lang_code ) on param:text:String = event => notify',
     `translate web searches to italian`, {},
-    `@com.bing.web_search() => @com.yandex.translate.translate(target_language=null^^tt:iso_lang_code("italian"), text=$result);`],
+    `@com.bing.web_search => @com.yandex.translate.translate(target_language=null^^tt:iso_lang_code("italian"), text=$result);`],
 
     ['now => @com.bing.web_search param:query:String = " pizza " => notify',
     `search pizza on bing`, {},
@@ -268,12 +268,12 @@ const TEST_CASES = [
 
     ['now => ( @com.twitter.search ) filter param:hashtags:Array(Entity(tt:hashtag)) contains " foo " ^^tt:hashtag => notify',
     `search hashtag foo on twitter`, {},
-    `@com.twitter.search() filter contains(hashtags, "foo"^^tt:hashtag);`],
+    `@com.twitter.search filter contains(hashtags, "foo"^^tt:hashtag);`],
 
     ['executor = " bob " ^^tt:username : now => @com.twitter.post',
     `ask bob to post on twitter`, {},
     `#[executor="bob"^^tt:username]
-@com.twitter.post();`],
+@com.twitter.post;`],
 
     ['now => @com.twitter.follow param:user_name:Entity(tt:username) = " bob " ^^tt:username',
     `follow bob on twitter`, {},
@@ -282,7 +282,7 @@ const TEST_CASES = [
     ['policy true : now => @org.thingpedia.builtin.thingengine.builtin.discover filter @org.thingpedia.builtin.test.get_data { param:data:String == QUOTED_STRING_0 }',
     'everybody has permission to discover new devices if the data of more data genning ... is exactly QUOTED_STRING_0', { QUOTED_STRING_0: 'foo' },
     `$policy {
-  true : now => @org.thingpedia.builtin.thingengine.builtin.discover filter any(@org.thingpedia.builtin.test.get_data() filter data == "foo");
+  true : now => @org.thingpedia.builtin.thingengine.builtin.discover filter any(@org.thingpedia.builtin.test.get_data filter data == "foo");
 }`],
 
     [`now => @com.xkcd.get_comic param:number:Number = SLOT_0 => notify`,
@@ -299,39 +299,39 @@ const TEST_CASES = [
 
     [`now => ( @com.twitter.search ) filter param:author:Entity(tt:username) == undefined => notify`,
      'search tweets by author', {},
-    `@com.twitter.search() filter author == $?;`],
+    `@com.twitter.search filter author == $?;`],
 
     ['now => sort param:sender_name:String asc of ( @com.gmail.inbox ) => notify',
     'show my emails sorted by sender name', {},
-    `sort(sender_name asc of @com.gmail.inbox());`],
+    `sort(sender_name asc of @com.gmail.inbox);`],
 
     ['now => sort param:sender_name:String desc of ( @com.gmail.inbox ) => notify',
     'show my emails sorted by sender name -lrb- in reverse order -rrb-', {},
-    `sort(sender_name desc of @com.gmail.inbox());`],
+    `sort(sender_name desc of @com.gmail.inbox);`],
 
     ['now => ( @com.gmail.inbox ) [ 1 ] => notify',
     'show me exactly one email', {},
-    `@com.gmail.inbox()[1];`],
+    `@com.gmail.inbox[1];`],
 
     ['now => ( @com.gmail.inbox ) [ 1 : 3 ] => notify',
     'show me exactly 3 emails', {},
-    `@com.gmail.inbox()[1 : 3];`],
+    `@com.gmail.inbox[1 : 3];`],
 
     ['now => ( @com.gmail.inbox ) [ 1 : NUMBER_0 ] => notify',
     'show me exactly NUMBER_0 emails', { NUMBER_0: 22 },
-    `@com.gmail.inbox()[1 : 22];`],
+    `@com.gmail.inbox[1 : 22];`],
 
     ['now => ( @com.gmail.inbox ) [ 3 : NUMBER_0 ] => notify',
     'show me exactly NUMBER_0 emails , starting from the third', { NUMBER_0: 22 },
-    `@com.gmail.inbox()[3 : 22];`],
+    `@com.gmail.inbox[3 : 22];`],
 
     ['now => ( @com.gmail.inbox ) [ NUMBER_1 : NUMBER_0 ] => notify',
     'show me exactly NUMBER_0 emails , starting from the NUMBER_1', { NUMBER_1: 13, NUMBER_0: 22 },
-    `@com.gmail.inbox()[13 : 22];`],
+    `@com.gmail.inbox[13 : 22];`],
 
     ['now => ( @com.gmail.inbox ) [ 3 , 7 , NUMBER_0 ] => notify',
     'show me exactly the emails number 3 , 7 and NUMBER_0', { NUMBER_0: 22 },
-    `@com.gmail.inbox()[3, 7, 22];`],
+    `@com.gmail.inbox[3, 7, 22];`],
 
     ['bookkeeping special special:yes',
     'yes', {},
@@ -398,15 +398,15 @@ const TEST_CASES = [
 
     ['now => [ param:description:String , param:title:String ] of ( @com.bing.web_search ) => notify',
     'get title and description from bing', {},
-    '[description, title] of @com.bing.web_search();'],
+    '[description, title] of @com.bing.web_search;'],
 
     [`now => @com.spotify.get_currently_playing => @com.spotify.add_songs_to_playlist param:songs:Array(String) = [ param:song:String ]`,
     `add the currently playing song to my playlist`, {},
-    `@com.spotify.get_currently_playing() => @com.spotify.add_songs_to_playlist(songs=[song]);`],
+    `@com.spotify.get_currently_playing => @com.spotify.add_songs_to_playlist(songs=[song]);`],
 
     [`[ param:author:Entity(tt:username) , param:text:String ] of ( monitor ( @com.twitter.home_timeline ) on new param:text:String ) => notify`,
     `monitor new text of tweets and show me the text and author`, {},
-    `[author, text] of monitor(text of @com.twitter.home_timeline());`],
+    `[author, text] of monitor(text of @com.twitter.home_timeline);`],
 
     ['now => @com.twitter.post param:status:String = context:selection:String',
     'post this on twitter', {},
@@ -414,12 +414,12 @@ const TEST_CASES = [
 
     [`now => ( @com.twitter.home_timeline ) filter count ( param:hashtags:Array(Entity(tt:hashtag)) ) >= 0 => notify`,
     `get tweets with hashtags`, {},
-    `@com.twitter.home_timeline() filter count(hashtags) >= 0;`],
+    `@com.twitter.home_timeline filter count(hashtags) >= 0;`],
 
     // just to test syntax, in reality we should not generate examples like this
     [`now => ( @com.twitter.home_timeline ) filter count ( param:hashtags:Array(Entity(tt:hashtag)) filter { param:value:Entity(tt:hashtag) == " foo " ^^tt:hashtag } ) >= 0 => notify`,
     `get tweets with hashtags foo`, {},
-    `@com.twitter.home_timeline() filter count(hashtags filter value == "foo"^^tt:hashtag) >= 0;`],
+    `@com.twitter.home_timeline filter count(hashtags filter value == "foo"^^tt:hashtag) >= 0;`],
 
     [`now => @light-bulb.set_power attribute:name:String = " bedroom " param:power:Enum(on,off) = enum:off`,
     `turn off my bedroom lights`, {},
@@ -433,14 +433,14 @@ const TEST_CASES = [
      `now => @com.thecatapi.get => notify ;`,
     `get a cat picture`, {},
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get();`],
+@com.thecatapi.get;`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction.execute ; ` +
      `now => @com.thecatapi.get => notify ` +
      `#[ results = [ { param:image_id = GENERIC_ENTITY_com.thecatapi:image_id_0 , param:picture_url = PICTURE_0 , param:link = URL_0 } ] ] ;`,
     `here is your cat picture`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_0: 'https://example.com/2' },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];`],
@@ -451,7 +451,7 @@ const TEST_CASES = [
      `now => @com.twitter.post_picture param:picture_url:Entity(tt:picture) = PICTURE_0 ;`,
     `now post it on twitter`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_1: 'https://example.com/2' },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
@@ -464,7 +464,7 @@ const TEST_CASES = [
      `#[ confirm = enum:confirmed ] ;`,
     `confirm posting it on twitter`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_1: 'https://example.com/2' },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
@@ -484,7 +484,7 @@ const TEST_CASES = [
         URL_1: 'https://example.com/3'
     },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
@@ -507,7 +507,7 @@ const TEST_CASES = [
         QUOTED_STRING_0: 'something bad happened'
     },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
@@ -528,7 +528,7 @@ const TEST_CASES = [
         URL_1: 'https://example.com/3'
     },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
@@ -542,7 +542,7 @@ const TEST_CASES = [
      `#[ count = NUMBER_0 ] ;`,
     `i found NUMBER_0 cat pictures , here is one`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_0: 'https://example.com/2', NUMBER_0: 55 },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]]
@@ -555,7 +555,7 @@ const TEST_CASES = [
      `#[ more = true ] ;`,
     `i found more than NUMBER_0 cat pictures , here is one`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_0: 'https://example.com/2', NUMBER_0: 55 },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]]
@@ -566,13 +566,13 @@ const TEST_CASES = [
      `now => @org.schema.restaurant => notify ;`,
      'what kind of cuisine are you looking for ?', {},
      `$dialogue @org.thingpedia.dialogue.transaction.sys_search_question(serveCuisine);
-@org.schema.restaurant();`],
+@org.schema.restaurant;`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction.sys_search_question param:price , param:serveCuisine ; ` +
      `now => @org.schema.restaurant => notify ;`,
      'what kind of cuisine and price are you looking for ?', {},
      `$dialogue @org.thingpedia.dialogue.transaction.sys_search_question(price, serveCuisine);
-@org.schema.restaurant();`],
+@org.schema.restaurant;`],
 
     [`bookkeeping answer @com.google.contacts.get_contacts`,
     `google contacts`, {},
@@ -580,15 +580,15 @@ const TEST_CASES = [
 
     [`now => ( @com.yelp.restaurant ) filter true param:cuisines:Array(Entity(com.yelp:restaurant_cuisine)) => notify`,
     `i 'm looking for a restaurant , i do n't care what cuisine`, {},
-    `@com.yelp.restaurant() filter true(cuisines);`],
+    `@com.yelp.restaurant filter true(cuisines);`],
 
     ['now => ( @org.schema.full.Recipe ) filter param:nutrition.fatContent:Measure(kg) >= MEASURE_kg_0 and param:nutrition.sugarContent:Measure(kg) >= MEASURE_kg_0 => notify',
      `yeah please find a recipe with that fat content and that sugar content`, { MEASURE_kg_0: { value: 13, unit: 'kg' } },
-     `@org.schema.full.Recipe() filter nutrition.fatContent >= 13kg && nutrition.sugarContent >= 13kg;`],
+     `@org.schema.full.Recipe filter nutrition.fatContent >= 13kg && nutrition.sugarContent >= 13kg;`],
 
     ['now => ( @com.uber.price_estimate ) filter param:low_estimate:Currency <= NUMBER_0 unit:$usd => notify',
      'is it less than $ NUMBER_0 ?', { NUMBER_0: 1000 },
-     '@com.uber.price_estimate() filter low_estimate <= 1000$usd;'],
+     '@com.uber.price_estimate filter low_estimate <= 1000$usd;'],
 
     ['now => @com.twitter.post attribute:id:Entity(tt:device_id) = GENERIC_ENTITY_tt:device_id_0 param:status:String = QUOTED_STRING_0',
      'post QUOTED_STRING_0 on it', { 'GENERIC_ENTITY_tt:device_id_0': { value: 'twitter-account-foo', display: "Twitter Account foo" },
@@ -627,7 +627,7 @@ const TEST_CASES = [
     [`now => ( @com.yelp.restaurant ) filter param:openingHours:RecurrentTimeSpecification == new RecurrentTimeSpecification ( { beginTime = time:0:0:0 , endTime = time:24:0:0 ,`
     + ` dayOfWeek = enum:friday } , { beginTime = time:0:0:0 , endTime = time:24:0:0 , dayOfWeek = enum:saturday } ) => notify`,
     `restaurants open 24 hours on friday and saturday`, {},
-    `@com.yelp.restaurant() filter openingHours == new RecurrentTimeSpecification({ beginTime=new Time(0, 0), endTime=new Time(24, 0), dayOfWeek=enum friday }, { beginTime=new Time(0, 0), endTime=new Time(24, 0), dayOfWeek=enum saturday });`],
+    `@com.yelp.restaurant filter openingHours == new RecurrentTimeSpecification({ beginTime=new Time(0, 0), endTime=new Time(24, 0), dayOfWeek=enum friday }, { beginTime=new Time(0, 0), endTime=new Time(24, 0), dayOfWeek=enum saturday });`],
 
     ['let param:foo = ( @org.thingpedia.weather.sunrise param:date:Date = new Date ( enum:monday ) )',
      'let foo be the weather on monday', {},

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -27,9 +27,9 @@ import _mockSchemaDelegate from './mock_schema_delegate';
 const schemaRetriever = new SchemaRetriever(_mockSchemaDelegate, null, true);
 
 const TEST_CASES = [
-    [`monitor ( @com.xkcd . get_comic ( ) ) ;`,
+    [`monitor ( @com.xkcd . get_comic ) ;`,
      `monitor xkcd`, {},
-     `monitor(@com.xkcd.get_comic());`
+     `monitor(@com.xkcd.get_comic);`
     ],
 
     [`@com.twitter . post ( status = QUOTED_STRING_0 ) ;`,
@@ -70,37 +70,37 @@ const TEST_CASES = [
     `get xkcd whose number is a random number max is NUMBER_0 min is NUMBER_1`, {'NUMBER_0': 1024, 'NUMBER_1': 55},
     `@org.thingpedia.builtin.thingengine.builtin.get_random_between(high=1024, low=55);`],
 
-    [`monitor ( @thermostat . get_temperature ( ) ) ;`,
+    [`monitor ( @thermostat . get_temperature ) ;`,
     `monitor thermostat`, {},
-    `monitor(@thermostat.get_temperature());`],
+    `monitor(@thermostat.get_temperature);`],
 
-    [`monitor ( @thermostat . get_temperature ( ) filter value >= NUMBER_0 F ) ;`,
+    [`monitor ( @thermostat . get_temperature filter value >= NUMBER_0 F ) ;`,
     `notify me if the temperature is above NUMBER_0 degrees`, {'NUMBER_0': 70},
-    `monitor(@thermostat.get_temperature() filter value >= 70F);`],
+    `monitor(@thermostat.get_temperature filter value >= 70F);`],
 
-    [`@com.bing . image_search ( ) filter height >= NUMBER_1 || width >= NUMBER_0 ;`,
+    [`@com.bing . image_search filter height >= NUMBER_1 || width >= NUMBER_0 ;`,
     `search images wider than NUMBER_0 pixels or taller than NUMBER_1 pixels`, {NUMBER_0: 100, NUMBER_1:200},
-    `@com.bing.image_search() filter height >= 200 || width >= 100;`],
+    `@com.bing.image_search filter height >= 200 || width >= 100;`],
 
-    [`@com.bing . image_search ( ) filter ( height >= NUMBER_1 || width >= NUMBER_0 ) && width <= NUMBER_2 ;`,
+    [`@com.bing . image_search filter ( height >= NUMBER_1 || width >= NUMBER_0 ) && width <= NUMBER_2 ;`,
     `search images wider than NUMBER_0 pixels || taller than NUMBER_1 pixels and narrower than NUMBER_2 pixels`, {NUMBER_0: 100, NUMBER_1:200, NUMBER_2: 500},
-    `@com.bing.image_search() filter (height >= 200 || width >= 100) && width <= 500;`],
+    `@com.bing.image_search filter (height >= 200 || width >= 100) && width <= 500;`],
 
-    [`@com.bing . image_search ( ) filter height >= NUMBER_0 || width >= NUMBER_0 ;`,
+    [`@com.bing . image_search filter height >= NUMBER_0 || width >= NUMBER_0 ;`,
     `search images larger than NUMBER_0 pixels in either dimension`, {NUMBER_0: 100},
-    `@com.bing.image_search() filter height >= 100 || width >= 100;`],
+    `@com.bing.image_search filter height >= 100 || width >= 100;`],
 
-    [`@com.bing . image_search ( ) filter width >= NUMBER_0 ;`,
+    [`@com.bing . image_search filter width >= NUMBER_0 ;`,
     `search images wider than NUMBER_0 pixels`, {NUMBER_0: 100 },
-    `@com.bing.image_search() filter width >= 100;`],
+    `@com.bing.image_search filter width >= 100;`],
 
-    ['monitor ( title of @com.xkcd . get_comic ( ) ) ;',
+    ['monitor ( title of @com.xkcd . get_comic ) ;',
     `monitor xkcd if the title changes`, {},
-    `monitor(title of @com.xkcd.get_comic());`],
+    `monitor(title of @com.xkcd.get_comic);`],
 
-    ['monitor ( alt_text , title of @com.xkcd . get_comic ( ) ) ;',
+    ['monitor ( alt_text , title of @com.xkcd . get_comic ) ;',
     `monitor xkcd if the title or alt text changes`, {},
-    `monitor(alt_text, title of @com.xkcd.get_comic());`],
+    `monitor(alt_text, title of @com.xkcd.get_comic);`],
 
     ['monitor ( @com.instagram . get_pictures ( count = NUMBER_0 ) filter in_array ( caption , [ QUOTED_STRING_0 , QUOTED_STRING_1 ] ) ) ;',
     `monitor my last NUMBER_0 instagram pics if the caption is either QUOTED_STRING_0 or QUOTED_STRING_1`, {NUMBER_0: 100, QUOTED_STRING_0: 'abc', QUOTED_STRING_1: 'def'},
@@ -110,39 +110,39 @@ const TEST_CASES = [
     `alert me every DURATION_0`, {DURATION_0: { value: 30, unit: 'min'}},
     `timer(base=$now, interval=30min);`],
 
-    ['monitor ( @com.phdcomics . get_post ( ) filter ! ( title =~ QUOTED_STRING_0 ) ) ;',
+    ['monitor ( @com.phdcomics . get_post filter ! ( title =~ QUOTED_STRING_0 ) ) ;',
     `monitor phd comics post that do n't have QUOTED_STRING_0 in the title`, {QUOTED_STRING_0: 'abc'}, //'
-    `monitor(@com.phdcomics.get_post() filter !(title =~ "abc"));`],
+    `monitor(@com.phdcomics.get_post filter !(title =~ "abc"));`],
 
     ['@com.uber . price_estimate ( end = $location . home , start = $location . work ) filter low_estimate >= CURRENCY_0 ;',
     `get an uber price estimate from home to work if the low estimate is greater than CURRENCY_0`, {CURRENCY_0: { value: 50, unit: 'usd' } },
     `@com.uber.price_estimate(end=$location.home, start=$location.work) filter low_estimate >= 50$usd;`],
 
-    ['@com.uber . price_estimate ( ) filter uber_type == enum uber_x ;',
+    ['@com.uber . price_estimate filter uber_type == enum uber_x ;',
     `get a price estimate for uber x`, {},
-    `@com.uber.price_estimate() filter uber_type == enum uber_x;`],
+    `@com.uber.price_estimate filter uber_type == enum uber_x;`],
 
     ['@org.thingpedia.builtin.thingengine.builtin . configure ( device = @com.google ) ;',
     `configure google`, {},
     `@org.thingpedia.builtin.thingengine.builtin.configure(device="com.google"^^tt:device);`],
 
-    ['@com.nytimes . get_front_page ( ) filter updated >= $now - DURATION_0 ;',
+    ['@com.nytimes . get_front_page filter updated >= $now - DURATION_0 ;',
      `get new york times articles published in the last DURATION_0`, { DURATION_0: { value: 15, unit: 'min' } },
-     `@com.nytimes.get_front_page() filter updated >= $now - 15min;`],
+     `@com.nytimes.get_front_page filter updated >= $now - 15min;`],
 
-    [`#[ executor = USERNAME_0 ] @com.twitter . post ( ) ;`,
+    [`#[ executor = USERNAME_0 ] @com.twitter . post ;`,
      `ask USERNAME_0 to post on twitter`, { USERNAME_0: 'bob' },
      `#[executor="bob"^^tt:username]
-@com.twitter.post();`],
+@com.twitter.post;`],
 
-    [`#[ executor = USERNAME_0 ] @com.xkcd . get_comic ( ) ;`,
+    [`#[ executor = USERNAME_0 ] @com.xkcd . get_comic ;`,
      `ask USERNAME_0 to get xkcd`, { USERNAME_0: 'bob' },
      `#[executor="bob"^^tt:username]
-@com.xkcd.get_comic();`],
+@com.xkcd.get_comic;`],
 
-    [`@security-camera . current_event ( ) filter any ( @org.thingpedia.builtin.thingengine.builtin . get_gps ( ) filter ! ( location == $location . home ) ) ;`,
+    [`@security-camera . current_event filter any ( @org.thingpedia.builtin.thingengine.builtin . get_gps filter ! ( location == $location . home ) ) ;`,
      `show me my security camera if i 'm not home`, {}, //'
-     `@security-camera.current_event() filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps() filter !(location == $location.home));`],
+     `@security-camera.current_event filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps filter !(location == $location.home));`],
 
     [`$policy { true : now => @com.twitter . post ; }`,
     `anyone can post on twitter`, {},
@@ -192,16 +192,16 @@ const TEST_CASES = [
   true : @com.bing.web_search filter description =~ "foo" => @com.twitter.post filter status =~ "foo";
 }`],
 
-    [`$policy { true : @com.bing . web_search filter any ( @org.thingpedia.builtin.thingengine.builtin . get_gps ( ) filter ! ( location == $location . home ) ) && description =~ QUOTED_STRING_0 => notify ; }`,
+    [`$policy { true : @com.bing . web_search filter any ( @org.thingpedia.builtin.thingengine.builtin . get_gps filter ! ( location == $location . home ) ) && description =~ QUOTED_STRING_0 => notify ; }`,
     `anyone can search on bing if i am not at home and the description contains QUOTED_STRING_0`, { QUOTED_STRING_0: 'foo' },
     `$policy {
-  true : @com.bing.web_search filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps() filter !(location == $location.home)) && description =~ "foo" => notify;
+  true : @com.bing.web_search filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps filter !(location == $location.home)) && description =~ "foo" => notify;
 }`],
 
-    [`#[ executor = USERNAME_0 ] @com.twitter . post_picture ( ) ;`,
+    [`#[ executor = USERNAME_0 ] @com.twitter . post_picture ;`,
      `USERNAME_0 can post pictures on twitter`, { USERNAME_0: 'mom' },
      `#[executor="mom"^^tt:username]
-@com.twitter.post_picture();`],
+@com.twitter.post_picture;`],
 
     [`@org.thingpedia.weather . sunrise ( date = DATE_0 ) ;`,
      `get sunrise sunset on date DATE_0`, { DATE_0: { year: 2018, month: 5, day: 23, hour: -1, minute: -1, second: -1 } },
@@ -223,13 +223,13 @@ const TEST_CASES = [
      `get sunrise sunset on date DATE_0`, { DATE_0: { year: 2018, month: 5, day: 23, hour: 10, minute: 40, second: 40.5 } },
      `@org.thingpedia.weather.sunrise(date=new Date("2018-05-23T17:40:40.500Z"));`],
 
-    ['@com.bing . web_search ( ) => @com.yandex.translate . translate ( target_language = GENERIC_ENTITY_tt:iso_lang_code_0 , text = $result ) ;',
+    ['@com.bing . web_search => @com.yandex.translate . translate ( target_language = GENERIC_ENTITY_tt:iso_lang_code_0 , text = $result ) ;',
     `translate web searches to GENERIC_ENTITY_tt:iso_lang_code_0`, { 'GENERIC_ENTITY_tt:iso_lang_code_0': { value: 'it', display: "Italian" } },
-    `@com.bing.web_search() => @com.yandex.translate.translate(target_language="it"^^tt:iso_lang_code("Italian"), text=$result);`],
+    `@com.bing.web_search => @com.yandex.translate.translate(target_language="it"^^tt:iso_lang_code("Italian"), text=$result);`],
 
-    ['@com.bing . web_search ( ) => @com.yandex.translate . translate ( target_language = null ^^tt:iso_lang_code ( " italian " ) , text = $result ) ;',
+    ['@com.bing . web_search => @com.yandex.translate . translate ( target_language = null ^^tt:iso_lang_code ( " italian " ) , text = $result ) ;',
     `translate web searches to italian`, {},
-    `@com.bing.web_search() => @com.yandex.translate.translate(target_language=null^^tt:iso_lang_code("italian"), text=$result);`],
+    `@com.bing.web_search => @com.yandex.translate.translate(target_language=null^^tt:iso_lang_code("italian"), text=$result);`],
 
     ['@com.bing . web_search ( query = " pizza " ) ;',
     `search pizza on bing`, {},
@@ -239,23 +239,23 @@ const TEST_CASES = [
     `search donald trump on bing`, {},
     `@com.bing.web_search(query="donald trump");`],
 
-    ['@com.twitter . search ( ) filter contains ( hashtags , " foo " ^^tt:hashtag ) ;',
+    ['@com.twitter . search filter contains ( hashtags , " foo " ^^tt:hashtag ) ;',
     `search hashtag foo on twitter`, {},
-    `@com.twitter.search() filter contains(hashtags, "foo"^^tt:hashtag);`],
+    `@com.twitter.search filter contains(hashtags, "foo"^^tt:hashtag);`],
 
-    ['#[ executor = " bob " ^^tt:username ] @com.twitter . post ( ) ;',
+    ['#[ executor = " bob " ^^tt:username ] @com.twitter . post ;',
     `ask bob to post on twitter`, {},
     `#[executor="bob"^^tt:username]
-@com.twitter.post();`],
+@com.twitter.post;`],
 
     ['@com.twitter . follow ( user_name = " bob " ^^tt:username ) ;',
     `follow bob on twitter`, {},
     `@com.twitter.follow(user_name="bob"^^tt:username);`],
 
-    ['$policy { true : now => @org.thingpedia.builtin.thingengine.builtin . discover filter any ( @org.thingpedia.builtin.test . get_data ( ) filter data == QUOTED_STRING_0 ) ; }',
+    ['$policy { true : now => @org.thingpedia.builtin.thingengine.builtin . discover filter any ( @org.thingpedia.builtin.test . get_data filter data == QUOTED_STRING_0 ) ; }',
     'everybody has permission to discover new devices if the data of more data genning ... is exactly QUOTED_STRING_0', { QUOTED_STRING_0: 'foo' },
     `$policy {
-  true : now => @org.thingpedia.builtin.thingengine.builtin.discover filter any(@org.thingpedia.builtin.test.get_data() filter data == "foo");
+  true : now => @org.thingpedia.builtin.thingengine.builtin.discover filter any(@org.thingpedia.builtin.test.get_data filter data == "foo");
 }`],
 
     [`@com.xkcd . get_comic ( number = SLOT_0 ) ;`,
@@ -270,41 +270,41 @@ const TEST_CASES = [
      'get some specific xkcd comic', {},
     `@com.xkcd.get_comic(number=$?);`],
 
-    [`@com.twitter . search ( ) filter author == $? ;`,
+    [`@com.twitter . search filter author == $? ;`,
      'search tweets by author', {},
-    `@com.twitter.search() filter author == $?;`],
+    `@com.twitter.search filter author == $?;`],
 
-    ['sort ( sender_name asc of @com.gmail . inbox ( ) ) ;',
+    ['sort ( sender_name asc of @com.gmail . inbox ) ;',
     'show my emails sorted by sender name', {},
-    `sort(sender_name asc of @com.gmail.inbox());`],
+    `sort(sender_name asc of @com.gmail.inbox);`],
 
-    ['sort ( sender_name desc of @com.gmail . inbox ( ) ) ;',
+    ['sort ( sender_name desc of @com.gmail . inbox ) ;',
     'show my emails sorted by sender name -lrb- in reverse order -rrb-', {},
-    `sort(sender_name desc of @com.gmail.inbox());`],
+    `sort(sender_name desc of @com.gmail.inbox);`],
 
-    ['@com.gmail . inbox ( ) [ 1 ] ;',
+    ['@com.gmail . inbox [ 1 ] ;',
     'show me exactly one email', {},
-    `@com.gmail.inbox()[1];`],
+    `@com.gmail.inbox[1];`],
 
-    ['@com.gmail . inbox ( ) [ 1 : 3 ] ;',
+    ['@com.gmail . inbox [ 1 : 3 ] ;',
     'show me exactly 3 emails', {},
-    `@com.gmail.inbox()[1 : 3];`],
+    `@com.gmail.inbox[1 : 3];`],
 
-    ['@com.gmail . inbox ( ) [ 1 : NUMBER_0 ] ;',
+    ['@com.gmail . inbox [ 1 : NUMBER_0 ] ;',
     'show me exactly NUMBER_0 emails', { NUMBER_0: 22 },
-    `@com.gmail.inbox()[1 : 22];`],
+    `@com.gmail.inbox[1 : 22];`],
 
-    ['@com.gmail . inbox ( ) [ 3 : NUMBER_0 ] ;',
+    ['@com.gmail . inbox [ 3 : NUMBER_0 ] ;',
     'show me exactly NUMBER_0 emails , starting from the third', { NUMBER_0: 22 },
-    `@com.gmail.inbox()[3 : 22];`],
+    `@com.gmail.inbox[3 : 22];`],
 
-    ['@com.gmail . inbox ( ) [ NUMBER_1 : NUMBER_0 ] ;',
+    ['@com.gmail . inbox [ NUMBER_1 : NUMBER_0 ] ;',
     'show me exactly NUMBER_0 emails , starting from the NUMBER_1', { NUMBER_1: 13, NUMBER_0: 22 },
-    `@com.gmail.inbox()[13 : 22];`],
+    `@com.gmail.inbox[13 : 22];`],
 
-    ['@com.gmail . inbox ( ) [ 3 , 7 , NUMBER_0 ] ;',
+    ['@com.gmail . inbox [ 3 , 7 , NUMBER_0 ] ;',
     'show me exactly the emails number 3 , 7 and NUMBER_0', { NUMBER_0: 22 },
-    `@com.gmail.inbox()[3, 7, 22];`],
+    `@com.gmail.inbox[3, 7, 22];`],
 
     ['$yes ;',
     'yes', {},
@@ -367,30 +367,30 @@ const TEST_CASES = [
     { QUOTED_STRING_0: "it's noon" },
     `attimer(time=[new Time(12, 0)]) => @org.thingpedia.builtin.thingengine.builtin.say(message="it's noon");`],
 
-    ['[ description , title ] of @com.bing . web_search ( ) ;',
+    ['[ description , title ] of @com.bing . web_search ;',
     'get title and description from bing', {},
-    '[description, title] of @com.bing.web_search();'],
+    '[description, title] of @com.bing.web_search;'],
 
-    [`@com.spotify . get_currently_playing ( ) => @com.spotify . add_songs_to_playlist ( songs = [ song ] ) ;`,
+    [`@com.spotify . get_currently_playing => @com.spotify . add_songs_to_playlist ( songs = [ song ] ) ;`,
     `add the currently playing song to my playlist`, {},
-    `@com.spotify.get_currently_playing() => @com.spotify.add_songs_to_playlist(songs=[song]);`],
+    `@com.spotify.get_currently_playing => @com.spotify.add_songs_to_playlist(songs=[song]);`],
 
-    [`[ author , text ] of monitor ( text of @com.twitter . home_timeline ( ) ) ;`,
+    [`[ author , text ] of monitor ( text of @com.twitter . home_timeline ) ;`,
     `monitor new text of tweets and show me the text and author`, {},
-    `[author, text] of monitor(text of @com.twitter.home_timeline());`],
+    `[author, text] of monitor(text of @com.twitter.home_timeline);`],
 
     ['@com.twitter . post ( status = $context . selection : String ) ;',
     'post this on twitter', {},
     `@com.twitter.post(status=$context.selection : String);`],
 
-    [`@com.twitter . home_timeline ( ) filter count ( hashtags ) >= 0 ;`,
+    [`@com.twitter . home_timeline filter count ( hashtags ) >= 0 ;`,
     `get tweets with hashtags`, {},
-    `@com.twitter.home_timeline() filter count(hashtags) >= 0;`],
+    `@com.twitter.home_timeline filter count(hashtags) >= 0;`],
 
     // just to test syntax, in reality we should not generate examples like this
-    [`@com.twitter . home_timeline ( ) filter count ( hashtags filter value == " foo " ^^tt:hashtag ) >= 0 ;`,
+    [`@com.twitter . home_timeline filter count ( hashtags filter value == " foo " ^^tt:hashtag ) >= 0 ;`,
     `get tweets with hashtags foo`, {},
-    `@com.twitter.home_timeline() filter count(hashtags filter value == "foo"^^tt:hashtag) >= 0;`],
+    `@com.twitter.home_timeline filter count(hashtags filter value == "foo"^^tt:hashtag) >= 0;`],
 
     [`@light-bulb ( name = " bedroom " ) . set_power ( power = enum off ) ;`,
     `turn off my bedroom lights`, {},
@@ -401,41 +401,41 @@ const TEST_CASES = [
      `$dialogue @org.thingpedia.dialogue.transaction.greet;`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . execute ; ` +
-     `@com.thecatapi . get ( ) ;`,
+     `@com.thecatapi . get ;`,
     `get a cat picture`, {},
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get();`],
+@com.thecatapi.get;`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . execute ; ` +
-     `@com.thecatapi . get ( ) ` +
+     `@com.thecatapi . get ` +
      `#[ results = [ { image_id = GENERIC_ENTITY_com.thecatapi:image_id_0 , picture_url = PICTURE_0 , link = URL_0 } ] ] ;`,
     `here is your cat picture`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_0: 'https://example.com/2' },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . execute ; ` +
-     `@com.thecatapi . get ( ) ` +
+     `@com.thecatapi . get ` +
      `#[ results = [ { image_id = GENERIC_ENTITY_com.thecatapi:image_id_0 , picture_url = PICTURE_0 , link = URL_1 } ] ] ; ` +
      `@com.twitter . post_picture ( picture_url = PICTURE_0 ) ;`,
     `now post it on twitter`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_1: 'https://example.com/2' },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
 @com.twitter.post_picture(picture_url="https://example.com/1"^^tt:picture);`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . execute ; ` +
-     `@com.thecatapi . get ( ) ` +
+     `@com.thecatapi . get ` +
      `#[ results = [ { image_id = GENERIC_ENTITY_com.thecatapi:image_id_0 , picture_url = PICTURE_0 , link = URL_1 } ] ] ; ` +
      `@com.twitter . post_picture ( picture_url = PICTURE_0 ) ` +
      `#[ confirm = enum confirmed ] ;`,
     `confirm posting it on twitter`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_1: 'https://example.com/2' },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
@@ -443,7 +443,7 @@ const TEST_CASES = [
 #[confirm=enum confirmed];`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . execute ; ` +
-     `@com.thecatapi . get ( ) ` +
+     `@com.thecatapi . get ` +
      `#[ results = [ { image_id = GENERIC_ENTITY_com.thecatapi:image_id_0 , picture_url = PICTURE_0 , link = URL_0 } ] ] ; ` +
      `@com.twitter . post_picture ( picture_url = PICTURE_0 ) ` +
      `#[ results = [ { tweet_id = GENERIC_ENTITY_com.twitter:tweet_id_0 , link = URL_1 } ] ] ;`,
@@ -455,7 +455,7 @@ const TEST_CASES = [
         URL_1: 'https://example.com/3'
     },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
@@ -465,7 +465,7 @@ const TEST_CASES = [
 ]];`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . execute ; ` +
-     `@com.thecatapi . get ( ) ` +
+     `@com.thecatapi . get ` +
      `#[ results = [ { image_id = GENERIC_ENTITY_com.thecatapi:image_id_0 , picture_url = PICTURE_0 , link = URL_0 } ] ] ; ` +
      `@com.twitter . post_picture ( picture_url = PICTURE_0 ) ` +
      `#[ results = [ ] ] #[ error = QUOTED_STRING_0 ] ;`,
@@ -478,7 +478,7 @@ const TEST_CASES = [
         QUOTED_STRING_0: 'something bad happened'
     },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
@@ -487,7 +487,7 @@ const TEST_CASES = [
 #[error="something bad happened"];`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . execute ; ` +
-     `@com.thecatapi . get ( ) ` +
+     `@com.thecatapi . get ` +
      `#[ results = [ { image_id = GENERIC_ENTITY_com.thecatapi:image_id_0 , picture_url = PICTURE_0 , link = URL_0 } ] ] ; ` +
      `@com.twitter . post_picture ( picture_url = PICTURE_0 ) ` +
      `#[ results = [ ] ] #[ error = enum my_error_code ] ;`,
@@ -499,7 +499,7 @@ const TEST_CASES = [
         URL_1: 'https://example.com/3'
     },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]];
@@ -508,25 +508,25 @@ const TEST_CASES = [
 #[error=enum my_error_code];`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . execute ; ` +
-     `@com.thecatapi . get ( ) ` +
+     `@com.thecatapi . get ` +
      `#[ results = [ { image_id = GENERIC_ENTITY_com.thecatapi:image_id_0 , picture_url = PICTURE_0 , link = URL_0 } ] ] ` +
      `#[ count = NUMBER_0 ] ;`,
     `i found NUMBER_0 cat pictures , here is one`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_0: 'https://example.com/2', NUMBER_0: 55 },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]]
 #[count=55];`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . execute ; ` +
-     `@com.thecatapi . get ( ) ` +
+     `@com.thecatapi . get ` +
      `#[ results = [ { image_id = GENERIC_ENTITY_com.thecatapi:image_id_0 , picture_url = PICTURE_0 , link = URL_0 } ] ] ` +
      `#[ count = NUMBER_0 ] ` +
      `#[ more = true ] ;`,
     `i found more than NUMBER_0 cat pictures , here is one`, { 'GENERIC_ENTITY_com.thecatapi:image_id_0': { value: '1234', display: null }, PICTURE_0: 'https://example.com/1', URL_0: 'https://example.com/2', NUMBER_0: 55 },
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-@com.thecatapi.get()
+@com.thecatapi.get
 #[results=[
   { image_id="1234"^^com.thecatapi:image_id, picture_url="https://example.com/1"^^tt:picture, link="https://example.com/2"^^tt:url }
 ]]
@@ -534,16 +534,16 @@ const TEST_CASES = [
 #[more=true];`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . sys_search_question ( serveCuisine ) ; ` +
-     `@org.schema . restaurant ( ) ;`,
+     `@org.schema . restaurant ;`,
      'what kind of cuisine are you looking for ?', {},
      `$dialogue @org.thingpedia.dialogue.transaction.sys_search_question(serveCuisine);
-@org.schema.restaurant();`],
+@org.schema.restaurant;`],
 
     [`$dialogue @org.thingpedia.dialogue.transaction . sys_search_question ( price , serveCuisine ) ; ` +
-     `@org.schema . restaurant ( ) ;`,
+     `@org.schema . restaurant ;`,
      'what kind of cuisine and price are you looking for ?', {},
      `$dialogue @org.thingpedia.dialogue.transaction.sys_search_question(price, serveCuisine);
-@org.schema.restaurant();`],
+@org.schema.restaurant;`],
 
     [`$answer ( null ^^tt:function ( " google contacts " ) ) ;`,
     `google contacts`, {},
@@ -553,17 +553,17 @@ const TEST_CASES = [
     ``, {},
     `$answer("com.google.contacts"^^tt:function);`],
 
-    [`@com.yelp . restaurant ( ) filter true ( cuisines ) ;`,
+    [`@com.yelp . restaurant filter true ( cuisines ) ;`,
     `i 'm looking for a restaurant , i do n't care what cuisine`, {},
-    `@com.yelp.restaurant() filter true(cuisines);`],
+    `@com.yelp.restaurant filter true(cuisines);`],
 
-    ['@org.schema.full . Recipe ( ) filter nutrition.fatContent >= MEASURE_kg_0 && nutrition.sugarContent >= MEASURE_kg_0 ;',
+    ['@org.schema.full . Recipe filter nutrition.fatContent >= MEASURE_kg_0 && nutrition.sugarContent >= MEASURE_kg_0 ;',
      `yeah please find a recipe with that fat content and that sugar content`, { MEASURE_kg_0: { value: 13, unit: 'kg' } },
-     `@org.schema.full.Recipe() filter nutrition.fatContent >= 13kg && nutrition.sugarContent >= 13kg;`],
+     `@org.schema.full.Recipe filter nutrition.fatContent >= 13kg && nutrition.sugarContent >= 13kg;`],
 
-    ['@com.uber . price_estimate ( ) filter low_estimate <= NUMBER_0 $usd ;',
+    ['@com.uber . price_estimate filter low_estimate <= NUMBER_0 $usd ;',
      'is it less than $ NUMBER_0 ?', { NUMBER_0: 1000 },
-     '@com.uber.price_estimate() filter low_estimate <= 1000$usd;'],
+     '@com.uber.price_estimate filter low_estimate <= 1000$usd;'],
 
     ['@com.twitter ( id = GENERIC_ENTITY_tt:device_id_0 ) . post ( status = QUOTED_STRING_0 ) ;',
      'post QUOTED_STRING_0 on it', { 'GENERIC_ENTITY_tt:device_id_0': { value: 'twitter-account-foo', display: "Twitter Account foo" },
@@ -607,18 +607,18 @@ const TEST_CASES = [
      `get sunrise sunset on Monday`, { TIME_0: { hour: 5, minute: 0 } },
      `@org.thingpedia.weather.sunrise(date=new Date(enum monday, new Time(5, 0)));`],
 
-    [`@com.yelp . restaurant ( ) filter openingHours == new RecurrentTimeSpecification ( { beginTime = new Time ( 0 , 0 ) , endTime = new Time ( NUMBER_0 , 0 ) ,`
+    [`@com.yelp . restaurant filter openingHours == new RecurrentTimeSpecification ( { beginTime = new Time ( 0 , 0 ) , endTime = new Time ( NUMBER_0 , 0 ) ,`
     + ` dayOfWeek = enum friday } , { beginTime = new Time ( 0 , 0 ) , endTime = new Time ( NUMBER_0 , 0 ) , dayOfWeek = enum saturday } ) ;`,
     `restaurants open NUMBER_0 hours on friday and saturday`, { NUMBER_0: 24 },
-    `@com.yelp.restaurant() filter openingHours == new RecurrentTimeSpecification({ beginTime=new Time(0, 0), endTime=new Time(24, 0), dayOfWeek=enum friday }, { beginTime=new Time(0, 0), endTime=new Time(24, 0), dayOfWeek=enum saturday });`],
+    `@com.yelp.restaurant filter openingHours == new RecurrentTimeSpecification({ beginTime=new Time(0, 0), endTime=new Time(24, 0), dayOfWeek=enum friday }, { beginTime=new Time(0, 0), endTime=new Time(24, 0), dayOfWeek=enum saturday });`],
 
     ['let foo = @org.thingpedia.weather . sunrise ( date = new Date ( enum monday ) ) ;',
      'let foo be the weather on monday', {},
      'let foo = @org.thingpedia.weather.sunrise(date=new Date(enum monday));'],
 
-    ['timer ( base = $now , interval = NUMBER_0 min ) => @com.tesla.car . get_mobile_enabled ( ) ;',
+    ['timer ( base = $now , interval = NUMBER_0 min ) => @com.tesla.car . get_mobile_enabled ;',
      'check the status of my tesla car every NUMBER_0 minutes', { NUMBER_0: 44 },
-     'timer(base=$now, interval=44min) => @com.tesla.car.get_mobile_enabled();'],
+     'timer(base=$now, interval=44min) => @com.tesla.car.get_mobile_enabled;'],
 ];
 
 async function testCase(test, i) {

--- a/test/test_nn_syntax_allocator.js
+++ b/test/test_nn_syntax_allocator.js
@@ -27,7 +27,7 @@ import _mockSchemaDelegate from './mock_schema_delegate';
 const schemaRetriever = new SchemaRetriever(_mockSchemaDelegate, null, true);
 
 const TEST_CASES = [
-    [`monitor ( @com.xkcd . get_comic ( ) ) ;`, {}],
+    [`monitor ( @com.xkcd . get_comic ) ;`, {}],
 
     [`@com.twitter . post ( status = QUOTED_STRING_0 ) ;`,
      {'QUOTED_STRING_0': 'hello'}],
@@ -55,21 +55,21 @@ const TEST_CASES = [
     [`@org.thingpedia.builtin.thingengine.builtin . get_random_between ( high = NUMBER_0 , low = NUMBER_1 ) ;`,
     {'NUMBER_0': 1024, 'NUMBER_1': 55}],
 
-    [`monitor ( @thermostat . get_temperature ( ) ) ;`, {}],
+    [`monitor ( @thermostat . get_temperature ) ;`, {}],
 
-    [`monitor ( @thermostat . get_temperature ( ) filter value >= MEASURE_C_0 ) ;`,
+    [`monitor ( @thermostat . get_temperature filter value >= MEASURE_C_0 ) ;`,
      {'MEASURE_C_0': { unit: 'F', value: 70 }}],
 
-    [`@com.bing . image_search ( ) filter height >= NUMBER_0 || width >= NUMBER_1 ;`,
+    [`@com.bing . image_search filter height >= NUMBER_0 || width >= NUMBER_1 ;`,
     { NUMBER_0: 100, NUMBER_1:200 }],
 
-    [`@com.bing . image_search ( ) filter ( height >= NUMBER_0 || width <= NUMBER_1 ) && width >= NUMBER_2 ;`,
+    [`@com.bing . image_search filter ( height >= NUMBER_0 || width <= NUMBER_1 ) && width >= NUMBER_2 ;`,
     {NUMBER_0: 100, NUMBER_1:200, NUMBER_2: 500}],
 
-    [`@com.bing . image_search ( ) filter height >= NUMBER_0 || width >= NUMBER_0 ;`,
+    [`@com.bing . image_search filter height >= NUMBER_0 || width >= NUMBER_0 ;`,
     {NUMBER_0: 100}],
 
-    [`@com.bing . image_search ( ) filter width >= NUMBER_0 ;`,
+    [`@com.bing . image_search filter width >= NUMBER_0 ;`,
      {NUMBER_0: 100 }],
 
     ['monitor ( @com.instagram . get_pictures ( count = NUMBER_0 ) filter in_array ( caption , [ QUOTED_STRING_0 , QUOTED_STRING_1 ] ) ) ;',
@@ -78,16 +78,16 @@ const TEST_CASES = [
     ['timer ( base = $now , interval = DURATION_0 ) ;',
      {DURATION_0: { value: 24, unit: 'h'}}],
 
-    ['monitor ( @com.phdcomics . get_post ( ) filter ! ( title =~ QUOTED_STRING_0 ) ) ;',
+    ['monitor ( @com.phdcomics . get_post filter ! ( title =~ QUOTED_STRING_0 ) ) ;',
      {QUOTED_STRING_0: 'abc'}],
 
     ['@com.uber . price_estimate ( end = $location . home , start = $location . work ) filter low_estimate >= CURRENCY_0 ;',
      {CURRENCY_0: { value: 50, unit: 'usd' } }],
 
-    ['@com.nytimes . get_front_page ( ) filter updated >= $now - DURATION_0 ;',
+    ['@com.nytimes . get_front_page filter updated >= $now - DURATION_0 ;',
      { DURATION_0: { value: 24, unit: 'h' } }],
 
-    [`#[ executor = USERNAME_0 ] @com.twitter . post ( ) ;`,
+    [`#[ executor = USERNAME_0 ] @com.twitter . post ;`,
      { USERNAME_0: 'bob' }],
 
     [`$policy { $source == USERNAME_0 : now => @com.twitter . post filter status =~ QUOTED_STRING_0 ; }`,
@@ -99,19 +99,19 @@ const TEST_CASES = [
     [`@org.thingpedia.weather . sunrise ( date = DATE_0 ) ;`,
      { DATE_0: new Date(2018, 5, 23, 10, 40, 0) }],
 
-    ['@com.bing . web_search ( ) => @com.yandex.translate . translate ( target_language = GENERIC_ENTITY_tt:iso_lang_code_0 , text = $result ) ;',
+    ['@com.bing . web_search => @com.yandex.translate . translate ( target_language = GENERIC_ENTITY_tt:iso_lang_code_0 , text = $result ) ;',
     { 'GENERIC_ENTITY_tt:iso_lang_code_0': { value: 'it', display: "Italian" } }],
 
-    ['@com.gmail . inbox ( ) [ 1 : NUMBER_0 ] ;',
+    ['@com.gmail . inbox [ 1 : NUMBER_0 ] ;',
     { NUMBER_0: 15 }],
 
-    ['@com.gmail . inbox ( ) [ NUMBER_0 : NUMBER_1 ] ;',
+    ['@com.gmail . inbox [ NUMBER_0 : NUMBER_1 ] ;',
     { NUMBER_0: 21, NUMBER_1: 23 }],
 
-    ['@com.gmail . inbox ( ) [ NUMBER_0 , NUMBER_1 , NUMBER_2 ] ;',
+    ['@com.gmail . inbox [ NUMBER_0 , NUMBER_1 , NUMBER_2 ] ;',
     { NUMBER_0: 21, NUMBER_1: 28, NUMBER_2: 22 }],
 
-    ['@com.gmail . inbox ( ) [ NUMBER_0 , NUMBER_1 , NUMBER_0 ] ;',
+    ['@com.gmail . inbox [ NUMBER_0 , NUMBER_1 , NUMBER_0 ] ;',
     { NUMBER_0: 22, NUMBER_1: 29 }],
 
     ['$answer ( LOCATION_0 ) ;',
@@ -123,7 +123,7 @@ const TEST_CASES = [
     ['@com.thecatapi . get ( count = NUMBER_0 ) ;',
      { NUMBER_0: 13 }],
 
-    ['@org.schema.full . Recipe ( ) filter nutrition.fatContent >= MEASURE_kg_0 ;',
+    ['@org.schema.full . Recipe filter nutrition.fatContent >= MEASURE_kg_0 ;',
      { MEASURE_kg_0: { value: 13, unit: 'kg' } }]
 ];
 

--- a/test/test_optimize.js
+++ b/test/test_optimize.js
@@ -24,96 +24,96 @@ import * as AppGrammar from '../lib/syntax_api';
 const TEST_CASES = [
     [
         `now => [text] of (@com.twitter.home_timeline()) => @com.twitter.post(status=text);`,
-        `@com.twitter.home_timeline() => @com.twitter.post(status=text);`
+        `@com.twitter.home_timeline => @com.twitter.post(status=text);`
     ],
     [
         `now => ([text] of @com.twitter.home_timeline()), text =~ "lol" => notify;`,
-        `[text] of @com.twitter.home_timeline() filter text =~ "lol";`
+        `[text] of @com.twitter.home_timeline filter text =~ "lol";`
     ],
     [
         `now => ([text] of @com.twitter.home_timeline()), text =~ "lol" => @com.twitter.post(status=text);`,
-        `@com.twitter.home_timeline() filter text =~ "lol" => @com.twitter.post(status=text);`
+        `@com.twitter.home_timeline filter text =~ "lol" => @com.twitter.post(status=text);`
     ],
     [
         `monitor ([text] of (@com.twitter.home_timeline())) => @com.twitter.post(status=text);`,
-        `monitor(text of @com.twitter.home_timeline()) => @com.twitter.post(status=text);`
+        `monitor(text of @com.twitter.home_timeline) => @com.twitter.post(status=text);`
     ],
     [
         `monitor (([text] of @com.twitter.home_timeline()), text =~ "lol") => notify;`,
-        `[text] of monitor(text of @com.twitter.home_timeline() filter text =~ "lol");`
+        `[text] of monitor(text of @com.twitter.home_timeline filter text =~ "lol");`
     ],
     [
-        `monitor (([text] of @com.twitter.home_timeline()), text =~ "lol") => @com.twitter.post(status=text);`,
-        `monitor(text of @com.twitter.home_timeline() filter text =~ "lol") => @com.twitter.post(status=text);`
+        `monitor (([text] of @com.twitter.home_timeline), text =~ "lol") => @com.twitter.post(status=text);`,
+        `monitor(text of @com.twitter.home_timeline filter text =~ "lol") => @com.twitter.post(status=text);`
     ],
     [
-        `now => [count] of count(@com.twitter.home_timeline()) => notify;`,
-        `count(@com.twitter.home_timeline());`
-    ],
-
-    [
-        `now => [text] of [text, author] of @com.twitter.home_timeline() => notify;`,
-        `[text] of @com.twitter.home_timeline();`,
+        `now => [count] of count(@com.twitter.home_timeline) => notify;`,
+        `count(@com.twitter.home_timeline);`
     ],
 
     [
-        `now => [text] of (([text, author] of @com.twitter.home_timeline()), text =~ "lol") => notify;`,
-        `[text] of @com.twitter.home_timeline() filter text =~ "lol";`
+        `now => [text] of [text, author] of @com.twitter.home_timeline => notify;`,
+        `[text] of @com.twitter.home_timeline;`,
     ],
 
     [
-        `monitor ([text, author] of @com.twitter.home_timeline()) => notify;`,
-        `[text, author] of monitor(text, author of @com.twitter.home_timeline());`
+        `now => [text] of (([text, author] of @com.twitter.home_timeline), text =~ "lol") => notify;`,
+        `[text] of @com.twitter.home_timeline filter text =~ "lol";`
     ],
 
     [
-        `monitor (text of [text, author] of @com.twitter.home_timeline()) => notify;`,
-        `[text, author] of monitor(text of @com.twitter.home_timeline());`
+        `monitor ([text, author] of @com.twitter.home_timeline) => notify;`,
+        `[text, author] of monitor(text, author of @com.twitter.home_timeline);`
     ],
 
     [
-        `monitor ([text, author] of @com.twitter.home_timeline()) => @com.twitter.post(status=text);`,
-        `monitor(text, author of @com.twitter.home_timeline()) => @com.twitter.post(status=text);`
+        `monitor (text of [text, author] of @com.twitter.home_timeline) => notify;`,
+        `[text, author] of monitor(text of @com.twitter.home_timeline);`
     ],
 
     [
-        `monitor (@com.twitter.home_timeline()), author == "bob"^^tt:username || author == "charlie"^^tt:username => notify;`,
-        `monitor(@com.twitter.home_timeline()) filter in_array(author, ["bob"^^tt:username, "charlie"^^tt:username]);`
+        `monitor ([text, author] of @com.twitter.home_timeline) => @com.twitter.post(status=text);`,
+        `monitor(text, author of @com.twitter.home_timeline) => @com.twitter.post(status=text);`
     ],
 
     [
-        `monitor (@com.twitter.home_timeline(), author == "bob"^^tt:username || author == "charlie"^^tt:username) => notify;`,
-        `monitor(@com.twitter.home_timeline() filter in_array(author, ["bob"^^tt:username, "charlie"^^tt:username]));`
+        `monitor (@com.twitter.home_timeline), author == "bob"^^tt:username || author == "charlie"^^tt:username => notify;`,
+        `monitor(@com.twitter.home_timeline) filter in_array(author, ["bob"^^tt:username, "charlie"^^tt:username]);`
     ],
 
     [
-        `now => @org.schema.full.Restaurant(), id =~ "starbucks" || id =~ "mcdonalds" => notify;`,
-        `@org.schema.full.Restaurant() filter in_array~(id, ["starbucks", "mcdonalds"]);`
+        `monitor (@com.twitter.home_timeline, author == "bob"^^tt:username || author == "charlie"^^tt:username) => notify;`,
+        `monitor(@com.twitter.home_timeline filter in_array(author, ["bob"^^tt:username, "charlie"^^tt:username]));`
     ],
 
     [
-        `now => @org.schema.restaurant(), 500mi >= distance(geo, $location.current_location) => notify;`,
-        `@org.schema.restaurant() filter distance(geo, $location.current_location) <= 500mi;`
+        `now => @org.schema.full.Restaurant, id =~ "starbucks" || id =~ "mcdonalds" => notify;`,
+        `@org.schema.full.Restaurant filter in_array~(id, ["starbucks", "mcdonalds"]);`
     ],
 
     [
-        `now => @org.schema.restaurant(), 1 == 1 => notify;`,
-        `@org.schema.restaurant();`
+        `now => @org.schema.restaurant, 500mi >= distance(geo, $location.current_location) => notify;`,
+        `@org.schema.restaurant filter distance(geo, $location.current_location) <= 500mi;`
     ],
 
     [
-        `now => @org.schema.restaurant(), 1 >= 1 => notify;`,
-        `@org.schema.restaurant();`
+        `now => @org.schema.restaurant, 1 == 1 => notify;`,
+        `@org.schema.restaurant;`
     ],
 
     [
-        `now => @org.schema.restaurant(), geo == geo => notify;`,
-        `@org.schema.restaurant();`
+        `now => @org.schema.restaurant, 1 >= 1 => notify;`,
+        `@org.schema.restaurant;`
+    ],
+
+    [
+        `now => @org.schema.restaurant, geo == geo => notify;`,
+        `@org.schema.restaurant;`
     ],
 
     [
 `$dialogue @org.thingpedia.dialogue.transaction.execute;
-now => [food] of ((@uk.ac.cam.multiwoz.Restaurant.Restaurant()), true) => notify
+now => [food] of ((@uk.ac.cam.multiwoz.Restaurant.Restaurant), true) => notify
 #[results=[
   { id="str:ENTITY_uk.ac.cam.multiwoz.Restaurant:Restaurant::0:"^^uk.ac.cam.multiwoz.Restaurant:Restaurant, food="str:QUOTED_STRING::9:", price_range=enum moderate, area=enum south },
   { id="str:ENTITY_uk.ac.cam.multiwoz.Restaurant:Restaurant::1:"^^uk.ac.cam.multiwoz.Restaurant:Restaurant, food="str:QUOTED_STRING::25:", price_range=enum moderate, area=enum centre },
@@ -129,7 +129,7 @@ now => [food] of ((@uk.ac.cam.multiwoz.Restaurant.Restaurant()), true) => notify
 #[count=50]
 #[more=true];`,
 `$dialogue @org.thingpedia.dialogue.transaction.execute;
-[food] of @uk.ac.cam.multiwoz.Restaurant.Restaurant()
+[food] of @uk.ac.cam.multiwoz.Restaurant.Restaurant
 #[results=[
   { id="str:ENTITY_uk.ac.cam.multiwoz.Restaurant:Restaurant::0:"^^uk.ac.cam.multiwoz.Restaurant:Restaurant, food="str:QUOTED_STRING::9:", price_range=enum moderate, area=enum south },
   { id="str:ENTITY_uk.ac.cam.multiwoz.Restaurant:Restaurant::1:"^^uk.ac.cam.multiwoz.Restaurant:Restaurant, food="str:QUOTED_STRING::25:", price_range=enum moderate, area=enum centre },
@@ -148,136 +148,136 @@ now => [food] of ((@uk.ac.cam.multiwoz.Restaurant.Restaurant()), true) => notify
 
     [`
 $dialogue @org.thingpedia.dialogue.transaction.execute;
-now => [distance(geo, $location.current_location)] of @com.yelp.restaurant() => notify
+now => [distance(geo, $location.current_location)] of @com.yelp.restaurant => notify
 #[results=[
 { distance=1.5604449514735575e-9 },
 { distance=0 }
 ]];
 `,
     `$dialogue @org.thingpedia.dialogue.transaction.execute;
-[distance(geo, $location.current_location)] of @com.yelp.restaurant()
+[distance(geo, $location.current_location)] of @com.yelp.restaurant
 #[results=[
   { distance=1.5604449514735575e-9 },
   { distance=0 }
 ]];`],
 
-    [`monitor (@com.twitter.home_timeline(), text =~ "foo" || (text =~"bar" && !(text =~ "lol"))) => notify;`,
-     `monitor(@com.twitter.home_timeline() filter !(text =~ "lol") && text =~ "bar" || text =~ "foo");`
+    [`monitor (@com.twitter.home_timeline, text =~ "foo" || (text =~"bar" && !(text =~ "lol"))) => notify;`,
+     `monitor(@com.twitter.home_timeline filter !(text =~ "lol") && text =~ "bar" || text =~ "foo");`
     ],
 
-    [`now => [aggregateRating.ratingValue] of (sort(distance(geo, new Location("foo")) asc of @org.schema.restaurant(), name =~ $context.selection : String)[1]) => notify;`,
-    `[aggregateRating.ratingValue] of sort(distance(geo, new Location("foo")) asc of @org.schema.restaurant() filter name =~ $context.selection : String)[1];`
+    [`now => [aggregateRating.ratingValue] of (sort(distance(geo, new Location("foo")) asc of @org.schema.restaurant, name =~ $context.selection : String)[1]) => notify;`,
+    `[aggregateRating.ratingValue] of sort(distance(geo, new Location("foo")) asc of @org.schema.restaurant filter name =~ $context.selection : String)[1];`
     ],
 
     // remove redundant * projection
-    [`[*] of @com.yelp.restaurant() => notify;`,
-     `@com.yelp.restaurant();`],
+    [`[*] of @com.yelp.restaurant => notify;`,
+     `@com.yelp.restaurant;`],
 
     // remove redundant * projection
-    [`[distance(geo, $location.current_location)] of [*] of @com.yelp.restaurant() => notify;`,
-     `[distance(geo, $location.current_location)] of @com.yelp.restaurant();`],
+    [`[distance(geo, $location.current_location)] of [*] of @com.yelp.restaurant => notify;`,
+     `[distance(geo, $location.current_location)] of @com.yelp.restaurant;`],
 
     // remove redundant projection
-    [`[distance(geo, $location.current_location)] of [geo] of @com.yelp.restaurant() => notify;`,
-     `[distance(geo, $location.current_location)] of @com.yelp.restaurant();`],
+    [`[distance(geo, $location.current_location)] of [geo] of @com.yelp.restaurant => notify;`,
+     `[distance(geo, $location.current_location)] of @com.yelp.restaurant;`],
 
     // remove redundant computation
-    [`[distance(geo, $location.current_location)] of [*, distance(geo, $location.current_location)] of @com.yelp.restaurant() => notify;`,
-     `[distance(geo, $location.current_location)] of @com.yelp.restaurant();`],
+    [`[distance(geo, $location.current_location)] of [*, distance(geo, $location.current_location)] of @com.yelp.restaurant => notify;`,
+     `[distance(geo, $location.current_location)] of @com.yelp.restaurant;`],
 
-    [`[*, distance(geo, $location.current_location)] of [*, distance(geo, $location.current_location)] of @com.yelp.restaurant() => notify;`,
-     `[*, distance(geo, $location.current_location)] of @com.yelp.restaurant();`],
+    [`[*, distance(geo, $location.current_location)] of [*, distance(geo, $location.current_location)] of @com.yelp.restaurant => notify;`,
+     `[*, distance(geo, $location.current_location)] of @com.yelp.restaurant;`],
 
-    [`[*, distance(geo, $location.current_location)] of [distance(geo, $location.current_location)] of @com.yelp.restaurant() => notify;`,
-     `[distance(geo, $location.current_location)] of @com.yelp.restaurant();`],
+    [`[*, distance(geo, $location.current_location)] of [distance(geo, $location.current_location)] of @com.yelp.restaurant => notify;`,
+     `[distance(geo, $location.current_location)] of @com.yelp.restaurant;`],
 
     // remove shadowed computation
-    [`[distance(geo, $location.current_location)] of [*, distance(geo, $location.home)] of @com.yelp.restaurant() => notify;`,
-     `[distance(geo, $location.current_location)] of @com.yelp.restaurant();`],
+    [`[distance(geo, $location.current_location)] of [*, distance(geo, $location.home)] of @com.yelp.restaurant => notify;`,
+     `[distance(geo, $location.current_location)] of @com.yelp.restaurant;`],
 
     // collapse invisible compuations
-    [`[distance(geo, $location.current_location)] of [*, rating + 2] of @com.yelp.restaurant() => notify;`,
-     `[distance(geo, $location.current_location)] of @com.yelp.restaurant();`],
+    [`[distance(geo, $location.current_location)] of [*, rating + 2] of @com.yelp.restaurant => notify;`,
+     `[distance(geo, $location.current_location)] of @com.yelp.restaurant;`],
 
     // collapse invisible computations
-    [`[distance(geo, $location.current_location)] of [geo, rating + 2] of @com.yelp.restaurant() => notify;`,
-     `[distance(geo, $location.current_location)] of @com.yelp.restaurant();`],
+    [`[distance(geo, $location.current_location)] of [geo, rating + 2] of @com.yelp.restaurant => notify;`,
+     `[distance(geo, $location.current_location)] of @com.yelp.restaurant;`],
 
     // collapse the use of the result
-    [`[geo, distance(geo, $location.current_location), result] of [geo, rating + 2] of @com.yelp.restaurant() => notify;`,
-     `[geo, distance(geo, $location.current_location), rating + 2] of @com.yelp.restaurant();`],
+    [`[geo, distance(geo, $location.current_location), result] of [geo, rating + 2] of @com.yelp.restaurant => notify;`,
+     `[geo, distance(geo, $location.current_location), rating + 2] of @com.yelp.restaurant;`],
 
     // preserve variable dependencies
-    [`[result + 2] of [rating + 2] of @com.yelp.restaurant() => notify;`,
-     `[result + 2] of [*, rating + 2] of @com.yelp.restaurant();`],
+    [`[result + 2] of [rating + 2] of @com.yelp.restaurant => notify;`,
+     `[result + 2] of [*, rating + 2] of @com.yelp.restaurant;`],
 
-    [`[result + 2] of [result + 2] of [rating + 2] of @com.yelp.restaurant() => notify;`,
-     `[result + 2] of [*, result + 2] of [*, rating + 2] of @com.yelp.restaurant();`],
+    [`[result + 2] of [result + 2] of [rating + 2] of @com.yelp.restaurant => notify;`,
+     `[result + 2] of [*, result + 2] of [*, rating + 2] of @com.yelp.restaurant;`],
 
     // preserve variable dependencies, with alias
-    [`[foo + 2] of [rating + 2 as foo] of @com.yelp.restaurant() => notify;`,
-     `[foo + 2] of [*, rating + 2 as foo] of @com.yelp.restaurant();`],
+    [`[foo + 2] of [rating + 2 as foo] of @com.yelp.restaurant => notify;`,
+     `[foo + 2] of [*, rating + 2 as foo] of @com.yelp.restaurant;`],
 
     // shadow, with alias
-    [`[rating + 2 as foo] of [*, rating + 3 as foo] of @com.yelp.restaurant() => notify;`,
-     `[rating + 2 as foo] of @com.yelp.restaurant();`],
+    [`[rating + 2 as foo] of [*, rating + 3 as foo] of @com.yelp.restaurant => notify;`,
+     `[rating + 2 as foo] of @com.yelp.restaurant;`],
 
-    [`[rating + 2 as foo] of [rating, rating + 3 as foo] of @com.yelp.restaurant() => notify;`,
-     `[rating + 2 as foo] of @com.yelp.restaurant();`],
+    [`[rating + 2 as foo] of [rating, rating + 3 as foo] of @com.yelp.restaurant => notify;`,
+     `[rating + 2 as foo] of @com.yelp.restaurant;`],
 
-    [`[*, rating + 2 as foo] of [rating, rating + 3 as foo] of @com.yelp.restaurant() => notify;`,
-     `[rating, rating + 2 as foo] of @com.yelp.restaurant();`],
+    [`[*, rating + 2 as foo] of [rating, rating + 3 as foo] of @com.yelp.restaurant => notify;`,
+     `[rating, rating + 2 as foo] of @com.yelp.restaurant;`],
 
-    [`[*, rating + 2 as foo] of [*, rating + 3 as foo] of @com.yelp.restaurant() => notify;`,
-     `[*, rating + 2 as foo] of @com.yelp.restaurant();`],
+    [`[*, rating + 2 as foo] of [*, rating + 3 as foo] of @com.yelp.restaurant => notify;`,
+     `[*, rating + 2 as foo] of @com.yelp.restaurant;`],
 
     // remove redundant projection at the top
-    [`[result] of [rating + 2] of @com.yelp.restaurant();`,
-     `[rating + 2] of @com.yelp.restaurant();`],
+    [`[result] of [rating + 2] of @com.yelp.restaurant;`,
+     `[rating + 2] of @com.yelp.restaurant;`],
 
     // remove redundant projection at the top, with alias
-    [`[foo] of [rating + 2 as foo] of @com.yelp.restaurant();`,
-     `[rating + 2 as foo] of @com.yelp.restaurant();`],
+    [`[foo] of [rating + 2 as foo] of @com.yelp.restaurant;`,
+     `[rating + 2 as foo] of @com.yelp.restaurant;`],
 
-    [`sort(distance asc of [distance(geo, $location.current_location)] of @com.yelp.restaurant());`,
-     `[distance(geo, $location.current_location)] of sort(distance(geo, $location.current_location) asc of @com.yelp.restaurant());`],
+    [`sort(distance asc of [distance(geo, $location.current_location)] of @com.yelp.restaurant);`,
+     `[distance(geo, $location.current_location)] of sort(distance(geo, $location.current_location) asc of @com.yelp.restaurant);`],
 
-    [`sort(distance asc of [*, distance(geo, $location.current_location)] of @com.yelp.restaurant());`,
-     `[*, distance(geo, $location.current_location)] of sort(distance(geo, $location.current_location) asc of @com.yelp.restaurant());`],
+    [`sort(distance asc of [*, distance(geo, $location.current_location)] of @com.yelp.restaurant);`,
+     `[*, distance(geo, $location.current_location)] of sort(distance(geo, $location.current_location) asc of @com.yelp.restaurant);`],
 
-    [`[distance(geo, $location.current_location)] of sort(distance asc of [distance(geo, $location.current_location)] of @com.yelp.restaurant());`,
-     `[distance(geo, $location.current_location)] of sort(distance(geo, $location.current_location) asc of @com.yelp.restaurant());`],
+    [`[distance(geo, $location.current_location)] of sort(distance asc of [distance(geo, $location.current_location)] of @com.yelp.restaurant);`,
+     `[distance(geo, $location.current_location)] of sort(distance(geo, $location.current_location) asc of @com.yelp.restaurant);`],
 
-    [`[distance(geo, $location.current_location)] of sort(distance asc of [*, distance(geo, $location.current_location)] of @com.yelp.restaurant());`,
-     `[distance(geo, $location.current_location)] of sort(distance(geo, $location.current_location) asc of @com.yelp.restaurant());`],
+    [`[distance(geo, $location.current_location)] of sort(distance asc of [*, distance(geo, $location.current_location)] of @com.yelp.restaurant);`,
+     `[distance(geo, $location.current_location)] of sort(distance(geo, $location.current_location) asc of @com.yelp.restaurant);`],
 
     // projection of chain to chain of projection
-    [`[link] of (@com.washingtonpost.get_article() => @com.bing.web_search(query=title));`,
-    `@com.washingtonpost.get_article() => [link] of @com.bing.web_search(query=title);`],
+    [`[link] of (@com.washingtonpost.get_article => @com.bing.web_search(query=title));`,
+    `@com.washingtonpost.get_article => [link] of @com.bing.web_search(query=title);`],
 
     // nested chains
-    [`(@com.bing.web_search() => @com.yandex.translate.translate(text=title)) => @com.twitter.post(status=translated_text);`,
-    `@com.bing.web_search() => @com.yandex.translate.translate(text=title) => @com.twitter.post(status=translated_text);`],
+    [`(@com.bing.web_search => @com.yandex.translate.translate(text=title)) => @com.twitter.post(status=translated_text);`,
+    `@com.bing.web_search => @com.yandex.translate.translate(text=title) => @com.twitter.post(status=translated_text);`],
 
     // remove redundant device ID
-    ['@com.yelp(id="com.yelp").restaurant();',
-     '@com.yelp.restaurant();'],
+    ['@com.yelp(id="com.yelp").restaurant;',
+     '@com.yelp.restaurant;'],
 
     // remove redundant device ID
-    ['@com.yelp(id="com.yelp", name="Yelp").restaurant();',
-     '@com.yelp.restaurant();'],
+    ['@com.yelp(id="com.yelp", name="Yelp").restaurant;',
+     '@com.yelp.restaurant;'],
 
     // remove redundant device ID
-    ['@com.yelp(id="com.yelp"^^tt:device_id("Yelp")).restaurant();',
-     '@com.yelp.restaurant();'],
+    ['@com.yelp(id="com.yelp"^^tt:device_id("Yelp")).restaurant;',
+     '@com.yelp.restaurant;'],
 
     // flip filters
-    ['@org.schema.full.Place() filter count(review) >= aggregateRating.ratingValue;',
-     '@org.schema.full.Place() filter aggregateRating.ratingValue <= count(review);'],
+    ['@org.schema.full.Place filter count(review) >= aggregateRating.ratingValue;',
+     '@org.schema.full.Place filter aggregateRating.ratingValue <= count(review);'],
 
     // __const is a VarRef, but it should not be moved to the left
-    ['@org.schema.full.Place() filter count(review) >= __const_NUMBER_0;',
-     '@org.schema.full.Place() filter count(review) >= __const_NUMBER_0;']
+    ['@org.schema.full.Place filter count(review) >= __const_NUMBER_0;',
+     '@org.schema.full.Place filter count(review) >= __const_NUMBER_0;']
 ];
 
 

--- a/test/test_permissions.js
+++ b/test/test_permissions.js
@@ -42,16 +42,16 @@ const TEST_CASES = [
     [`now => @com.facebook.post(status="this is totally not funny");`, null],
 
     [`now => @com.twitter.search(), text =~ "funny lol" => @com.facebook.post(status=text);`,
-     `@com.twitter.search() filter text =~ "funny lol" => @com.facebook.post(status=text);`],
+     `@com.twitter.search filter text =~ "funny lol" => @com.facebook.post(status=text);`],
 
     [`now => @com.twitter.search() => @com.facebook.post(status=text);`,
-     `@com.twitter.search() filter in_array~(text, ["https://www.wsj.com", "https://www.washingtonpost.com"]) || text =~ "funny" && text =~ "lol" => @com.facebook.post(status=text);`],
+     `@com.twitter.search filter in_array~(text, ["https://www.wsj.com", "https://www.washingtonpost.com"]) || text =~ "funny" && text =~ "lol" => @com.facebook.post(status=text);`],
 
     [`now => @com.bing.web_search(query="cats") => @com.facebook.post(status=description);`,
      `@com.bing.web_search(query="cats") filter description =~ "funny" && description =~ "lol" || in_array~(description, ["https://www.wsj.com", "https://www.washingtonpost.com"]) || description =~ "cat" => @com.facebook.post(status=description);`],
 
     [`monitor(@security-camera.current_event(), has_person == true) => notify;`,
-    `monitor(@security-camera.current_event() filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps() filter location == new Location(1, 2)) && has_person == true);`],
+    `monitor(@security-camera.current_event filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps filter location == new Location(1, 2)) && has_person == true);`],
 
     // the program should be rejected because there is no rule that allows builtin.get_gps()
     [`monitor (@security-camera.current_event(), (has_person == true && any(@org.thingpedia.builtin.thingengine.builtin.get_gps(), location == new Location(1, 2))))  => notify;`,
@@ -60,7 +60,7 @@ const TEST_CASES = [
     [`now => @org.thingpedia.builtin.thingengine.builtin.get_gps() => notify;`, null],
 
     [`now => @thermostat.get_temperature() => notify;`,
-     `@thermostat.get_temperature() filter any(@com.xkcd.get_comic(number=10) filter title =~ "lol");`],
+     `@thermostat.get_temperature filter any(@com.xkcd.get_comic(number=10) filter title =~ "lol");`],
 
     // this test case does not work because we add the filter outside as stream filter which no longer exists
     //[`attimer(time=[new Time(10,30)]) => @thermostat.get_temperature() => notify;`,
@@ -87,7 +87,7 @@ const TEST_CASES = [
               in req location : Location)
   #[minimal_projection=[]];
 }
-@com.instagram.get_pictures() filter caption =~ "trip" => @__dyn_0.send(__flow=0, __kindChannel=$type, __principal="matrix-account:@rayx6:matrix.org"^^tt:contact, __program_id=$program_id, caption=caption, filter_=filter_, hashtags=hashtags, link=link, location=location, media_id=media_id, picture_url=picture_url);`]
+@com.instagram.get_pictures filter caption =~ "trip" => @__dyn_0.send(__flow=0, __kindChannel=$type, __principal="matrix-account:@rayx6:matrix.org"^^tt:contact, __program_id=$program_id, caption=caption, filter_=filter_, hashtags=hashtags, link=link, location=location, media_id=media_id, picture_url=picture_url);`]
 
     /*[`monitor @thermostat.get_temperature(), @com.xkcd.get_comic(number=10) { title =~ "lol" }  => notify;`,
     `@thermostat.temperature(), @xkcd.get_comic(number=10) { title =~ "lol" }  => notify;`],

--- a/test/test_prettyprint.js
+++ b/test/test_prettyprint.js
@@ -66,12 +66,12 @@ const TEST_CASES = [
 }`,
 
 // aggregate filter
-`@org.schema.restaurant() filter count(review) >= 1;`,
+`@org.schema.restaurant filter count(review) >= 1;`,
 
 // compute table
-`[count(reviews)] of @org.schema.restaurants();`,
-`[aggregateRating.reviews filter author == "Bob"] of @org.schema.restaurants();`,
-`[aggregateRating.reviews filter author == "Bob" as foo] of @org.schema.restaurants();`,
+`[count(reviews)] of @org.schema.restaurants;`,
+`[aggregateRating.reviews filter author == "Bob"] of @org.schema.restaurants;`,
+`[aggregateRating.reviews filter author == "Bob" as foo] of @org.schema.restaurants;`,
 
 // device selectors
 `@light-bulb(name="bathroom").set_power(power=enum on);`,
@@ -80,10 +80,10 @@ const TEST_CASES = [
 
 `dataset @everything
 #[language="en"] {
-  query = @org.thingpedia.rss(all=true).get_post()
+  query = @org.thingpedia.rss(all=true).get_post
   #_[utterances=["all rss feeds"]];
 
-  query (p_name : String) = @org.thingpedia.rss(name=p_name).get_post()
+  query (p_name : String) = @org.thingpedia.rss(name=p_name).get_post
   #_[utterances=["$p_name rss feed"]];
 }`,
 ];

--- a/test/test_runtime.js
+++ b/test/test_runtime.js
@@ -2455,7 +2455,7 @@ some alt text` }
     { type: 'output',
       outputType: 'org.wikidata:query',
       value: {
-        query: '@org.wikidata.city() filter id =~ "palo alto";'
+        query: '@org.wikidata.city filter id =~ "palo alto";'
       }
     }]],
 
@@ -2471,7 +2471,7 @@ some alt text` }
     {
         type: 'action',
         fn: 'com.twitter:post',
-        params: { status: '@org.wikidata.city() filter postal_code =~ "94305";' }
+        params: { status: '@org.wikidata.city filter postal_code =~ "94305";' }
     }]],
 ];
 

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -1840,3 +1840,7 @@ now => @com.facebook.post();
 ====
 
 @org.schema.full.Place() filter count(review) >= __const_NUMBER_0;
+
+====
+
+@org.schema.full.Place filter count(review) >= __const_NUMBER_0;

--- a/tools/generate-parser/slr_generator.ts
+++ b/tools/generate-parser/slr_generator.ts
@@ -684,9 +684,9 @@ export class SLRParserGenerator {
 
                             const printed = new Set<number>();
                             this._recursivePrintItemSet(itemSet.info.id, printed);
-                            if (existing[0] === 'shift')
-                                console.log(`WARNING: ignored shift-reduce conflict at state ${itemSet.info.id} terminal ${term} want ${["reduce", ruleId]} have ${existing}`);
-                            else
+                            //if (existing[0] === 'shift')
+                            //    console.log(`WARNING: ignored shift-reduce conflict at state ${itemSet.info.id} terminal ${term} want ${["reduce", ruleId]} have ${existing}`);
+                            //else
                                 throw new Error(`Conflict for state ${itemSet.info.id} terminal ${term} want ${["reduce", ruleId]} have ${existing}`);
                         } else {
                             this.actionTable[itemSet.info.id][term] = ['reduce', ruleId];


### PR DESCRIPTION
The old NN syntax did not have parenthesis around parameters at
all, so now the semantic parser is forced to predict a pair of
parenthesis, which is redundant in the common case of KBQA (queries
as tables, no input parameters). This commit makes it so that
empty parenthesis can be omitted altogether.