### PR TITLE
[AL1-14] Implement entity inheritance

### DIFF
--- a/lib/entity-retriever.ts
+++ b/lib/entity-retriever.ts
@@ -275,6 +275,15 @@ export class EntityRetriever extends AbstractEntityRetriever {
         if (ignoreNotFound)
             return null;
 
+        if (entityType.startsWith('GENERIC_ENTITY_') && this._syntaxType === SyntaxType.Tokenized) {
+            const genericEntity = entity as GenericEntity;
+            if (genericEntity.display) {
+                found = this._findEntityInBag('QUOTED_STRING', genericEntity.display, this.entities);
+                if (found)
+                    return List.concat('null', '^^' + entityType.substring('GENERIC_ENTITY_'.length), '(', found, ')');
+            }
+        }
+
         found = this._findStringLikeEntity(entityType, entity, entityString, false);
         if (found)
             return found;

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -318,9 +318,9 @@ class_member = v:(function_def / import_mixin_stmt / entity_def_stmt) _ { return
 import_mixin_stmt = 'import' __ first:ident _ rest:(',' _ ident _)* 'from' __ name:class_name _ in_params:input_param_list _ ';' {
   return new Ast.MixinImportStmt(location(), [first].concat(take(rest, 2)), name, in_params);
 }
-entity_def_stmt = 'entity' __ name:ident annotations: (_ annotation _)* ';' _ {
+entity_def_stmt = 'entity' __ name:ident _extends:(__ 'extends' __ (ident / entity_type))? annotations: (_ annotation _)* ';' _ {
   const [nl_annotations, impl_annotations] = splitAnnotations(annotations);
-  return new Ast.EntityDef(location(), name, { nl:nl_annotations, impl:impl_annotations });
+  return new Ast.EntityDef(location(), name, _extends ? _extends[3] : null, { nl:nl_annotations, impl:impl_annotations });
 }
 
 function_name_list = first:ident _ rest:(',' _ ident _)* {

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -557,10 +557,22 @@ class_stmt : Ast.ClassMember = {
         => new Ast.MixinImportStmt($.location, facets, name.value, in_param_list);
 
     'entity' name:variable_name ';'
-        => new Ast.EntityDef($.location, name, {});
+        => new Ast.EntityDef($.location, name, null, {});
 
     'entity' name:variable_name annotations:annotation_spec ';'
-        => new Ast.EntityDef($.location, name, annotations);
+        => new Ast.EntityDef($.location, name, null, annotations);
+
+    'entity' name:variable_name 'extends' _extends:variable_name ';'
+        => new Ast.EntityDef($.location, name, _extends, {});
+
+    'entity' name:variable_name 'extends' _extends:variable_name annotations:annotation_spec ';'
+        => new Ast.EntityDef($.location, name, _extends, annotations);
+
+    'entity' name:variable_name 'extends' _extends:ENTITY_NAME ';'
+        => new Ast.EntityDef($.location, name, _extends.value, {});
+
+    'entity' name:variable_name 'extends' _extends:ENTITY_NAME annotations:annotation_spec ';'
+        => new Ast.EntityDef($.location, name, _extends.value, annotations);
 
     fntype:function_type_decl name:function_name args:decl_param_list ';' => {
         const [functionType, is_list, is_monitorable] = fntype;

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -630,10 +630,16 @@ export default class SchemaRetriever {
                 for (const entity of classDef.entities) {
                     if (entity.name === name) {
                         const hasNer = entity.getImplementationAnnotation<boolean>('has_ner');
+                        let subTypeOf = null;
+                        if (entity.extends) {
+                            subTypeOf = entity.extends.includes(':') ? entity.extends
+                                : classDef.kind + ':' + entity.extends;
+                        }
                         const newRecord : EntityTypeRecord = {
                             type: entityType,
                             is_well_known: false,
-                            has_ner_support: hasNer === undefined ? true : hasNer
+                            has_ner_support: hasNer === undefined ? true : hasNer,
+                            subtype_of : subTypeOf
                         };
                         this._entityTypeCache.set(entityType, newRecord);
                         return newRecord;

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -136,10 +136,10 @@ export default abstract class Type implements Hashable<Type> {
         return type;
     }
 
-    static isAssignable(type : Type, assignableTo : Type|string, typeScope : TypeScope = {}, lenient = false) : boolean {
+    static isAssignable(type : Type, assignableTo : Type|string, typeScope : TypeScope = {}) : boolean {
         if (typeof assignableTo === 'string') {
             if (typeScope[assignableTo])
-                return Type.isAssignable(type, typeScope[assignableTo] as Type, typeScope, lenient);
+                return Type.isAssignable(type, typeScope[assignableTo] as Type, typeScope);
             typeScope[assignableTo] = type;
             return true;
         }
@@ -181,34 +181,28 @@ export default abstract class Type implements Hashable<Type> {
                     return true;
 
                 if (typeScope[assignableTo.elem])
-                    return Type.isAssignable(type.elem, typeScope[assignableTo.elem] as Type, typeScope, lenient);
+                    return Type.isAssignable(type.elem, typeScope[assignableTo.elem] as Type, typeScope);
                 typeScope[assignableTo.elem] = type.elem;
                 return true;
             }
             if (typeof type.elem === 'string') {
                 if (typeScope[type.elem])
-                    return Type.isAssignable(typeScope[type.elem] as Type, assignableTo.elem, typeScope, lenient);
+                    return Type.isAssignable(typeScope[type.elem] as Type, assignableTo.elem, typeScope);
                 typeScope[type.elem] = assignableTo.elem;
                 return true;
             }
             if (type.elem.isAny)
                 return true;
-            if (Type.isAssignable(type.elem, assignableTo.elem, typeScope, lenient))
+            if (Type.isAssignable(type.elem, assignableTo.elem, typeScope))
                 return true;
         }
         if (type instanceof ArrayType) {
             if (typeof type.elem === 'string')
                 return false;
             if (assignableTo instanceof EntityType && assignableTo.type === 'tt:contact_group')
-                return Type.isAssignable(type.elem, new Type.Entity('tt:contact'), typeScope, lenient);
+                return Type.isAssignable(type.elem, new Type.Entity('tt:contact'), typeScope);
         }
 
-        if (lenient && type.isEntity && assignableTo.isString)
-            return true;
-        if (lenient && type.isString && assignableTo.isEntity) {
-            //console.log('Using String for ' + assignableTo + ' is deprecated');
-            return true;
-        }
         if (type instanceof EnumType && assignableTo instanceof EnumType) {
             if (type.entries === null)
                 return true;

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -520,13 +520,6 @@ function arrayEquals(a : unknown[]|null, b : unknown[]|null) : boolean {
 }
 
 function entitySubType(type : string, assignableTo : string) : boolean {
-    if (type === 'tt:username' || type === 'tt:contact_name') {
-        return assignableTo === 'tt:phone_number' ||
-            assignableTo === 'tt:email_address' ||
-            assignableTo === 'tt:contact';
-    }
-    if (type === 'tt:contact_group_name')
-        return assignableTo === 'tt:contact_group';
     if (type === 'tt:picture_url')
         return assignableTo === 'tt:url';
     return false;

--- a/lib/typecheck.ts
+++ b/lib/typecheck.ts
@@ -29,6 +29,7 @@ import * as Ast from './ast';
 import Type, {
     TypeMap,
     TypeScope,
+    EntitySubTypeMap,
     EnumType,
     ArrayType,
     CompoundType,
@@ -194,12 +195,35 @@ export default class TypeChecker {
     private _schemas : SchemaRetriever;
     private _classes : ClassMap;
     private _useMeta : boolean;
+    private _entitySubTypeMap : EntitySubTypeMap;
 
     constructor(schemas : SchemaRetriever,
                 useMeta = false) {
         this._schemas = schemas;
         this._useMeta = useMeta;
         this._classes = {};
+        this._entitySubTypeMap = {};
+    }
+
+    private async _ensureEntitySubTypes(entityType : string) {
+        if (this._entitySubTypeMap[entityType] !== undefined)
+            return;
+
+        const parent = await this._schemas.getEntityParent(entityType);
+        this._entitySubTypeMap[entityType] = parent;
+        if (parent)
+            await this._ensureEntitySubTypes(parent);
+    }
+
+    private async _isAssignable(type : Type,
+                                assignableTo : Type|string,
+                                typeScope : TypeScope) {
+        if (type instanceof Type.Entity)
+            await this._ensureEntitySubTypes(type.type);
+        if (assignableTo instanceof Type.Entity)
+            await this._ensureEntitySubTypes(assignableTo.type);
+
+        return Type.isAssignable(type, assignableTo, typeScope, this._entitySubTypeMap);
     }
 
     private async _typeCheckValue(value : Ast.Value,
@@ -209,7 +233,7 @@ export default class TypeChecker {
                 return value.type;
 
             const operands = await Promise.all(value.operands.map((o) => this._typeCheckValue(o, scope)));
-            const [overload, resultType] = this._resolveScalarExpressionOps(value.op, operands);
+            const [overload, resultType] = await this._resolveScalarExpressionOps(value.op, operands);
 
             value.overload = overload;
             return value.type = resultType;
@@ -320,7 +344,7 @@ export default class TypeChecker {
                     }
                 }
 
-                if (!Type.isAssignable(vtype, elem, typeScope))
+                if (!await this._isAssignable(vtype, elem, typeScope))
                     throw new TypeError(`Inconsistent type for array value`);
             }
 
@@ -342,16 +366,16 @@ export default class TypeChecker {
             throw new TypeError(`Invalid principal ${principal}, must be a contact or a group`);
     }
 
-    private _resolveOverload(overloads : Builtin.OpDefinition,
-                             operator : string,
-                             argTypes : Type[]) : [Type[], Type] {
+    private async _resolveOverload(overloads : Builtin.OpDefinition,
+                                   operator : string,
+                                   argTypes : Type[]) : Promise<[Type[], Type]> {
         for (const overload of overloads.types) {
             if (argTypes.length !== overload.length-1)
                 continue;
             const typeScope : TypeScope = {};
             let good = true;
             for (let i = 0; i < argTypes.length; i++) {
-                if (!Type.isAssignable(argTypes[i], overload[i], typeScope)) {
+                if (!await this._isAssignable(argTypes[i], overload[i], typeScope)) {
                     good = false;
                     break;
                 }
@@ -376,12 +400,12 @@ export default class TypeChecker {
         return this._resolveOverload(op, operator, argTypes);
     }
 
-    private _resolveFilterOverload(type_lhs : Type, operator : string, type_rhs : Type) {
+    private async _resolveFilterOverload(type_lhs : Type, operator : string, type_rhs : Type) {
         log('resolve filter overload');
         const op = Builtin.BinaryOps[operator];
         if (!op)
             throw new TypeError('Invalid operator ' + operator);
-        const [overload,] = this._resolveOverload(op, operator, [type_lhs, type_rhs]);
+        const [overload,] = await this._resolveOverload(op, operator, [type_lhs, type_rhs]);
         return overload;
     }
 
@@ -429,14 +453,14 @@ export default class TypeChecker {
             if (!type_lhs)
                 type_lhs = await this._typeCheckValue(new Ast.Value.VarRef(name), scope);
             const type_rhs = await this._typeCheckValue(ast.value, scope);
-            ast.overload = this._resolveFilterOverload(type_lhs, ast.operator, type_rhs);
+            ast.overload = await this._resolveFilterOverload(type_lhs, ast.operator, type_rhs);
             return;
         }
 
         if (ast instanceof Ast.ComputeBooleanExpression) {
             const type_lhs = await this._typeCheckValue(ast.lhs, scope);
             const type_rhs = await this._typeCheckValue(ast.rhs, scope);
-            ast.overload = this._resolveFilterOverload(type_lhs, ast.operator, type_rhs);
+            ast.overload = await this._resolveFilterOverload(type_lhs, ast.operator, type_rhs);
             return;
         }
 
@@ -449,10 +473,10 @@ export default class TypeChecker {
         await this._typeCheckFilterHelper(ast.filter, ast.schema, scope);
     }
 
-    private _resolveAggregationOverload(ast : Ast.AggregationTable|Ast.AggregationExpression,
-                                        operator : string,
-                                        field : string,
-                                        schema : Ast.FunctionDef) {
+    private async _resolveAggregationOverload(ast : Ast.AggregationTable|Ast.AggregationExpression,
+                                              operator : string,
+                                              field : string,
+                                              schema : Ast.FunctionDef) {
         const fieldType = schema.out[field];
         if (!fieldType)
             throw new TypeError('Invalid aggregation field ' + field);
@@ -462,7 +486,7 @@ export default class TypeChecker {
 
         for (const overload of ag.types) {
             const typeScope = {};
-            if (!Type.isAssignable(fieldType, overload[0], typeScope))
+            if (!await this._isAssignable(fieldType, overload[0], typeScope))
                 continue;
 
             ast.overload = overload.map((t) => resolveTypeVars(t, typeScope));
@@ -472,7 +496,7 @@ export default class TypeChecker {
         throw new TypeError('Invalid field type ' + fieldType + ' for ' + operator);
     }
 
-    private _typeCheckAggregation(ast : Ast.AggregationTable|Ast.AggregationExpression, scope : Scope) {
+    private async _typeCheckAggregation(ast : Ast.AggregationTable|Ast.AggregationExpression, scope : Scope) {
         const schema = (ast instanceof Ast.AggregationExpression ? ast.expression.schema : ast.table.schema)!;
 
         let name, type, nl_annotations;
@@ -484,7 +508,7 @@ export default class TypeChecker {
             name = ast.alias ? ast.alias : 'count';
             nl_annotations = { canonical: 'count' };
         } else {
-            type = this._resolveAggregationOverload(ast, ast.operator, ast.field, schema);
+            type = await this._resolveAggregationOverload(ast, ast.operator, ast.field, schema);
             name = ast.alias ? ast.alias : ast.field;
             nl_annotations = schema.getArgument(ast.field)!.nl_annotations;
         }
@@ -510,16 +534,16 @@ export default class TypeChecker {
         if (ast.indices.length === 1) {
             const valueType = await this._typeCheckValue(ast.indices[0], scope);
             if (valueType.isArray) {
-                if (!Type.isAssignable(valueType, new Type.Array(Type.Number)))
+                if (!await this._isAssignable(valueType, new Type.Array(Type.Number), {}))
                     throw new TypeError(`Invalid index parameter, must be of type Array(Number)`);
             } else {
-                if (!Type.isAssignable(valueType, Type.Number))
+                if (!await this._isAssignable(valueType, Type.Number, {}))
                     throw new TypeError(`Invalid index parameter, must be a Number`);
             }
         } else {
             for (const index of ast.indices) {
                 const valueType = await this._typeCheckValue(index, scope);
-                if (!Type.isAssignable(valueType, Type.Number))
+                if (!await this._isAssignable(valueType, Type.Number, {}))
                     throw new TypeError(`Invalid index parameter, must be a Number`);
             }
         }
@@ -530,9 +554,9 @@ export default class TypeChecker {
     private async _typeCheckSlice(ast : Ast.SlicedTable|Ast.SliceExpression, scope : Scope) {
         const baseType = await this._typeCheckValue(ast.base, scope);
         const limitType = await this._typeCheckValue(ast.limit, scope);
-        if (!Type.isAssignable(baseType, Type.Number))
+        if (!await this._isAssignable(baseType, Type.Number, {}))
             throw new TypeError(`Invalid slice offset parameter, must be a Number`);
-        if (!Type.isAssignable(limitType, Type.Number))
+        if (!await this._isAssignable(limitType, Type.Number, {}))
             throw new TypeError(`Invalid slice limit parameter, must be a Number`);
 
         ast.schema = ast instanceof Ast.SliceExpression ? ast.expression.schema : ast.table.schema;
@@ -676,7 +700,7 @@ export default class TypeChecker {
                 if (!attr.value.isVarRef && !attr.value.isConstant())
                     throw new TypeError(`Device attribute ${attr.value} must be a constant or variable`);
                 const valueType = await this._typeCheckValue(attr.value, attrscope);
-                if (!Type.isAssignable(valueType, Type.String) || attr.value.isUndefined)
+                if (!await this._isAssignable(valueType, Type.String, {}) || attr.value.isUndefined)
                     throw new TypeError(`Invalid type for device attribute ${attr.name}, have ${valueType}, need String`);
             }
 
@@ -702,7 +726,7 @@ export default class TypeChecker {
                 throw new TypeError('Invalid input parameter ' + inParam.name);
 
             const valueType = await this._typeCheckValue(inParam.value, scope);
-            if (!Type.isAssignable(valueType, inParamType))
+            if (!await this._isAssignable(valueType, inParamType, {}))
                 throw new TypeError(`Invalid type for parameter ${inParam.name}, have ${valueType}, need ${inParamType}`);
             if (presentParams.has(inParam.name))
                 throw new TypeError('Duplicate input param ' + inParam.name);
@@ -755,7 +779,7 @@ export default class TypeChecker {
         } else if (ast instanceof Ast.AggregationExpression) {
             await this._typeCheckExpression(ast.expression, scope);
             this._checkExpressionType(ast.expression, ['query'], 'aggregation');
-            this._typeCheckAggregation(ast, scope);
+            await this._typeCheckAggregation(ast, scope);
         } else if (ast instanceof Ast.SortExpression) {
             await this._typeCheckExpression(ast.expression, scope);
             this._checkExpressionType(ast.expression, ['query'], 'sort');
@@ -884,7 +908,7 @@ export default class TypeChecker {
                 throw new TypeError(`Mixin parameter ${in_param.name} must be a constant`);
             const inParamType = mixin.types[i];
             const valueType = await this._typeCheckValue(in_param.value, new Scope);
-            if (!Type.isAssignable(valueType, inParamType))
+            if (!await this._isAssignable(valueType, inParamType, {}))
                 throw new TypeError(`Invalid type for parameter ${in_param.name}, have ${valueType}, need ${inParamType}`);
         }
         for (let i = 0; i < mixin.args.length; i ++ ) {
@@ -1019,7 +1043,7 @@ export default class TypeChecker {
                 if (!value)
                     continue;
 
-                if (!Type.isAssignable(await this._typeCheckValue(value, new Scope), arg.type))
+                if (!await this._isAssignable(await this._typeCheckValue(value, new Scope), arg.type, {}))
                     throw new TypeError(`Invalid #[${name}] annotation: must be a ${arg.type}`);
             }
         }
@@ -1267,7 +1291,7 @@ export default class TypeChecker {
 
             if (item.results !== null) {
                 if (!item.results.count.isConstant() ||
-                    !Type.isAssignable(await this._typeCheckValue(item.results.count, new Scope), Type.Number))
+                    !await this._isAssignable(await this._typeCheckValue(item.results.count, new Scope), Type.Number, {}))
                     throw new TypeError(`History annotation #[count] must be a constant of Number type`);
                 if (item.results.error) {
                     if (!item.results.error.isConstant())

--- a/lib/typecheck.ts
+++ b/lib/typecheck.ts
@@ -467,7 +467,7 @@ export default class TypeChecker {
         if (ast instanceof Ast.ComparisonSubqueryBooleanExpression) {
             const type_lhs = await this._typeCheckValue(ast.lhs, scope);
             const type_rhs = await this._typeCheckSubqueryValue(ast.rhs, scope);
-            ast.overload = this._resolveFilterOverload(type_lhs, ast.operator, type_rhs);
+            ast.overload = await this._resolveFilterOverload(type_lhs, ast.operator, type_rhs);
             return;
         }
 

--- a/test/entities.json
+++ b/test/entities.json
@@ -732,6 +732,19 @@
       "name": "Username",
       "is_well_known": 1,
       "has_ner_support": 0
+    },
+    {
+      "type": "tt:test_entity_subtype1",
+      "name": "Test Entity Subtype 1",
+      "is_well_known": 0,
+      "has_ner_support": 0,
+      "subtype_of": "tt:test_entity_parenttype1"
+    },
+    {
+      "type": "tt:test_entity_parenttype1",
+      "name": "Test Entity ParentType 1",
+      "is_well_known": 0,
+      "has_ner_support": 0
     }
   ]
 }

--- a/test/test_compiler.js
+++ b/test/test_compiler.js
@@ -994,7 +994,9 @@ const TEST_CASES = [
   }`]],
 
     // 20
-    [`monitor(@com.twitter.home_timeline()) => @org.thingpedia.builtin.thingengine.builtin.say(message=$type);`,
+    // this used to be a different program
+    // it is left here to avoid changing numbers
+    [`monitor(@com.twitter.home_timeline()) => @org.thingpedia.builtin.thingengine.builtin.say(message=$result);`,
     [`"use strict";
   let _t_0;
   let _t_1;
@@ -1037,7 +1039,7 @@ const TEST_CASES = [
         if (_t_13) {
           try {
             _t_15 = {};
-            _t_16 = String (_t_4);
+            _t_16 = await __env.formatEvent(_t_4, _t_5, "string");
             _t_15.message = _t_16;
             await __builtin.drainAction(__env.invokeAction("org.thingpedia.builtin.thingengine.builtin", { }, "say", _t_15));
           } catch(_exc_) {
@@ -1054,7 +1056,7 @@ const TEST_CASES = [
   }`]],
 
     // 21
-    [`monitor(@com.xkcd(id="com.xkcd-6").get_comic()) => @com.twitter.post(status=picture_url);`,
+    [`monitor(@com.xkcd(id="com.xkcd-6").get_comic()) => @com.twitter.post(status=title);`,
     [`"use strict";
   let _t_0;
   let _t_1;
@@ -1071,11 +1073,10 @@ const TEST_CASES = [
   let _t_12;
   let _t_13;
   let _t_14;
-  let _t_15;
   _t_0 = await __env.readState(0);
   try {
     _t_1 = {};
-    _t_2 = await __env.invokeMonitor("com.xkcd", { id: "com.xkcd-6", }, "get_comic", _t_1, { projection: ["picture_url", "title", "link", "alt_text"] });
+    _t_2 = await __env.invokeMonitor("com.xkcd", { id: "com.xkcd-6", }, "get_comic", _t_1, { projection: ["title", "picture_url", "link", "alt_text"] });
     {
       let _iter_tmp = await _t_2.next();
       while (!_iter_tmp.done) {
@@ -1095,8 +1096,7 @@ const TEST_CASES = [
         if (_t_12) {
           try {
             _t_14 = {};
-            _t_15 = String (_t_9);
-            _t_14.status = _t_15;
+            _t_14.status = _t_8;
             await __builtin.drainAction(__env.invokeAction("com.twitter", { }, "post", _t_14));
           } catch(_exc_) {
             __env.reportError("Failed to invoke action", _exc_);
@@ -6546,7 +6546,7 @@ const TEST_CASES = [
   }`]],
 
     // 77 computation (+)
-    [`now => [("Author: " + author)] of @com.twitter.home_timeline() => notify;`,
+    [`now => [("Text: " + text)] of @com.twitter.home_timeline() => notify;`,
     [`"use strict";
   let _t_0;
   let _t_1;
@@ -6568,7 +6568,7 @@ const TEST_CASES = [
   try {
     try {
       _t_0 = {};
-      _t_1 = await __env.invokeQuery("com.twitter", { }, "home_timeline", _t_0, { projection: ["result", "author"] });
+      _t_1 = await __env.invokeQuery("com.twitter", { }, "home_timeline", _t_0, { projection: ["result", "text"] });
       _t_2 = __builtin.getAsyncIterator(_t_1);
       {
         let _iter_tmp = await _t_2.next();
@@ -6583,8 +6583,8 @@ const TEST_CASES = [
           _t_10 = _t_5.author;
           _t_11 = _t_5.in_reply_to;
           _t_12 = _t_5.tweet_id;
-          _t_13 = "Author: ";
-          _t_14 = _t_13 + _t_10;
+          _t_13 = "Text: ";
+          _t_14 = _t_13 + _t_7;
           _t_5.result = _t_14;
           _t_15 = {};
           _t_15.result = _t_14;
@@ -7215,7 +7215,7 @@ const TEST_CASES = [
       // FIXME
       //now => cat() => @com.twitter.post_picture(picture_url=picture_url, caption="cat");
       now => cat() => notify;
-      @com.twitter.post_picture(picture_url="http://foo", caption="cat");
+      @com.twitter.post_picture(picture_url="http://foo"^^tt:picture, caption="cat");
     }
     // FIXME this does not work for some reason
     //let cat2 = cat_and_twitter();
@@ -7247,6 +7247,7 @@ const TEST_CASES = [
   let _t_21;
   let _t_22;
   let _t_23;
+  let _t_24;
   await __env.enterProcedure(0, "cat_and_twitter");
   try {
     _t_0 = new Array(0);
@@ -7300,8 +7301,9 @@ const TEST_CASES = [
       _t_21 = {};
       _t_22 = "cat";
       _t_21.caption = _t_22;
-      _t_23 = "http://foo";
-      _t_21.picture_url = _t_23;
+      _t_23 = new __builtin.Entity("http://foo", null);
+      _t_24 = String (_t_23);
+      _t_21.picture_url = _t_24;
       await __builtin.drainAction(__env.invokeAction("com.twitter", { }, "post_picture", _t_21));
     } catch(_exc_) {
       __env.reportError("Failed to invoke action", _exc_);

--- a/test/test_legacy_nn_syntax.js
+++ b/test/test_legacy_nn_syntax.js
@@ -183,18 +183,6 @@ const TEST_CASES = [
   true : now => @com.twitter.post filter status =~ "foo";
 }`],
 
-    [`policy param:source:Entity(tt:contact) == USERNAME_0 : now => @com.twitter.post`,
-    `USERNAME_0 can post on twitter`, { USERNAME_0: 'bob' },
-    `$policy {
-  $source == "bob"^^tt:username : now => @com.twitter.post;
-}`],
-
-    [`policy param:source:Entity(tt:contact) == USERNAME_0 : now => @com.twitter.post filter param:status:String =~ QUOTED_STRING_0`,
-    `USERNAME_0 can post on twitter if he puts QUOTED_STRING_0 in the status`, { USERNAME_0: 'bob', QUOTED_STRING_0: 'foo' },
-    `$policy {
-  $source == "bob"^^tt:username : now => @com.twitter.post filter status =~ "foo";
-}`],
-
     [`policy true : @com.bing.web_search => notify`,
     `anyone can search on bing`, {},
     `$policy {

--- a/test/test_legacy_syntax.tt
+++ b/test/test_legacy_syntax.tt
@@ -83,21 +83,6 @@ executor = "matrix-account:@gcampax:matrix.org"^^tt:contact : { // WithPrincipal
 
 ====
 
-// DownCast
-{
-    monitor @com.xkcd(id="com.xkcd-6").get_comic()
-    => @com.twitter.post(status=picture_url);
-}
-
-====
-
-// EventType
-{
-    monitor @com.twitter.home_timeline() => @org.thingpedia.builtin.thingengine.builtin.say(message=$event.type);
-}
-
-====
-
 // FormatEvent
 {
     monitor @com.twitter.home_timeline() => @org.thingpedia.builtin.thingengine.builtin.say(message=$event);
@@ -294,7 +279,6 @@ monitor @com.twitter.home_timeline() => notify;
 
 // PhoneNumberTest
 {
-    now => @org.thingpedia.builtin.thingengine.phone.send_sms(to="+15555555555", message="");
     now => @org.thingpedia.builtin.thingengine.phone.send_sms(to="+15555555555"^^tt:phone_number, message="");
     monitor @org.thingpedia.builtin.thingengine.phone.sms(), sender=="+15555555555"^^tt:phone_number => notify;
 }

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -156,16 +156,16 @@ const TEST_CASES = [
   true : now => @com.twitter.post filter status =~ "foo";
 }`],
 
-    [`$policy { $source == USERNAME_0 : now => @com.twitter . post ; }`,
-    `USERNAME_0 can post on twitter`, { USERNAME_0: 'bob' },
+    [`$policy { $source == null ^^tt:contact ( QUOTED_STRING_0 ) : now => @com.twitter . post ; }`,
+    `QUOTED_STRING_0 can post on twitter`, { QUOTED_STRING_0: 'bob' },
     `$policy {
-  $source == "bob"^^tt:username : now => @com.twitter.post;
+  $source == null^^tt:contact("bob") : now => @com.twitter.post;
 }`],
 
-    [`$policy { $source == USERNAME_0 : now => @com.twitter . post filter status =~ QUOTED_STRING_0 ; }`,
-    `USERNAME_0 can post on twitter if he puts QUOTED_STRING_0 in the status`, { USERNAME_0: 'bob', QUOTED_STRING_0: 'foo' },
+    [`$policy { $source == null ^^tt:contact ( QUOTED_STRING_0 ) : now => @com.twitter . post filter status =~ QUOTED_STRING_1 ; }`,
+    `QUOTED_STRING_0 can post on twitter if he puts QUOTED_STRING_1 in the status`, { QUOTED_STRING_0: 'bob', QUOTED_STRING_1: 'foo' },
     `$policy {
-  $source == "bob"^^tt:username : now => @com.twitter.post filter status =~ "foo";
+  $source == null^^tt:contact("bob") : now => @com.twitter.post filter status =~ "foo";
 }`],
 
     [`$policy { true : @com.bing . web_search => notify ; }`,

--- a/test/test_nn_syntax_allocator.js
+++ b/test/test_nn_syntax_allocator.js
@@ -90,8 +90,8 @@ const TEST_CASES = [
     [`#[ executor = USERNAME_0 ] @com.twitter . post ( ) ;`,
      { USERNAME_0: 'bob' }],
 
-    [`$policy { $source == USERNAME_0 : now => @com.twitter . post filter status =~ QUOTED_STRING_0 ; }`,
-     { USERNAME_0: 'bob', QUOTED_STRING_0: 'foo' }],
+    [`$policy { $source == GENERIC_ENTITY_tt:contact_0 : now => @com.twitter . post filter status =~ QUOTED_STRING_0 ; }`,
+     { 'GENERIC_ENTITY_tt:contact_0': { value: 'bob', display: 'bob' }, QUOTED_STRING_0: 'foo' }],
 
     [`@org.thingpedia.weather . sunrise ( date = DATE_0 ) ;`,
      { DATE_0: new Date(2018, 5, 23, 0, 0, 0) }],

--- a/test/test_runtime.js
+++ b/test/test_runtime.js
@@ -231,49 +231,6 @@ const TEST_CASES = [
     }
     ]],
 
-    [`now => @com.xkcd.get_comic() => @com.twitter.post(status=$program_id);`,
-    null,
-    { 'com.xkcd:get_comic': [
-        { number: 1234, title: 'Douglas Engelbart (1925-2013)',
-          link: 'https://xkcd.com/1234/',
-          picture_url: 'https://imgs.xkcd.com/comics/douglas_engelbart_1925_2013.png',
-          alt_text: 'some alt text' }
-    ]},
-    [
-    {
-     type: 'action',
-     fn: 'com.twitter:post',
-     params: { status: `uuid-XXXXXXXXXXXX` }
-    }
-    ]],
-
-    [`now => @com.xkcd.get_comic() => @com.twitter.post(status=$type);`,
-    null,
-    { 'com.xkcd:get_comic': [
-        { number: 1234, title: 'Douglas Engelbart (1925-2013)',
-          link: 'https://xkcd.com/1234/',
-          picture_url: 'https://imgs.xkcd.com/comics/douglas_engelbart_1925_2013.png',
-          alt_text: 'some alt text' }
-    ]},
-    [
-    {
-     type: 'action',
-     fn: 'com.twitter:post',
-     params: { status: `com.xkcd:get_comic` }
-    }
-    ]],
-
-    [`now => @com.twitter.post(status=$program_id);`,
-    null,
-    {},
-    [
-    {
-     type: 'action',
-     fn: 'com.twitter:post',
-     params: { status: `uuid-XXXXXXXXXXXX` }
-    }
-    ]],
-
     [`monitor(@com.xkcd.get_comic()) => @com.twitter.post(status=title);`,
     { fn: 'com.xkcd:get_comic',
       value: [

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -1836,3 +1836,23 @@ now => @com.facebook.post();
 ====
 
 @org.schema.full.Place() filter count(review) >= __const_NUMBER_0;
+
+====
+
+// Entity subtyping
+@com.test.entitysubtype1.parent(), id == "foo"^^tt:test_entity_subtype1;
+@com.test.entitysubtype1.stuff(), contains(stuff, "foo"^^tt:test_entity_subtype1);
+@com.test.entitysubtype1.foo(param="foo"^^tt:test_entity_subtype1);
+@com.test.entitysubtype1.sub() => @com.test.entitysubtype1.foo(param=id);
+
+====
+
+// Entity subtyping
+// ** expect TypeError **
+@com.test.entitysubtype1.sub(), id == "foo"^^tt:test_entity_parenttype1;
+
+====
+
+// Entity subtyping
+// ** expect TypeError **
+@com.test.entitysubtype1.sub(), "foo"^^tt:test_entity_parenttype1 == id;

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -1856,3 +1856,11 @@ now => @com.facebook.post();
 // Entity subtyping
 // ** expect TypeError **
 @com.test.entitysubtype1.sub(), "foo"^^tt:test_entity_parenttype1 == id;
+
+====
+
+// Entity subtyping
+@com.test.entitysubtype2.parent(), id == "foo"^^com.test.entitysubtype2:sub;
+@com.test.entitysubtype2.stuff(), contains(stuff, "foo"^^com.test.entitysubtype2:sub);
+@com.test.entitysubtype2.foo(param="foo"^^com.test.entitysubtype2:sub);
+@com.test.entitysubtype2.sub() => @com.test.entitysubtype2.foo(param=id);

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -103,14 +103,6 @@ monitor(@com.twitter.home_timeline() filter starts_with(text, "foo"));
 @com.twitter.post_picture(caption="lol", picture_url="http://foo.com/bar.jpg"^^tt:picture);
 ====
 
-// DownCast
-monitor(@com.xkcd(id="com.xkcd-6"^^tt:device_id).get_comic()) => @com.twitter.post(status=picture_url);
-====
-
-// EventType
-monitor(@com.twitter.home_timeline()) => @org.thingpedia.builtin.thingengine.builtin.say(message=$type);
-====
-
 // FormatEvent
 monitor(@com.twitter.home_timeline()) => @org.thingpedia.builtin.thingengine.builtin.say(message=$result);
 ====
@@ -308,7 +300,6 @@ attimer(time=[$time.morning]);
 ====
 
 // PhoneNumberTest
-@org.thingpedia.builtin.thingengine.phone.send_sms(to="+15555555555", message="");
 @org.thingpedia.builtin.thingengine.phone.send_sms(to="+15555555555"^^tt:phone_number, message="");
 monitor(@org.thingpedia.builtin.thingengine.phone.sms() filter sender == "+15555555555"^^tt:phone_number);
 ====

--- a/test/thingpedia.tt
+++ b/test/thingpedia.tt
@@ -5328,3 +5328,14 @@ class @com.test.entitysubtype1 {
 
   action foo(in req param : Entity(tt:test_entity_parenttype1));
 }
+
+class @com.test.entitysubtype2 {
+  entity parent;
+  entity sub extends parent;
+
+  query sub(out id : Entity(com.test.entitysubtype2:sub));
+  query parent(out id : Entity(com.test.entitysubtype2:parent));
+  query stuff(out stuff : Array(Entity(com.test.entitysubtype2:parent)));
+
+  action foo(in req param : Entity(com.test.entitysubtype2:parent));
+}

--- a/test/thingpedia.tt
+++ b/test/thingpedia.tt
@@ -5320,3 +5320,11 @@ class @uk.ac.cam.multiwoz.Train
      no_slot_available=["there are no seats available on ${train}"]
   }];
 }
+
+class @com.test.entitysubtype1 {
+  query sub(out id : Entity(tt:test_entity_subtype1));
+  query parent(out id : Entity(tt:test_entity_parenttype1));
+  query stuff(out stuff : Array(Entity(tt:test_entity_parenttype1)));
+
+  action foo(in req param : Entity(tt:test_entity_parenttype1));
+}


### PR DESCRIPTION
Entity inheritance (subtyping) is the ability to declare that a certain custom entity type is assignable to another entity type.
The syntax is the obvious one: `entity foo extends bar;`

This feature is needed for MultiWOZ to convert everything from strings to entities (which fixes some issues in generating cross-domain coreferences and fixes requoting MultiWOZ datasets), because the taxi action needs to take in a place that can be a restaurant name, an hotel name, or an attraction name.
It is also needed for Spotify, because we want song and album to be both assignable to a parameter of play().

Entity inheritance combines nicely with function inheritance: if two queries inherit from each other, they should also declare the type of their `id` parameters as subtypes.