### PR TITLE
[AL1-18] Make $context values non-compilable, and support nested keys

### DIFF
--- a/lib/ast/values.ts
+++ b/lib/ast/values.ts
@@ -986,7 +986,9 @@ export class ContextRefValue extends Value {
     }
 
     toSource() : TokenStream {
-        return List.concat('$context', '.', this.name, ':', this.type.toSource());
+        return List.concat('$context', '.',
+            List.join(this.name.split('.').map((n) => List.singleton(n)), '.'),
+            ':', this.type.toSource());
     }
 
     toString() : string {
@@ -1008,6 +1010,10 @@ export class ContextRefValue extends Value {
     }
 
     isConstant() : boolean {
+        return false;
+    }
+
+    isConcrete() : boolean {
         return false;
     }
 

--- a/lib/compiler/jsir.ts
+++ b/lib/compiler/jsir.ts
@@ -267,20 +267,6 @@ class LoadConstant {
     }
 }
 
-class LoadContext {
-    private _context : Ast.ContextRefValue;
-    private _into : Register;
-
-    constructor(context : Ast.ContextRefValue, into : Register) {
-        this._context = context;
-        this._into = into;
-    }
-
-    codegen(prefix : string) : string {
-        return prefix + '_t_' + this._into + ` = await __env.loadContext("${this._context.name}", "${this._context.type.toString()}");`;
-    }
-}
-
 class LoadBuiltin {
     private _builtin : string;
     private _into : Register;
@@ -1179,7 +1165,6 @@ export {
     GetScope,
     AsyncIterator,
     LoadConstant,
-    LoadContext,
     LoadBuiltin,
     NewObject,
     BinaryFunctionOp,

--- a/lib/compiler/ops-to-jsir.ts
+++ b/lib/compiler/ops-to-jsir.ts
@@ -218,12 +218,6 @@ export default class OpCompiler {
             return result;
         }
 
-        if (ast instanceof Ast.ContextRefValue) {
-            const reg = this._irBuilder.allocRegister();
-            this._irBuilder.add(new JSIr.LoadContext(ast, reg));
-            return reg;
-        }
-
         if (ast instanceof Ast.ArrayValue) {
             const array = this._irBuilder.allocRegister();
             this._irBuilder.add(new JSIr.CreateTuple(ast.value.length, array));

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -856,7 +856,7 @@ location_value = ('makeLocation' / 'new' __ 'Location') _ '(' _ lat:literal_numb
     return new Ast.Value.Location(new Ast.Location.Relative(ctx));
 }
 
-context_value = '$context' _ '.' _ name:ident _ ':' _ type:type_ref _ {
+context_value = '$context' _ '.' _ name:qualified_name _ ':' _ type:type_ref _ {
     return new Ast.Value.ContextRef(name, type);
 }
 

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -1277,7 +1277,7 @@ event_value : Ast.EventValue = {
 }
 
 context_value : Ast.ContextRefValue = {
-    '$context' '.' name:variable_name type:type_annot => new Ast.Value.ContextRef(name, type);
+    '$context' '.' name:qualified_name type:type_annot => new Ast.Value.ContextRef(name, type);
 }
 
 array_value : Ast.ArrayValue = {

--- a/lib/runtime/exec_environment.ts
+++ b/lib/runtime/exec_environment.ts
@@ -153,10 +153,6 @@ export default abstract class ExecEnvironment {
     reportError(message : string, err : Error) : Promise<void> {
         throw new Error('Must be overridden');
     }
-    /* istanbul ignore next */
-    loadContext(info : string, into : string) : Promise<unknown> {
-        throw new Error('Must be overridden');
-    }
 
     formatEvent(outputType : string, output : PlainObject, hint : string) : Promise<string> {
         throw new Error('Must be overridden');

--- a/test/test_compiler.js
+++ b/test/test_compiler.js
@@ -6488,8 +6488,9 @@ const TEST_CASES = [
     await __env.exitProcedure(0, null);
   }`]],
 
-    // 74 Test screen selection as a context
-    [`now => @com.twitter.post(status=$context.selection: String);`,
+    // 74 Used to be "Test screen selection as a context"
+    // Left here to preserve the numbering
+    [`now => @com.twitter.post(status="foo");`,
     [`"use strict";
   let _t_0;
   let _t_1;
@@ -6497,7 +6498,7 @@ const TEST_CASES = [
   try {
     try {
       _t_0 = {};
-      _t_1 = await __env.loadContext("selection", "String");
+      _t_1 = "foo";
       _t_0.status = _t_1;
       await __builtin.drainAction(__env.invokeAction("com.twitter", { }, "post", _t_0));
     } catch(_exc_) {

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -1845,3 +1845,11 @@ now => @com.facebook.post();
 ====
 
 @org.schema.full.Place() filter count(review) >= __const_NUMBER_0;
+
+====
+
+// $context.result
+
+$dialogue @org.thingpedia.dialogue.transaction.execute;
+@com.thecatapi.get();
+@com.twitter.post_picture(picture_url=$context.result.picture_url : Entity(tt:picture));


### PR DESCRIPTION
$context values are placeholders for future values. Making
them non-compilable means I can (need to) replace them in
the dialogue agent before execution.

This commit makes $context.result suitable to represent
non-default parameter passing across multiple dialogue turns.

Example: "search a website then post the title on twitter"
can be split into:
```
@com.bing.web_search();
@com.twitter.post(status=$context.result.title : String);
```
to be stored in the dialogue state.

The semantics of this are that the dialogue agent executes
the first command, and presents the result to the user.
The dialogue agent remembers that the user wanted to post the title
on Twitter, and this is preserved across slot-filling of the
query and search refinements, so when the agent offers
"do you want to post it on twitter", or when the user says
"ok now post it on twitter", the right parameter passing occurs.

I thought about using `$result` instead of `$context.result` but
`$result` already means "a string representation of the current
result" (the old `$event` in ThingTalk 1.0) and overloading the
meaning was awkward. Plus we need type annotations to typecheck
the individual dialogue turns without looking at the context.

Note that the new semantics are also more correct for `$context.selection`
(the selection on the screen), because that one also should be
resolved once and for all when the program is started, and not
delayed until the action is invoked, potentially much later.