### PR TITLE
SchemaRetriever: another attempt at retrieving the right entity record

### DIFF
--- a/lib/typecheck.ts
+++ b/lib/typecheck.ts
@@ -206,6 +206,8 @@ export default class TypeChecker {
     }
 
     private async _ensureEntitySubTypes(entityType : string) {
+        if (!entityType)
+            return;
         if (this._entitySubTypeMap[entityType] !== undefined)
             return;
 


### PR DESCRIPTION
entities.json cannot be trusted for entities that are defined in
classes, if classes are overridden locally.