### PR TITLE
Add support for existential subquery

### DIFF
--- a/lib/ast/base.ts
+++ b/lib/ast/base.ts
@@ -23,7 +23,7 @@ import NodeVisitor from './visitor';
 
 import type {
     Invocation,
-    ExternalBooleanExpression,
+    ExternalBooleanExpression
 } from './expression';
 import type { Value } from './values';
 import type {

--- a/lib/ast/expression.ts
+++ b/lib/ast/expression.ts
@@ -24,7 +24,7 @@ import Node, { SourceRange } from './base';
 import NodeVisitor from './visitor';
 import { FunctionDef } from './function_def';
 import { Value } from './values';
-import { Expression } from './expression2';
+import { Expression, FilterExpression, InvocationExpression } from './expression2';
 
 import Type from '../type';
 import * as Optimizer from '../optimize';
@@ -963,6 +963,21 @@ export class ExistentialSubqueryBooleanExpression extends BooleanExpression {
 
     toString() : string {
         return `ExistentialSubquery(${this.subquery})`;
+    }
+
+    toLegacy() : ExternalBooleanExpression|null {
+        if (this.subquery instanceof FilterExpression && this.subquery.expression instanceof InvocationExpression) {
+            const invocation = this.subquery.expression.invocation;
+            return new ExternalBooleanExpression(
+                null,
+                invocation.selector,
+                invocation.channel,
+                invocation.in_params,
+                this.subquery.filter,
+                this.subquery.schema
+            );
+        }
+        return null;
     }
 
     equals(other : BooleanExpression) : boolean {

--- a/lib/ast/visitor.ts
+++ b/lib/ast/visitor.ts
@@ -270,6 +270,10 @@ export default abstract class NodeVisitor {
     visitComparisonSubqueryBooleanExpression(node : Exp.ComparisonSubqueryBooleanExpression) : boolean {
         return true;
     }
+    /* istanbul ignore next */
+    visitExistentialSubqueryBooleanExpression(node : Exp.ExistentialSubqueryBooleanExpression) : boolean {
+        return true;
+    }
 
 
 

--- a/lib/compiler/ast-to-ops.ts
+++ b/lib/compiler/ast-to-ops.ts
@@ -770,6 +770,13 @@ function compileBooleanExpressionToOp(expr : Ast.BooleanExpression) : BooleanExp
         );
     }
 
+    if (expr instanceof Ast.ExistentialSubqueryBooleanExpression) {
+        return new BooleanExpressionOp.ExistentialSubquery(
+            expr,
+            compileTableToOps(expr.subquery.toLegacy() as Ast.Table, [], new QueryInvocationHints(new Set))
+        );
+    }
+
     if (expr instanceof Ast.ComparisonSubqueryBooleanExpression) {
         assert(expr.rhs instanceof Ast.ProjectionExpression && expr.rhs.args.length + expr.rhs.computations.length === 1);
         let rhs, hints;

--- a/lib/compiler/ops-to-jsir.ts
+++ b/lib/compiler/ops-to-jsir.ts
@@ -306,6 +306,20 @@ export default class OpCompiler {
 
             this._irBuilder.popBlock(); // for-of
             this._irBuilder.popBlock(); // try-catch
+        } else if (expr instanceof Ops.ExistentialSubqueryBooleanExpressionOp) {
+            this._irBuilder.add(new JSIr.LoadConstant(new Ast.Value.Boolean(false), cond));
+
+            const blockStack = this._irBuilder.saveStackState();
+            const tmpScope = this._currentScope;
+
+            this._compileTable(expr.subquery);
+
+            this._irBuilder.add(new JSIr.LoadConstant(new Ast.Value.Boolean(true), cond));
+            this._irBuilder.add(new JSIr.Break());
+            this._irBuilder.popBlock();
+
+            this._currentScope = tmpScope;
+            this._irBuilder.popTo(blockStack);
         } else if (expr instanceof Ops.ComparisonSubqueryBooleanExpressionOp) {
             this._irBuilder.add(new JSIr.LoadConstant(new Ast.Value.Boolean(false), cond));
 

--- a/lib/compiler/ops.ts
+++ b/lib/compiler/ops.ts
@@ -353,6 +353,7 @@ export abstract class BooleanExpressionOp {
     static Not : typeof NotBooleanExpressionOp;
     static Atom : typeof AtomBooleanExpressionOp;
     static External : typeof ExternalBooleanExpressionOp;
+    static ExistentialSubquery : typeof ExistentialSubqueryBooleanExpressionOp;
     static ComparisonSubquery : typeof ComparisonSubqueryBooleanExpressionOp;
     static True : TrueBooleanExpressionOp;
     static False : FalseBooleanExpressionOp;
@@ -411,6 +412,14 @@ export class ExternalBooleanExpressionOp extends BooleanExpressionOp {
     }
 }
 BooleanExpressionOp.External = ExternalBooleanExpressionOp;
+
+export class ExistentialSubqueryBooleanExpressionOp extends BooleanExpressionOp {
+    constructor(ast : Ast.ExistentialSubqueryBooleanExpression,
+                public subquery : TableOp) {
+        super(ast);
+    }
+}
+BooleanExpressionOp.ExistentialSubquery = ExistentialSubqueryBooleanExpressionOp;
 
 export class ComparisonSubqueryBooleanExpressionOp extends BooleanExpressionOp {
     constructor(ast : Ast.ComparisonSubqueryBooleanExpression,

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -645,7 +645,15 @@ executable_statement = body:rule_body _ ';' {
 
 get_predicate = fn:thingpedia_function_name _ in_params:input_param_list _ '{' _ filter:or_expr _ '}' {
     let [selector, function_name] = fn;
-    return new Ast.BooleanExpression.External(location(), selector, function_name, in_params, filter, null);
+    const invocation = new Ast.Invocation(location(), selector, function_name, in_params, null);
+    return new Ast.BooleanExpression.ExistentialSubquery(
+        location(),
+        new Ast.FilterExpression(
+            location(),
+            new Ast.InvocationExpression(location(), invocation, null),
+            filter
+        )
+    );
 }
 
 function_style_predicate = fn:$(ident '~'? / '~' ident) _ '(' _ lhs:qualified_name _ ',' _ rhs:value _ ')' !'(' {

--- a/lib/legacy-prettyprint.ts
+++ b/lib/legacy-prettyprint.ts
@@ -22,7 +22,6 @@ import assert from 'assert';
 import { stringEscape } from './utils/escaping';
 import * as Ast from './ast';
 import Type, { ArrayType, CompoundType } from './type';
-import { UnserializableError } from "./utils/errors";
 
 function prettyprintType(ast : Type, prefix='') : string {
     if (ast instanceof ArrayType) {
@@ -207,14 +206,8 @@ function prettyprintFilterExpression(ast : Ast.BooleanExpression) : string {
         return prettyprintExternalFilter(ast);
     if (ast instanceof Ast.ComputeBooleanExpression)
         return `${prettyprintValue(ast.lhs)} ${ast.operator} ${prettyprintValue(ast.rhs)}`;
-    if (ast instanceof Ast.ComparisonSubqueryBooleanExpression)
-        throw new UnserializableError('Comparison Subquery');
-    if (ast instanceof Ast.ExistentialSubqueryBooleanExpression) {
-        const externalEquivalent = ast.toLegacy();
-        if (externalEquivalent)
-            return prettyprintExternalFilter(externalEquivalent);
-        throw new UnserializableError('Existential Subquery');
-    }
+    if (ast instanceof Ast.ComparisonSubqueryBooleanExpression || ast instanceof Ast.ExistentialSubqueryBooleanExpression)
+        return prettyprintExternalFilter(ast.toLegacy());
     assert(ast instanceof Ast.AtomBooleanExpression);
 
     if (INFIX_FILTERS.has(ast.operator))

--- a/lib/legacy-prettyprint.ts
+++ b/lib/legacy-prettyprint.ts
@@ -22,6 +22,7 @@ import assert from 'assert';
 import { stringEscape } from './utils/escaping';
 import * as Ast from './ast';
 import Type, { ArrayType, CompoundType } from './type';
+import { UnserializableError } from "./utils/errors";
 
 function prettyprintType(ast : Type, prefix='') : string {
     if (ast instanceof ArrayType) {
@@ -206,6 +207,14 @@ function prettyprintFilterExpression(ast : Ast.BooleanExpression) : string {
         return prettyprintExternalFilter(ast);
     if (ast instanceof Ast.ComputeBooleanExpression)
         return `${prettyprintValue(ast.lhs)} ${ast.operator} ${prettyprintValue(ast.rhs)}`;
+    if (ast instanceof Ast.ComparisonSubqueryBooleanExpression)
+        throw new UnserializableError('Comparison Subquery');
+    if (ast instanceof Ast.ExistentialSubqueryBooleanExpression) {
+        const externalEquivalent = ast.toLegacy();
+        if (externalEquivalent)
+            return prettyprintExternalFilter(externalEquivalent);
+        throw new UnserializableError('Existential Subquery');
+    }
     assert(ast instanceof Ast.AtomBooleanExpression);
 
     if (INFIX_FILTERS.has(ast.operator))

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -1211,10 +1211,8 @@ atom_filter : Ast.BooleanExpression = {
     op:function_like_comparison_op '(' lhs:value ',' 'any' '(' rhs:projection_expression ')' ')' =>
         new Ast.BooleanExpression.ComparisonSubquery($.location, lhs, op, rhs);
 
-    'any' '(' inv:thingpedia_call 'filter' filter:or_filter ')' =>
-        new Ast.BooleanExpression.External($.location, inv.selector, inv.channel, inv.in_params, filter, null);
-    'any' '(' inv:thingpedia_call ',' filter:or_filter ')' =>
-        new Ast.BooleanExpression.External($.location, inv.selector, inv.channel, inv.in_params, filter, null);
+    'any' '(' subquery:chain_expression ')' =>
+        new Ast.BooleanExpression.ExistentialSubquery($.location, subquery);
 }
 
 primary_value : Ast.Value = {

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -392,7 +392,13 @@ atom_filter : Ast.BooleanExpression = {
         return new Ast.BooleanExpression.Compute($.location, lhs, op, rhs);
     };
     fn:call '{' filter '}' => {
-        return new Ast.BooleanExpression.External($.location, fn.selector, fn.channel, fn.in_params, filter, null);
+        const expr = new Ast.FilterExpression(
+            $.location,
+            new Ast.InvocationExpression($.location, fn, null),
+            filter,
+            null
+        );
+        return new Ast.BooleanExpression.ExistentialSubquery($.location, expr);
     };
 }
 

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -25,6 +25,7 @@ import Type from '../type';
 import List from '../utils/list';
 
 import { UnsynthesizableError } from './errors';
+import { UnserializableError } from "../utils/errors";
 
 // small integers are predicted/translated by the neural network, while
 // large integers are copied using NUMBER_* tokens
@@ -103,8 +104,17 @@ function filterToCNF(filter) {
                 ors.push(...or.operands);
                 continue;
             }
+            if (or.isExistentialSubquery) {
+                const externalEquivalent = or.toLegacy();
+                if (externalEquivalent)
+                    currentClause.push(externalEquivalent);
+                else
+                    throw new UnserializableError('Existential subquery');
+            }
+            if (or.isComparisonSubquery)
+                throw new UnserializableError('Comparison subquery');
             if (or.isAnd)
-                throw new Error('TODO');
+                throw new UnserializableError('AND boolean expression');
         }
         clauses.push(new Ast.BooleanExpression.Or(null, currentClause));
     }
@@ -473,6 +483,7 @@ export default class ToNNConverter {
                         lhs = this.valueToNN(or.lhs, scope);
                     orclause = List.concat(lhs, or.operator, this.valueToNN(or.rhs, scope));
                 } else {
+                    assert(or.isExternal);
                     orclause = List.concat(`@${or.selector.kind}.${or.channel}`);
                     for (let inParam of or.in_params) {
                         let ptype = or.schema.inReq[inParam.name] || or.schema.inOpt[inParam.name];

--- a/lib/nn-syntax/tonn_converter.js
+++ b/lib/nn-syntax/tonn_converter.js
@@ -104,15 +104,13 @@ function filterToCNF(filter) {
                 ors.push(...or.operands);
                 continue;
             }
-            if (or.isExistentialSubquery) {
+            if (or.isExistentialSubquery || or.isComparisonSubquery) {
                 const externalEquivalent = or.toLegacy();
                 if (externalEquivalent)
                     currentClause.push(externalEquivalent);
                 else
-                    throw new UnserializableError('Existential subquery');
+                    throw new UnserializableError('Subquery');
             }
-            if (or.isComparisonSubquery)
-                throw new UnserializableError('Comparison subquery');
             if (or.isAnd)
                 throw new UnserializableError('AND boolean expression');
         }

--- a/lib/optimize.ts
+++ b/lib/optimize.ts
@@ -176,6 +176,12 @@ function optimizeFilter(expr : Ast.BooleanExpression) : Ast.BooleanExpression {
         return new Ast.BooleanExpression.External(expr.location, expr.selector,
             expr.channel, expr.in_params, subfilter, expr.schema);
     }
+    if (expr instanceof Ast.ExistentialSubqueryBooleanExpression) {
+        return new Ast.BooleanExpression.ExistentialSubquery(
+            expr.location,
+            optimizeExpression(expr.subquery)
+        );
+    }
     if (expr instanceof Ast.ComputeBooleanExpression) {
         const lhs = expr.lhs;
         const rhs = expr.rhs;

--- a/lib/permission_checker.ts
+++ b/lib/permission_checker.ts
@@ -397,20 +397,6 @@ class SmtReduction {
         return smt.And(anyresult, this._processFilter(ast.filter, subscope, subscopeType));
     }
 
-    private _existentialToExternal(ast : Ast.ExistentialSubqueryBooleanExpression) : Ast.ExternalBooleanExpression|null {
-        if (ast.subquery instanceof Ast.FilterExpression && ast.subquery.expression instanceof Ast.InvocationExpression) {
-            return new Ast.ExternalBooleanExpression(
-                null,
-                ast.subquery.expression.invocation.selector,
-                ast.subquery.expression.invocation.channel,
-                ast.subquery.expression.invocation.in_params,
-                ast.subquery.filter,
-                ast.subquery.schema
-            );
-        }
-        return null;
-    }
-
     private _processFilter(ast : Ast.BooleanExpression,
                            scope : { [key : string] : string },
                            scopeType : { [key : string] : Type }) : smt.SNode {
@@ -432,9 +418,9 @@ class SmtReduction {
         if (ast instanceof Ast.ExternalBooleanExpression) {
             return this._addGetPredicate(ast, scope, scopeType);
         } else if (ast instanceof Ast.ExistentialSubqueryBooleanExpression) {
-            const external = this._existentialToExternal(ast);
-            if (external)
-                return this._addGetPredicate(external, scope, scopeType);
+            const externalEquivalent = ast.toLegacy();
+            if (externalEquivalent)
+                return this._addGetPredicate(externalEquivalent, scope, scopeType);
             // TODO: add support for existential subquery in general
             throw new Error('Unsupported subquery');
         } else if (ast instanceof Ast.ComparisonSubqueryBooleanExpression) {
@@ -506,9 +492,9 @@ class SmtReduction {
         if (ast instanceof Ast.ExternalBooleanExpression) {
             return this._addGetPredicate(ast, {}, {});
         } else if (ast instanceof Ast.ExistentialSubqueryBooleanExpression) {
-            const external = this._existentialToExternal(ast);
-            if (external)
-                return this._addGetPredicate(external, scope, scopeType);
+            const externalEquivalent = ast.toLegacy();
+            if (externalEquivalent)
+                return this._addGetPredicate(externalEquivalent, scope, scopeType);
             // TODO: add support for existential subquery in general
             throw new Error('Unsupported subquery');
         } else if (ast instanceof Ast.ComparisonSubqueryBooleanExpression) {

--- a/lib/typecheck.ts
+++ b/lib/typecheck.ts
@@ -473,13 +473,25 @@ export default class TypeChecker {
             return;
         }
 
-        assert(ast instanceof Ast.ExternalBooleanExpression);
-        if (ast.schema === null)
-            await this._loadTpSchema(ast);
-        if (ast.schema!.functionType !== 'query')
-            throw new TypeError(`Subquery function must be a query, not ${ast.schema!.functionType}`);
-        await this._typeCheckInputArgs(ast, ast.schema!, scope);
-        await this._typeCheckFilterHelper(ast.filter, ast.schema, scope);
+        if (ast instanceof Ast.ExternalBooleanExpression) {
+            if (ast.schema === null)
+                await this._loadTpSchema(ast);
+            if (ast.schema!.functionType !== 'query')
+                throw new TypeError(`Subquery function must be a query, not ${ast.schema!.functionType}`);
+            await this._typeCheckInputArgs(ast, ast.schema!, scope);
+            await this._typeCheckFilterHelper(ast.filter, ast.schema, scope);
+            return;
+        }
+
+        assert(ast instanceof Ast.ExistentialSubqueryBooleanExpression);
+        await this._typeCheckSubquery(ast.subquery, scope);
+    }
+
+    private async _typeCheckSubquery(expr : Ast.Expression, scope : Scope) {
+        if (expr.schema === null)
+            await this._loadAllSchemas(expr);
+        await this._typeCheckExpression(expr, scope);
+        this._checkExpressionType(expr, ['query'], 'projection');
     }
 
     private async _typeCheckSubqueryValue(expr : Ast.Expression, scope : Scope) {

--- a/lib/typecheck.ts
+++ b/lib/typecheck.ts
@@ -491,7 +491,7 @@ export default class TypeChecker {
         if (expr.schema === null)
             await this._loadAllSchemas(expr);
         await this._typeCheckExpression(expr, scope);
-        this._checkExpressionType(expr, ['query'], 'projection');
+        this._checkExpressionType(expr, ['query'], 'subquery');
     }
 
     private async _typeCheckSubqueryValue(expr : Ast.Expression, scope : Scope) {

--- a/lib/utils/errors.ts
+++ b/lib/utils/errors.ts
@@ -48,3 +48,9 @@ export class ThingTalkSyntaxError extends Error {
         this.location = location || null;
     }
 }
+
+export class UnserializableError extends Error {
+    constructor(what : string) {
+        super(what + ' is not serializable');
+    }
+}

--- a/test/test_compiler.js
+++ b/test/test_compiler.js
@@ -1323,7 +1323,7 @@ const TEST_CASES = [
     // 25
     [`monitor(@com.twitter.home_timeline(), any(@org.thingpedia.builtin.thingengine.builtin.get_time(), time >= new Time(9,0) && time <= new Time(10, 0)));
     monitor(@com.twitter.home_timeline(), text =~ "lol" && any(@org.thingpedia.builtin.thingengine.builtin.get_time(), time >= new Time(9,0) && time <= new Time(10, 0)));`,
-    [`"use strict";
+    [`  "use strict";
   let _t_0;
   let _t_1;
   let _t_2;
@@ -1354,6 +1354,7 @@ const TEST_CASES = [
   let _t_27;
   let _t_28;
   let _t_29;
+  let _t_30;
   _t_0 = await __env.readState(0);
   try {
     _t_1 = {};
@@ -1378,26 +1379,27 @@ const TEST_CASES = [
         if (_t_13) {
           _t_15 = false;
           try {
-            _t_17 = {};
-            _t_16 = await __env.invokeQuery("org.thingpedia.builtin.thingengine.builtin", { }, "get_time", _t_17, { projection: ["time"] });
-            _t_18 = __builtin.getAsyncIterator(_t_16);
+            _t_16 = {};
+            _t_17 = await __env.invokeQuery("org.thingpedia.builtin.thingengine.builtin", { }, "get_time", _t_16, { projection: ["time"] });
+            _t_18 = __builtin.getAsyncIterator(_t_17);
             {
               let _iter_tmp = await _t_18.next();
               while (!_iter_tmp.done) {
                 _t_19 = _iter_tmp.value;
                 _t_20 = _t_19[0];
                 _t_21 = _t_19[1];
-                _t_22 = _t_21.time;
-                _t_23 = true;
-                _t_25 = __builtin.getTime (_t_22);
-                _t_26 = new __builtin.Time(10, 0, 0);
-                _t_24 = _t_25 <= _t_26;
-                _t_23 = _t_23 && _t_24;
-                _t_28 = __builtin.getTime (_t_22);
-                _t_29 = new __builtin.Time(9, 0, 0);
-                _t_27 = _t_28 >= _t_29;
-                _t_23 = _t_23 && _t_27;
-                if (_t_23) {
+                _t_22 = _t_21.__response;
+                _t_23 = _t_21.time;
+                _t_24 = true;
+                _t_26 = __builtin.getTime (_t_23);
+                _t_27 = new __builtin.Time(10, 0, 0);
+                _t_25 = _t_26 <= _t_27;
+                _t_24 = _t_24 && _t_25;
+                _t_29 = __builtin.getTime (_t_23);
+                _t_30 = new __builtin.Time(9, 0, 0);
+                _t_28 = _t_29 >= _t_30;
+                _t_24 = _t_24 && _t_28;
+                if (_t_24) {
                   _t_15 = true;
                   break;
                 } else {
@@ -1407,7 +1409,7 @@ const TEST_CASES = [
               }
             }
           } catch(_exc_) {
-            __env.reportError("Failed to invoke get-predicate query", _exc_);
+            __env.reportError("Failed to invoke query", _exc_);
           }
           if (_t_15) {
             try {
@@ -1426,7 +1428,7 @@ const TEST_CASES = [
     }
   } catch(_exc_) {
     __env.reportError("Failed to invoke trigger", _exc_);
-  }`, `"use strict";
+  }`, `  "use strict";
   let _t_0;
   let _t_1;
   let _t_2;
@@ -1465,6 +1467,7 @@ const TEST_CASES = [
   let _t_35;
   let _t_36;
   let _t_37;
+  let _t_38;
   _t_0 = await __env.readState(1);
   try {
     _t_1 = {};
@@ -1499,26 +1502,27 @@ const TEST_CASES = [
           _t_20 = true;
           _t_21 = false;
           try {
-            _t_23 = {};
-            _t_22 = await __env.invokeQuery("org.thingpedia.builtin.thingengine.builtin", { }, "get_time", _t_23, { projection: ["time"] });
-            _t_24 = __builtin.getAsyncIterator(_t_22);
+            _t_22 = {};
+            _t_23 = await __env.invokeQuery("org.thingpedia.builtin.thingengine.builtin", { }, "get_time", _t_22, { projection: ["time"] });
+            _t_24 = __builtin.getAsyncIterator(_t_23);
             {
               let _iter_tmp = await _t_24.next();
               while (!_iter_tmp.done) {
                 _t_25 = _iter_tmp.value;
                 _t_26 = _t_25[0];
                 _t_27 = _t_25[1];
-                _t_28 = _t_27.time;
-                _t_29 = true;
-                _t_31 = __builtin.getTime (_t_28);
-                _t_32 = new __builtin.Time(10, 0, 0);
-                _t_30 = _t_31 <= _t_32;
-                _t_29 = _t_29 && _t_30;
-                _t_34 = __builtin.getTime (_t_28);
-                _t_35 = new __builtin.Time(9, 0, 0);
-                _t_33 = _t_34 >= _t_35;
-                _t_29 = _t_29 && _t_33;
-                if (_t_29) {
+                _t_28 = _t_27.__response;
+                _t_29 = _t_27.time;
+                _t_30 = true;
+                _t_32 = __builtin.getTime (_t_29);
+                _t_33 = new __builtin.Time(10, 0, 0);
+                _t_31 = _t_32 <= _t_33;
+                _t_30 = _t_30 && _t_31;
+                _t_35 = __builtin.getTime (_t_29);
+                _t_36 = new __builtin.Time(9, 0, 0);
+                _t_34 = _t_35 >= _t_36;
+                _t_30 = _t_30 && _t_34;
+                if (_t_30) {
                   _t_21 = true;
                   break;
                 } else {
@@ -1528,12 +1532,12 @@ const TEST_CASES = [
               }
             }
           } catch(_exc_) {
-            __env.reportError("Failed to invoke get-predicate query", _exc_);
+            __env.reportError("Failed to invoke query", _exc_);
           }
           _t_20 = _t_20 && _t_21;
-          _t_37 = "lol";
-          _t_36 = __builtin.like(_t_12, _t_37);
-          _t_20 = _t_20 && _t_36;
+          _t_38 = "lol";
+          _t_37 = __builtin.like(_t_12, _t_38);
+          _t_20 = _t_20 && _t_37;
           if (_t_20) {
             try {
               await __env.output(String(_t_9), _t_10);
@@ -9489,6 +9493,125 @@ const TEST_CASES = [
 
                 }
                 _iter_tmp = await _t_18.next();
+              }
+            }
+          } catch(_exc_) {
+            __env.reportError("Failed to invoke query", _exc_);
+          }
+          if (_t_15) {
+            try {
+              await __env.output(String(_t_4), _t_5);
+            } catch(_exc_) {
+              __env.reportError("Failed to invoke action", _exc_);
+            }
+          } else {
+
+          }
+          _iter_tmp = await _t_2.next();
+        }
+      }
+    } catch(_exc_) {
+      __env.reportError("Failed to invoke query", _exc_);
+    }
+  } finally {
+    await __env.exitProcedure(0, null);
+  }`]
+    ],
+
+    // 107 existential subquery
+    [`@com.spotify2.song() filter any([id] of @com.spotify2.album() filter id =~ "lol");`,
+    [`"use strict";
+  let _t_0;
+  let _t_1;
+  let _t_2;
+  let _t_3;
+  let _t_4;
+  let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
+  let _t_16;
+  let _t_17;
+  let _t_18;
+  let _t_19;
+  let _t_20;
+  let _t_21;
+  let _t_22;
+  let _t_23;
+  let _t_24;
+  let _t_25;
+  let _t_26;
+  let _t_27;
+  let _t_28;
+  let _t_29;
+  let _t_30;
+  let _t_31;
+  let _t_32;
+  let _t_33;
+  let _t_34;
+  await __env.enterProcedure(0, null);
+  try {
+    try {
+      _t_0 = {};
+      _t_1 = await __env.invokeQuery("com.spotify2", { }, "song", _t_0, { projection: ["id", "artists", "album", "genres", "release_date", "popularity", "energy", "danceability"] });
+      _t_2 = __builtin.getAsyncIterator(_t_1);
+      {
+        let _iter_tmp = await _t_2.next();
+        while (!_iter_tmp.done) {
+          _t_3 = _iter_tmp.value;
+          _t_4 = _t_3[0];
+          _t_5 = _t_3[1];
+          _t_6 = _t_5.__response;
+          _t_7 = _t_5.id;
+          _t_8 = _t_5.artists;
+          _t_9 = _t_5.album;
+          _t_10 = _t_5.genres;
+          _t_11 = _t_5.release_date;
+          _t_12 = _t_5.popularity;
+          _t_13 = _t_5.energy;
+          _t_14 = _t_5.danceability;
+          _t_15 = false;
+          try {
+            _t_16 = {};
+            _t_17 = new Array(1);
+            _t_18 = new Array(3);
+            _t_19 = "id";
+            _t_18[0] = _t_19;
+            _t_20 = "=~";
+            _t_18[1] = _t_20;
+            _t_21 = "lol";
+            _t_18[2] = _t_21;
+            _t_17[0] = _t_18;
+            _t_22 = await __env.invokeQuery("com.spotify2", { }, "album", _t_16, { projection: ["id"], filter: _t_17 });
+            _t_23 = __builtin.getAsyncIterator(_t_22);
+            {
+              let _iter_tmp = await _t_23.next();
+              while (!_iter_tmp.done) {
+                _t_24 = _iter_tmp.value;
+                _t_25 = _t_24[0];
+                _t_26 = _t_24[1];
+                _t_27 = _t_26.__response;
+                _t_28 = _t_26.id;
+                _t_29 = _t_26.artists;
+                _t_30 = _t_26.release_date;
+                _t_31 = _t_26.popularity;
+                _t_33 = "lol";
+                _t_32 = __builtin.like(_t_28, _t_33);
+                if (_t_32) {
+                  _t_34 = {};
+                  _t_15 = true;
+                  break;
+                } else {
+
+                }
+                _iter_tmp = await _t_23.next();
               }
             }
           } catch(_exc_) {

--- a/test/test_iteration_apis.js
+++ b/test/test_iteration_apis.js
@@ -465,11 +465,11 @@ now => [food] of ((@uk.ac.cam.multiwoz.Restaurant.Restaurant()), true) => notify
 
     [`monitor( @security-camera.current_event()), (has_person == true && any(@org.thingpedia.builtin.thingengine.builtin.get_gps(), location == new Location(1, 2)))  => notify;`,
     ['query: Invocation(Device(security-camera, , ), current_event, , )',
-     'filter: External(Device(org.thingpedia.builtin.thingengine.builtin, , ), get_gps, , Atom(location, ==, Location(Absolute(1, 2, null))))'],
+     'query: Invocation(Device(org.thingpedia.builtin.thingengine.builtin, , ), get_gps, , )'],
     [
     'Device(security-camera, , ) security-camera:current_event',
     'Device(org.thingpedia.builtin.thingengine.builtin, , ) org.thingpedia.builtin.thingengine.builtin:get_gps',
-    'Atom(location, ==, Location(Absolute(1, 2, null))) security-camera:current_event',
+    'Atom(location, ==, Location(Absolute(1, 2, null))) org.thingpedia.builtin.thingengine.builtin:get_gps',
     'Atom(has_person, ==, Boolean(true)) security-camera:current_event',
     ],
     [

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -1888,3 +1888,36 @@ now => @com.facebook.post();
 $dialogue @org.thingpedia.dialogue.transaction.execute;
 @com.thecatapi.get();
 @com.twitter.post_picture(picture_url=$context.result.picture_url : Entity(tt:picture));
+
+====
+
+// existential subquery
+// simple invocation no filter
+monitor(@com.twitter.home_timeline() filter any(@org.thingpedia.builtin.thingengine.builtin.get_gps()));
+
+
+====
+
+// existential subquery
+// projection
+monitor(@com.twitter.home_timeline() filter any([speed] of @org.thingpedia.builtin.thingengine.builtin.get_gps()));
+
+====
+
+// existential subquery
+// computation
+monitor(@com.twitter.home_timeline() filter any([distance(location, new Location(1, 2))] of @org.thingpedia.builtin.thingengine.builtin.get_gps()));
+
+====
+
+// existential subquery
+// sort
+monitor(@com.twitter.home_timeline() filter any(sort(file_size asc of @com.dropbox.list_folder())));
+
+====
+
+// ** expect TypeError **
+// existential subquery on action
+monitor(@com.twitter.home_timeline() filter any(@com.twitter.post()));
+
+


### PR DESCRIPTION
Existential subquery generalizes the old get predicate (`ExternalBooleanExpression`) as it has full support for all possible queries, such as projection, sort, computation. 

`ExternalBooleanExpression` is not removed for compatibility reasons.
