### PR TITLE
Fix inadvertently merging location entities

### DIFF
--- a/lib/entity-retriever.ts
+++ b/lib/entity-retriever.ts
@@ -35,6 +35,8 @@ import {
     EntityMap
 } from './entities';
 
+const EPSILON = 1e-8;
+
 function entitiesEqual(type : string, one : AnyEntity, two : AnyEntity) : boolean {
     if (one === two)
         return true;
@@ -81,8 +83,8 @@ function entitiesEqual(type : string, one : AnyEntity, two : AnyEntity) : boolea
         const etwo = two as LocationEntity;
         if (isNaN(eone.latitude) && isNaN(etwo.latitude) && isNaN(eone.longitude) && isNaN(etwo.longitude))
             return eone.display === etwo.display;
-        return Math.abs(eone.latitude - etwo.latitude) < 0.01 &&
-            Math.abs(eone.longitude - etwo.longitude) < 0.01;
+        return Math.abs(eone.latitude - etwo.latitude) < EPSILON &&
+            Math.abs(eone.longitude - etwo.longitude) < EPSILON;
     }
     }
 

--- a/test/test_nn_syntax_allocator_2.js
+++ b/test/test_nn_syntax_allocator_2.js
@@ -44,6 +44,17 @@ const TEST_CASES = [
      },
     ],
 
+    [`now => @org.thingpedia.weather.current ( location = new Location ( 37.442156 , -122.1634471 , " palo alto " ) ) => notify ;`,
+     {
+         'LOCATION_0': { display: 'palo alto', latitude: 37.442156, longitude: -122.1634471 }
+     },
+     `now => @org.thingpedia.weather.current ( location = new Location ( 37.445523 , -122.1607073261 ) ) => notify ;`,
+     {
+         'LOCATION_0': { display: 'palo alto', latitude: 37.442156, longitude: -122.1634471 },
+         'LOCATION_1': { display: null, latitude: 37.445523, longitude: -122.1607073261 },
+     },
+    ],
+
     [`now => @org.thingpedia.weather.current ( location = new Location ( " stanford california " ) ) => notify ;`,
      {'LOCATION_0': { display: 'stanford california', latitude: NaN, longitude: NaN }},
      `now => @org.thingpedia.weather.current ( location = new Location ( " stanford california " ) ) => notify ;`,


### PR DESCRIPTION
Two locations that are less than 0.1 degree apart in either coordinate
can be quite far (for latitude, 0.1 degrees is about 7 miles).
Instead, we should compare a lot more strictly, so we only catch
floating point rounding errors (due to roundtripping from JSON/strings
in various places) and not locations that are actually distinct.