### PR TITLE
dialogues: allow dialogue act params to be constants instead of labels

### DIFF
--- a/lib/ast/dialogues.ts
+++ b/lib/ast/dialogues.ts
@@ -371,7 +371,7 @@ export class DialogueHistoryItem extends AstNode {
 export class DialogueState extends Input {
     policy : string;
     dialogueAct : string;
-    dialogueActParam : string[]|null;
+    dialogueActParam : Array<string|Value>|null;
     history : DialogueHistoryItem[];
 
     private _current : DialogueHistoryItem|null;
@@ -379,7 +379,7 @@ export class DialogueState extends Input {
     constructor(location : SourceRange|null,
                 policy : string,
                 dialogueAct : string,
-                dialogueActParam : string[]|string|null,
+                dialogueActParam : Array<string|Value>|string|null,
                 history : DialogueHistoryItem[]) {
         super(location);
         assert(typeof policy === 'string');
@@ -420,7 +420,7 @@ export class DialogueState extends Input {
     toSource() : TokenStream {
         let list : TokenStream = List.concat('$dialogue', '@' + this.policy, '.', this.dialogueAct);
         if (this.dialogueActParam)
-            list = List.concat(list, '(', List.join(this.dialogueActParam.map((p) => List.singleton(p)), ','), ')');
+            list = List.concat(list, '(', List.join(this.dialogueActParam.map((p) => typeof p === 'string' ? List.singleton(p) : p.toSource()), ','), ')');
         list = List.concat(list, ';');
         for (const item of this.history)
             list = List.concat(list, '\n', item.toSource());
@@ -428,7 +428,8 @@ export class DialogueState extends Input {
     }
 
     clone() : DialogueState {
-        return new DialogueState(this.location, this.policy, this.dialogueAct, this.dialogueActParam,
+        return new DialogueState(this.location, this.policy, this.dialogueAct,
+            this.dialogueActParam ? this.dialogueActParam.map((v) => typeof v === 'string' ? v : v.clone()) : null,
             this.history.map((item) => item.clone()));
     }
 

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -349,15 +349,15 @@ dialogue_state : Ast.DialogueState = {
     '$dialogue' dialogueAct:thingpedia_function_name ';' history:dialogue_history_item_list => {
         return new Ast.DialogueState($.location, dialogueAct.kind, dialogueAct.name, null, history);
     };
-    '$dialogue' dialogueAct:thingpedia_function_name '(' pnames:identifier_list ')' ';' history:dialogue_history_item_list => {
-        return new Ast.DialogueState($.location, dialogueAct.kind, dialogueAct.name, pnames, history);
+    '$dialogue' dialogueAct:thingpedia_function_name '(' pnames:array_literal_values ')' ';' history:dialogue_history_item_list => {
+        return new Ast.DialogueState($.location, dialogueAct.kind, dialogueAct.name, pnames.map((p) => p instanceof Ast.VarRefValue ? p.name : p), history);
     };
 
     '$dialogue' dialogueAct:thingpedia_function_name ';' => {
         return new Ast.DialogueState($.location, dialogueAct.kind, dialogueAct.name, null, []);
     };
-    '$dialogue' dialogueAct:thingpedia_function_name '(' pnames:identifier_list ')' ';' => {
-        return new Ast.DialogueState($.location, dialogueAct.kind, dialogueAct.name, pnames, []);
+    '$dialogue' dialogueAct:thingpedia_function_name '(' pnames:array_literal_values ')' ';' => {
+        return new Ast.DialogueState($.location, dialogueAct.kind, dialogueAct.name, pnames.map((p) => p instanceof Ast.VarRefValue ? p.name : p), []);
     };
 }
 

--- a/lib/typecheck.ts
+++ b/lib/typecheck.ts
@@ -1334,6 +1334,15 @@ export default class TypeChecker {
     async typeCheckDialogue(ast : Ast.DialogueState) : Promise<void> {
         await this._loadAllSchemas(ast);
 
+        if (ast.dialogueActParam) {
+            for (const param of ast.dialogueActParam) {
+                if (typeof param === 'string')
+                    continue;
+                if (!param.isConstant())
+                    throw new TypeError(`Dialogue act parameters must be constants`);
+            }
+        }
+
         for (const item of ast.history) {
             const scope = new Scope(null);
             await this._typeCheckExpressionStatement(item.stmt, scope);

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -1939,3 +1939,16 @@ function foo() {
 foo();
 foo() filter text =~ "lol";
 foo() => @com.twitter.retweet(tweet_id=tweet_id);
+
+====
+
+// dialogue states with constants as parameters
+$dialogue @org.thingpedia.dialogue.transaction.sys_choose_device("bedroom lights", "living room lights");
+@light-bulb.set_power(power=enum on);
+
+====
+
+// dialogue states parameters must be constants
+// ** expect TypeError **
+$dialogue @org.thingpedia.dialogue.transaction.sys_invalid(5 + 3);
+@light-bulb.set_power(power=enum on);


### PR DESCRIPTION
This will be useful for entity linking & device choice, as the user
is asked to choose among several possible choices.