### PR TITLE
Fix parsing dates on March 31st

### DIFF
--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -795,12 +795,12 @@ long_date_value = ('makeDate' / 'new' __ 'Date') _ '(' _ year:literal_number? _ 
     }
     var d = new Date;
     d.setFullYear(year);
-    d.setMonth(month-1);
-    d.setDate(day);
-    d.setHours(hours);
-    d.setMinutes(minutes);
-    d.setSeconds(seconds);
-    d.setMilliseconds(0);
+    // set both the month and the date at the same time
+    // otherwise when today's date is the 31st and the chosen
+    // month has 30 days, the Date will be adjusted to the
+    // first day of the subsequent month, which is wrong
+    d.setMonth(month-1, day);
+    d.setHours(hours, minutes, seconds, 0);
     return new Ast.Value.Date(d);
 }
 short_date_value = ('makeDate' / 'new' __ 'Date') _ '(' _ year:literal_number? _ ',' _ month:literal_number? _ ',' _ day:literal_number? _ ')' {
@@ -808,12 +808,8 @@ short_date_value = ('makeDate' / 'new' __ 'Date') _ '(' _ year:literal_number? _
         return new Ast.Value.Date(new Ast.DatePiece(year, month, day, null));
     var d = new Date;
     d.setFullYear(year);
-    d.setMonth(month-1);
-    d.setDate(day);
-    d.setHours(0);
-    d.setMinutes(0);
-    d.setSeconds(0);
-    d.setMilliseconds(0);
+    d.setMonth(month-1, day);
+    d.setHours(0, 0, 0, 0);
     return new Ast.Value.Date(d);
 }
 long_weekday_value = 'new' __ 'Date' _ '(' _ day:ident _ ',' _ hours:literal_number _ ',' _ minutes:literal_number _ ',' _ seconds:literal_number _ ')' {

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -226,12 +226,8 @@ function parseIncompleteDate($ : $runtime.ParserInterface,
                 }
 
                 d.setFullYear(unix_or_year);
-                d.setMonth(0);
-                d.setDate(1);
-                d.setHours(0);
-                d.setMinutes(0);
-                d.setSeconds(0);
-                d.setMilliseconds(0);
+                d.setMonth(0, 1);
+                d.setHours(0, 0, 0, 0);
             } else {
                 d.setTime(unix_or_year);
             }
@@ -245,18 +241,15 @@ function parseIncompleteDate($ : $runtime.ParserInterface,
             }
 
             d.setFullYear(year);
-            d.setMonth((parts[1] || 1) - 1);
-            d.setDate(parts[2] || 1);
-            if (time) {
-                d.setHours(time.hour);
-                d.setMinutes(time.minute);
-                d.setSeconds(time.second);
-            } else {
-                d.setHours(parts[3] || 0);
-                d.setMinutes(parts[4] || 0);
-                d.setSeconds(parts[5] || 0);
-            }
-            d.setMilliseconds(0);
+            // set both the month and the date at the same time
+            // otherwise when today's date is the 31st and the chosen
+            // month has 30 days, the Date will be adjusted to the
+            // first day of the subsequent month, which is wrong
+            d.setMonth((parts[1] || 1) - 1, parts[2] || 1);
+            if (time)
+                d.setHours(time.hour, time.minute, time.second, 0);
+            else
+                d.setHours(parts[3] || 0, parts[4] || 0, parts[5] || 0, 0);
         }
         return new Ast.Value.Date(d);
     } else {
@@ -1505,138 +1498,6 @@ absolute_or_edge_date : Ast.DateValue = {
 
     'new' 'Date' '(' params:date_param_list ',' time:absolute_time ')' =>
         parseIncompleteDate($, params, time);
-
-    /*'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' day:constant_Number ')' => {
-        const d = new Date;
-        d.setFullYear(year.value);
-        d.setMonth(month.value-1);
-        d.setDate(day.value);
-        d.setHours(0);
-        d.setMinutes(0);
-        d.setSeconds(0);
-        d.setMilliseconds(0);
-        return new Ast.Value.Date(d);
-    };
-    'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' day:constant_Number ','
-                     hours:constant_Number ',' minutes:constant_Number ',' seconds:constant_Number ')' => {
-        const d = new Date;
-        d.setFullYear(year.value);
-        d.setMonth(month.value-1);
-        d.setDate(day.value);
-        d.setHours(hours.value);
-        d.setMinutes(minutes.value);
-        d.setSeconds(seconds.value);
-        d.setMilliseconds(0);
-        return new Ast.Value.Date(d);
-    };
-    'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' day:constant_Number ','
-                     hours:constant_Number ',' minutes:constant_Number ')' => {
-        const d = new Date;
-        d.setFullYear(year.value);
-        d.setMonth(month.value-1);
-        d.setDate(day.value);
-        d.setHours(hours.value);
-        d.setMinutes(minutes.value);
-        d.setSeconds(0);
-        d.setMilliseconds(0);
-        return new Ast.Value.Date(d);
-    };
-    'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' day:constant_Number ','
-                     time:absolute_time ')' => {
-        const d = new Date;
-        d.setFullYear(year.value);
-        d.setMonth(month.value-1);
-        d.setDate(day.value);
-        d.setHours(time.hour);
-        d.setMinutes(time.minute);
-        d.setSeconds(time.second);
-        d.setMilliseconds(0);
-        return new Ast.Value.Date(d);
-    };
-
-    'new' 'Date' '(' unix_or_year:constant_Number ')' => {
-        const v = unix_or_year.value;
-
-
-    };
-
-
-    'new' 'Date' '(' year:constant_Number ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(year.value, null, null, null));
-    };
-    'new' 'Date' '(' year:constant_Number ',' ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(year.value, null, null, null));
-    };
-    'new' 'Date' '(' year:constant_Number ',' ',' ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(year.value, null, null, null));
-    };
-
-    'new' 'Date' '(' ',' month:constant_Number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, null, null));
-    };
-    'new' 'Date' '(' ',' month:constant_Number ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, null, null));
-    };
-    'new' 'Date' '(' ',' month:constant_Number ',' ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, null, null));
-    };
-
-    'new' 'Date' '(' ',' ',' day:constant_Number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value, null));
-    };
-    'new' 'Date' '(' ',' ',' day:constant_Number ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value, null));
-    };
-
-    'new' 'Date' '(' year:constant_Number ',' month:constant_Number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, null, null));
-    };
-    'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, null, null));
-    };
-    'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(year.value, month.value, null, null));
-    };
-
-    'new' 'Date' '(' ',' month:constant_Number ',' day:constant_Number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value, null));
-    };
-    'new' 'Date' '(' ',' month:constant_Number ',' day:constant_Number ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value, null));
-    };
-
-    'new' 'Date' '(' ',' ',' day:constant_Number ',' time:absolute_time ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value, new Ast.Value.Time(time)));
-    };
-    'new' 'Date' '(' ',' ',' day:constant_Number ',' hours:constant_Number ',' minutes:constant_Number ',' seconds:constant_Number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value,
-            new Ast.Value.Time(new Ast.Time.Absolute(hours.value, minutes.value, seconds.value))));
-    };
-    'new' 'Date' '(' ',' ',' day:constant_Number ',' hours:constant_Number ',' minutes:constant_Number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value,
-            new Ast.Value.Time(new Ast.Time.Absolute(hours.value, minutes.value, 0))));
-    };
-    'new' 'Date' '(' ',' ',' day:constant_Number ',' hours:constant_Number ',' minutes:constant_Number ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, null, day.value,
-            new Ast.Value.Time(new Ast.Time.Absolute(hours.value, minutes.value, 0))));
-    };
-
-    'new' 'Date' '(' ',' month:constant_Number ',' day:constant_Number ',' time:absolute_time ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value, new Ast.Value.Time(time)));
-    };
-    'new' 'Date' '(' ',' month:constant_Number ',' day:constant_Number ',' hours:constant_Number ',' minutes:constant_Number ',' seconds:constant_Number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value,
-            new Ast.Value.Time(new Ast.Time.Absolute(hours.value, minutes.value, seconds.value))));
-    };
-    'new' 'Date' '(' ',' month:constant_Number ',' day:constant_Number ',' hours:constant_Number ',' minutes:constant_Number ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value,
-            new Ast.Value.Time(new Ast.Time.Absolute(hours.value, minutes.value, 0))));
-    };
-    'new' 'Date' '(' ',' month:constant_Number ',' day:constant_Number ',' hours:constant_Number ',' minutes:constant_Number ',' ')' => {
-        return new Ast.Value.Date(new Ast.DatePiece(null, month.value, day.value,
-            new Ast.Value.Time(new Ast.Time.Absolute(hours.value, minutes.value, 0))));
-    };
-    */
 
     'new' 'Date' '(' weekday:enum_literal ')' => {
         const d = new Ast.WeekDayDate(weekday, null);

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -771,12 +771,12 @@ absolute_or_edge_date : Ast.DateValue = {
         }
         const d = new Date;
         d.setFullYear(yearnum);
-        d.setMonth(month.value-1);
-        d.setDate(day.value);
-        d.setHours(0);
-        d.setMinutes(0);
-        d.setSeconds(0);
-        d.setMilliseconds(0);
+        // set both the month and the date at the same time
+        // otherwise when today's date is the 31st and the chosen
+        // month has 30 days, the Date will be adjusted to the
+        // first day of the subsequent month, which is wrong
+        d.setMonth(month.value-1, day.value);
+        d.setHours(0, 0, 0, 0);
         return new Ast.Value.Date(d);
     };
     'new' 'Date' '(' year:constant_Number ',' month:constant_Number ',' day:constant_Number ','
@@ -790,12 +790,8 @@ absolute_or_edge_date : Ast.DateValue = {
                 yearnum = 2000 + yearnum;
         }
         d.setFullYear(yearnum);
-        d.setMonth(month.value-1);
-        d.setDate(day.value);
-        d.setHours(hours.value);
-        d.setMinutes(minutes.value);
-        d.setSeconds(seconds.value);
-        d.setMilliseconds(0);
+        d.setMonth(month.value-1, day.value);
+        d.setHours(hours.value, minutes.value, seconds.value, 0);
         return new Ast.Value.Date(d);
     };
     'new' 'Date' '(' unix:constant_Number ')' => {

--- a/lib/utils/date_utils.ts
+++ b/lib/utils/date_utils.ts
@@ -100,6 +100,10 @@ function createDatePiece(year : number|null, month : number|null, day : number|n
         date.setHours(0, 0, 0, 0);
     }
     if (month !== null && month > 0) {
+        // set both the month and the date at the same time
+        // otherwise when today's date is the 31st and the chosen
+        // month has 30 days, the Date will be adjusted to the
+        // first day of the subsequent month, which is wrong
         date.setMonth(month - 1, 1);
         date.setHours(0, 0, 0, 0);
     }

--- a/test/test_optimize.js
+++ b/test/test_optimize.js
@@ -285,7 +285,11 @@ now => [distance(geo, $location.current_location)] of @com.yelp.restaurant() => 
 
     // __const is a VarRef, but it should not be moved to the left
     ['@org.schema.full.Place() filter count(review) >= __const_NUMBER_0;',
-     '@org.schema.full.Place() filter count(review) >= __const_NUMBER_0;']
+     '@org.schema.full.Place() filter count(review) >= __const_NUMBER_0;'],
+
+    // test parsing of dates
+    [`@com.washingtonpost.get_article() filter updated == new Date(2020, 6, 15);`,
+     `@com.washingtonpost.get_article() filter updated == new Date("2020-06-15T07:00:00.000Z");`],
 ];
 
 


### PR DESCRIPTION
Date.setMonth will adjust the date to the following month if the
current day number causes the date to be invalid (e.g. June 31st).
We avoid that by setting both month and day at the same time.