### PR TITLE
primitive_ops: be robust to undefined/null

### DIFF
--- a/lib/runtime/primitive_ops.ts
+++ b/lib/runtime/primitive_ops.ts
@@ -236,17 +236,23 @@ export function recurrentTimeSpecContains(spec : RecurrentTimeRule[],
     return contained;
 }
 
-export function contains(a : unknown[], b : unknown) : boolean {
+export function contains(a : unknown[]|null|undefined, b : unknown) : boolean {
+    if (a === null || a === undefined)
+        return false;
     return a.some((x) => equality(x, b));
 }
 
 // b is a substring of any element of a
-export function containsLike(a : unknown[], b : string) {
+export function containsLike(a : unknown[]|null|undefined, b : string) {
+    if (a === null || a === undefined)
+        return false;
     return a.some((x) => like(x, b));
 }
 
 // any element of b is a substring of a
-export function inArrayLike(a : string, b : string[]) {
+export function inArrayLike(a : string, b : string[]|null|undefined) {
+    if (b === null || b === undefined)
+        return false;
     return b.some((x) => like(a, x));
 }
 


### PR DESCRIPTION
A skill can always return undefined/null in a parameter if the
value is not available. In that case, we should return false
in the filter without an error.

Fixes https://github.com/stanford-oval/thingpedia-common-devices/issues/292