### PR TITLE
Fix default minimal projection if there is an ID input parameter

### DIFF
--- a/lib/ast/function_def.ts
+++ b/lib/ast/function_def.ts
@@ -996,7 +996,8 @@ export class FunctionDef extends Node {
 
     private _setMinimalProjection() {
         if (this.minimal_projection === undefined) {
-            if (this.hasArgument('id')) {
+            const idArg = this.getArgument('id');
+            if (idArg && !idArg.is_input) {
                 this.minimal_projection = ['id'];
                 this._impl_annotations.minimal_projection = new Value.Array([new Value.String('id')]);
             } else {


### PR DESCRIPTION
The minimal projection should not include "id" if "id" is not an output.

---

This currently trips the Genie basic tests in https://github.com/stanford-oval/genie-toolkit/pull/729 because basic tests fetch the snapshot from Thingpedia. Thingpedia snapshots don't include `#[minimal_projection]` so we get the default, and we have a function that has an `id` input parameter.