### PR TITLE
Typecheck invalid relative locations and relative times

### DIFF
--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -2003,3 +2003,15 @@ $dialogue @org.thingpedia.dialogue.transaction;
 @com.thecatapi.get()
 #[confirm=enum accepted]
 #[program_counter=123];
+
+====
+
+// bad relative location
+// ** expect TypeError **
+@org.thingpedia.weather.current(location=$location.foo);
+
+====
+
+// bad relative time
+// ** expect TypeError **
+@org.thingpedia.builtin.thingengine.builtin.get_time(), time == $time.foo;


### PR DESCRIPTION
So if the neural model predicts something invalid, we throw an
exception in a predictable place and not much later on with
an obscure stack trace.

Addresses #355 