### PR TITLE
Bring back join

### DIFF
--- a/lib/ast/syntax_priority.ts
+++ b/lib/ast/syntax_priority.ts
@@ -24,26 +24,27 @@ import List from '../utils/list';
 export enum SyntaxPriority {
     // priority of table-like expressions
     Chain = 0,
-    Projection = 1,
-    Filter = 2,
-    Alias = 3,
-    Index = 4,
+    Join = 1,
+    Projection = 2,
+    Filter = 3,
+    Alias = 4,
+    Index = 5,
 
     // low-priority scalar expression
-    ArrayField = 5,
+    ArrayField = 6,
 
     // priority of boolean expressions
-    Or = 6,
-    And = 7,
-    Comp = 8,
-    Not = 9,
+    Or = 7,
+    And = 8,
+    Comp = 9,
+    Not = 10,
 
     // priority of scalar expression
-    Add = 10,
-    Mul = 11,
-    Exp = 12,
+    Add = 11,
+    Mul = 12,
+    Exp = 13,
 
-    Primary = 13,
+    Primary = 14,
 }
 
 export function addParenthesis(p1 : SyntaxPriority, p2 : SyntaxPriority, syntax : TokenStream) : TokenStream {

--- a/lib/ast/visitor.ts
+++ b/lib/ast/visitor.ts
@@ -446,6 +446,10 @@ export default abstract class NodeVisitor {
     visitChainExpression(node : Exp2.ChainExpression) : boolean {
         return true;
     }
+    /* istanbul ignore next */
+    visitJoinExpression(node : Exp2.JoinExpression) : boolean {
+        return true;
+    }
 
     // statements and inputs
     /* istanbul ignore next */

--- a/lib/compiler/ast-to-ops.ts
+++ b/lib/compiler/ast-to-ops.ts
@@ -652,14 +652,13 @@ function compileTableToOps(table : Ast.Expression,
     } else if (table instanceof Ast.JoinExpression) {
         const lhsop = compileTableToOps(table.lhs, restrictHintsForJoin(hints, table.lhs.schema!));
         const rhsop = compileTableToOps(table.rhs, restrictHintsForJoin(hints, table.rhs.schema!));
-        const condition = table.condition ? compileBooleanExpressionToOp(table.condition) : null;
         let device : Ast.DeviceSelector|null = null;
         let handle_thingtalk = false;
         if (lhsop.device && rhsop.device) {
             device = sameDevice(lhsop.device, rhsop.device) ? lhsop.device : null;
             handle_thingtalk = sameDevice(lhsop.device, rhsop.device) ? lhsop.handle_thingtalk && rhsop.handle_thingtalk : false;
         }
-        return new TableOp.Join(lhsop, rhsop, condition, device, handle_thingtalk, table);
+        return new TableOp.Join(lhsop, rhsop, device, handle_thingtalk, table);
     } else {
         throw new TypeError(table.constructor.name);
     }

--- a/lib/compiler/ast-to-ops.ts
+++ b/lib/compiler/ast-to-ops.ts
@@ -649,6 +649,17 @@ function compileTableToOps(table : Ast.Expression,
             compiled.handle_thingtalk, 
             table
         );
+    } else if (table instanceof Ast.JoinExpression) {
+        const lhsop = compileTableToOps(table.lhs, restrictHintsForJoin(hints, table.lhs.schema!));
+        const rhsop = compileTableToOps(table.rhs, restrictHintsForJoin(hints, table.rhs.schema!));
+        const condition = table.condition ? compileBooleanExpressionToOp(table.condition) : null;
+        let device : Ast.DeviceSelector|null = null;
+        let handle_thingtalk = false;
+        if (lhsop.device && rhsop.device) {
+            device = sameDevice(lhsop.device, rhsop.device) ? lhsop.device : null;
+            handle_thingtalk = sameDevice(lhsop.device, rhsop.device) ? lhsop.handle_thingtalk && rhsop.handle_thingtalk : false;
+        }
+        return new TableOp.Join(lhsop, rhsop, condition, device, handle_thingtalk, table);
     } else {
         throw new TypeError(table.constructor.name);
     }

--- a/lib/compiler/jsir.ts
+++ b/lib/compiler/jsir.ts
@@ -147,6 +147,8 @@ class GetKey {
     }
 
     codegen(prefix : string) : string {
+        if (this._key.includes('.'))
+            return `${prefix}_t_${this._into} = _t_${this._object}["${this._key}"];`;
         return `${prefix}_t_${this._into} = _t_${this._object}.${this._key};`;
     }
 }

--- a/lib/compiler/ops-to-jsir.ts
+++ b/lib/compiler/ops-to-jsir.ts
@@ -1217,12 +1217,6 @@ export default class OpCompiler {
         this._irBuilder.pushBlock(loop.body);
         const [outputType, result] = this._readTypeResult(typeAndResult);
         this._mergeJoinScope(lhsScope, rhsScope, outputType, result);
-        if (tableop.condition) {
-            const filter = this._compileFilter(tableop.condition, this._currentScope);
-            const ifStmt = new JSIr.IfStatement(filter);
-            this._irBuilder.add(ifStmt);
-            this._irBuilder.pushBlock(ifStmt.iftrue);
-        }
     }
 
     private _compileTableCrossJoin(tableop : TableOp.CrossJoin) {

--- a/lib/compiler/ops.ts
+++ b/lib/compiler/ops.ts
@@ -357,7 +357,6 @@ export class Reduce extends TableOp {
 export class Join extends TableOp {
     constructor(public lhs : TableOp,
                 public rhs : TableOp,
-                public condition : BooleanExpressionOp|null,
                 public device : Ast.DeviceSelector|null,
                 public handle_thingtalk : boolean,
                 public ast : Ast.Expression) {
@@ -365,7 +364,7 @@ export class Join extends TableOp {
     }
 
     toString() {
-        return `TableOp.Join(${this.lhs}, ${this.rhs}, ${this.condition})`;
+        return `TableOp.Join(${this.lhs}, ${this.rhs})`;
     }
 }
 

--- a/lib/compiler/ops.ts
+++ b/lib/compiler/ops.ts
@@ -354,6 +354,21 @@ export class Reduce extends TableOp {
     }
 }
 
+export class Join extends TableOp {
+    constructor(public lhs : TableOp,
+                public rhs : TableOp,
+                public condition : BooleanExpressionOp|null,
+                public device : Ast.DeviceSelector|null,
+                public handle_thingtalk : boolean,
+                public ast : Ast.Expression) {
+        super();
+    }
+
+    toString() {
+        return `TableOp.Join(${this.lhs}, ${this.rhs}, ${this.condition})`;
+    }
+}
+
 export class CrossJoin extends TableOp {
     constructor(public lhs : TableOp,
                 public rhs : TableOp,

--- a/lib/new-syntax/keywords.ts
+++ b/lib/new-syntax/keywords.ts
@@ -49,6 +49,7 @@ export const KEYWORDS = new Set<string>([
     'opt',
     'req',
     'sort',
+    'on',
 
     // keywords and reserved words from JavaScript are reserved for future extensions
     'await',

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -931,11 +931,7 @@ join_expression : Ast.Expression = {
     projection_expression;
     
     lhs:join_expression 'join' rhs:projection_expression => {
-        return new Ast.JoinExpression($.location, lhs, rhs, Ast.BooleanExpression.True, null);
-    };
-
-    lhs:join_expression 'join' rhs:projection_expression 'on' condition:or_filter => {
-        return new Ast.JoinExpression($.location, lhs, rhs, condition, null);
+        return new Ast.JoinExpression($.location, lhs, rhs, null);
     };
 }
 

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -919,11 +919,23 @@ toplevel_chain_expression : Ast.ChainExpression = {
 // ```
 
 chain_expression_list : Ast.Expression[] = {
-    expr:projection_expression => [expr];
-
-    list:chain_expression_list '=>' expr:projection_expression => {
+    expr:join_expression => [expr];
+    
+    list:chain_expression_list '=>' expr:join_expression => {
         list.push(expr);
         return list;
+    };
+}
+
+join_expression : Ast.Expression = {
+    projection_expression;
+    
+    lhs:join_expression 'join' rhs:projection_expression => {
+        return new Ast.JoinExpression($.location, lhs, rhs, Ast.BooleanExpression.True, null);
+    };
+
+    lhs:join_expression 'join' rhs:projection_expression 'on' condition:or_filter => {
+        return new Ast.JoinExpression($.location, lhs, rhs, condition, null);
     };
 }
 
@@ -1824,6 +1836,7 @@ identifier_or_keyword : string = {
     'opt';
     'req';
     'sort';
+    'on';
 
     // reserved words from JavaScript
     'await';

--- a/lib/new-syntax/pretty.ts
+++ b/lib/new-syntax/pretty.ts
@@ -202,7 +202,7 @@ export function prettyprint(tokens : TokenStream) : string {
             if (buffer.endsWith('[')) // projection
                 buffer += token;
             else // multiplication
-                buffer += ' ' + token + ' ';
+                buffer += (buffer.endsWith(' ') ? '' : ' ') + token + ' ';
             break;
 
         // add a space before and after certain operators
@@ -253,7 +253,9 @@ export function prettyprint(tokens : TokenStream) : string {
         case 'while':
         case '$dialogue':
         case '$policy':
-            buffer += token + ' ';
+            buffer += token;
+            if (!buffer.endsWith('enum '))
+                buffer += ' ';
             break;
 
         // add a space BEFORE and AFTER filter, with, of, and as
@@ -265,7 +267,10 @@ export function prettyprint(tokens : TokenStream) : string {
         case 'extends':
         case 'join':
         case 'on':
-            buffer += ' ' + token + ' ';
+            if (buffer.endsWith('enum '))
+                buffer += token;
+            else
+                buffer += ' ' + token + ' ';
             break;
 
         // the following keywords DO NOT receive a space: null, true, false, sort

--- a/lib/new-syntax/pretty.ts
+++ b/lib/new-syntax/pretty.ts
@@ -263,6 +263,8 @@ export function prettyprint(tokens : TokenStream) : string {
         case 'of':
         case 'as':
         case 'extends':
+        case 'join':
+        case 'on':
             buffer += ' ' + token + ' ';
             break;
 

--- a/lib/optimize.ts
+++ b/lib/optimize.ts
@@ -523,6 +523,13 @@ function optimizeExpression(expression : Ast.Expression, allow_projection=true) 
         return expression;
     }
 
+    if (expression instanceof Ast.JoinExpression) {
+        const lhs = optimizeExpression(expression.lhs);
+        const rhs = optimizeExpression(expression.rhs);
+        const condition = optimizeFilter(expression.condition);
+        return new Ast.JoinExpression(expression.location, lhs, rhs, condition, expression.schema);
+    }
+
     if (isUnaryExpressionOp(expression)) {
         const inner = optimizeExpression(expression.expression, allow_projection);
         expression.expression = inner;

--- a/lib/optimize.ts
+++ b/lib/optimize.ts
@@ -526,8 +526,7 @@ function optimizeExpression(expression : Ast.Expression, allow_projection=true) 
     if (expression instanceof Ast.JoinExpression) {
         const lhs = optimizeExpression(expression.lhs);
         const rhs = optimizeExpression(expression.rhs);
-        const condition = optimizeFilter(expression.condition);
-        return new Ast.JoinExpression(expression.location, lhs, rhs, condition, expression.schema);
+        return new Ast.JoinExpression(expression.location, lhs, rhs, expression.schema);
     }
 
     if (isUnaryExpressionOp(expression)) {

--- a/test/test_builtin.js
+++ b/test/test_builtin.js
@@ -80,6 +80,40 @@ function testStreamUnion() {
     });
 }
 
+function testJoin() {
+    let lhs = testStream([[1000, ['a', {a:1}]], [5000, ['a', {a:2}]], [0, ['a', {a:3}]], [10000, ['a', {a:4}]]]);
+    let rhs = testStream([[500, ['b', {b:5}]], [6000, ['b', {b:6}]], [1000, ['b', {b:7}]]]);
+    let expect = JSON.stringify([
+        ['a+b', { 'first.a': 1, 'second.b': 5 }],
+        ['a+b', { 'first.a': 1, 'second.b': 6 }],
+        ['a+b', { 'first.a': 1, 'second.b': 7 }],
+        ['a+b', { 'first.a': 2, 'second.b': 5 }],
+        ['a+b', { 'first.a': 2, 'second.b': 6 }],
+        ['a+b', { 'first.a': 2, 'second.b': 7 }],
+        ['a+b', { 'first.a': 3, 'second.b': 5 }],
+        ['a+b', { 'first.a': 3, 'second.b': 6 }],
+        ['a+b', { 'first.a': 3, 'second.b': 7 }],
+        ['a+b', { 'first.a': 4, 'second.b': 5 }],
+        ['a+b', { 'first.a': 4, 'second.b': 6 }],
+        ['a+b', { 'first.a': 4, 'second.b': 7 }],
+    ]);
+
+    let acc = [];
+
+    let union = Builtin.tableJoin(lhs, rhs);
+    return runStream(acc, union).then(() => {
+        if (JSON.stringify(acc) !== expect) {
+            console.error('Expected:', expect);
+            console.error('Computed:', acc);
+            throw new Error();
+        }
+    }).catch((e) => {
+        console.error('testCrossJoin FAILED', e.stack);
+        if (process.env.TEST_MODE)
+            throw e;
+    });
+}
+
 function testCrossJoin() {
     let lhs = testStream([[1000, ['a', {a:1}]], [5000, ['a', {a:2}]], [0, ['a', {a:3}]], [10000, ['a', {a:4}]]]);
     let rhs = testStream([[500, ['b', {b:5}]], [6000, ['b', {b:6}]], [1000, ['b', {b:7}]]]);
@@ -154,6 +188,8 @@ function testEdgeNew() {
 export default async function main() {
     console.log('testStreamUnion');
     await timeout(30000, testStreamUnion());
+    console.log('testJoin');
+    await timeout(30000, testJoin());
     console.log('testCrossJoin');
     await timeout(30000, testCrossJoin());
     console.log('testEdgeNew');

--- a/test/test_compiler.txt
+++ b/test/test_compiler.txt
@@ -11510,7 +11510,7 @@ ontimer(date=[set_time(new Date(2021, 0, 1), new Time(10, 30, 0))]) => @org.thin
   }
 ====
 // 114
-@com.spotify2.song() join @com.spotify2.album() on first.album == second.id;
+(@com.spotify2.song() join @com.spotify2.album()) filter first.album == second.id;
 >>>>
   "use strict";
   let _t_0;

--- a/test/test_compiler.txt
+++ b/test/test_compiler.txt
@@ -11508,3 +11508,146 @@ ontimer(date=[set_time(new Date(2021, 0, 1), new Time(10, 30, 0))]) => @org.thin
   } finally {
     await __env.exitProcedure(0, null);
   }
+====
+// 114
+@com.spotify2.song() join @com.spotify2.album() on first.album == second.id;
+>>>>
+  "use strict";
+  let _t_0;
+  let _t_1;
+  let _t_2;
+  let _t_3;
+  let _t_4;
+  let _t_5;
+  let _t_6;
+  let _t_7;
+  let _t_8;
+  let _t_9;
+  let _t_10;
+  let _t_11;
+  let _t_12;
+  let _t_13;
+  let _t_14;
+  let _t_15;
+  let _t_16;
+  let _t_17;
+  let _t_18;
+  let _t_19;
+  let _t_20;
+  let _t_21;
+  let _t_22;
+  let _t_23;
+  let _t_24;
+  let _t_25;
+  let _t_26;
+  let _t_27;
+  let _t_28;
+  let _t_29;
+  let _t_30;
+  let _t_31;
+  let _t_32;
+  let _t_33;
+  let _t_34;
+  let _t_35;
+  let _t_36;
+  let _t_37;
+  let _t_38;
+  let _t_39;
+  let _t_40;
+  let _t_41;
+  let _t_42;
+  let _t_43;
+  let _t_44;
+  let _t_45;
+  let _t_46;
+  await __env.enterProcedure(0, null);
+  try {
+    _t_0 = async function(__emit) {
+      try {
+        _t_1 = {};
+        _t_2 = await __env.invokeQuery("com.spotify2", { }, "song", _t_1, { projection: [] });
+        _t_3 = __builtin.getAsyncIterator(_t_2);
+        {
+          let _iter_tmp = await _t_3.next();
+          while (!_iter_tmp.done) {
+            _t_4 = _iter_tmp.value;
+            _t_5 = _t_4[0];
+            _t_6 = _t_4[1];
+            _t_7 = _t_6.__response;
+            _t_8 = _t_6.id;
+            _t_9 = _t_6.artists;
+            _t_10 = _t_6.album;
+            _t_11 = _t_6.genres;
+            _t_12 = _t_6.release_date;
+            _t_13 = _t_6.popularity;
+            _t_14 = _t_6.energy;
+            _t_15 = _t_6.danceability;
+            __emit(_t_5, _t_6);
+            _iter_tmp = await _t_3.next();
+          }
+        }
+      } catch(_exc_) {
+        __env.reportError("Failed to invoke query", _exc_);
+      }
+    }
+    _t_16 = async function(__emit) {
+      try {
+        _t_17 = {};
+        _t_18 = await __env.invokeQuery("com.spotify2", { }, "album", _t_17, { projection: [] });
+        _t_19 = __builtin.getAsyncIterator(_t_18);
+        {
+          let _iter_tmp = await _t_19.next();
+          while (!_iter_tmp.done) {
+            _t_20 = _iter_tmp.value;
+            _t_21 = _t_20[0];
+            _t_22 = _t_20[1];
+            _t_23 = _t_22.__response;
+            _t_24 = _t_22.id;
+            _t_25 = _t_22.artists;
+            _t_26 = _t_22.release_date;
+            _t_27 = _t_22.popularity;
+            __emit(_t_21, _t_22);
+            _iter_tmp = await _t_19.next();
+          }
+        }
+      } catch(_exc_) {
+        __env.reportError("Failed to invoke query", _exc_);
+      }
+    }
+    _t_28 = __builtin.tableJoin(_t_0, _t_16);
+    {
+      let _iter_tmp = await _t_28.next();
+      while (!_iter_tmp.done) {
+        _t_29 = _iter_tmp.value;
+        _t_30 = _t_29[0];
+        _t_31 = _t_29[1];
+        _t_32 = _t_31.first.__response;
+        _t_33 = _t_31.first.id;
+        _t_34 = _t_31.first.artists;
+        _t_35 = _t_31.first.album;
+        _t_36 = _t_31.first.genres;
+        _t_37 = _t_31.first.release_date;
+        _t_38 = _t_31.first.popularity;
+        _t_39 = _t_31.first.energy;
+        _t_40 = _t_31.first.danceability;
+        _t_41 = _t_31.second.__response;
+        _t_42 = _t_31.second.id;
+        _t_43 = _t_31.second.artists;
+        _t_44 = _t_31.second.release_date;
+        _t_45 = _t_31.second.popularity;
+        _t_46 = __builtin.equality(_t_35, _t_42);
+        if (_t_46) {
+          try {
+            await __env.output(String(_t_30), _t_31);
+          } catch(_exc_) {
+            __env.reportError("Failed to invoke action", _exc_);
+          }
+        } else {
+
+        }
+        _iter_tmp = await _t_28.next();
+      }
+    }
+  } finally {
+    await __env.exitProcedure(0, null);
+  }

--- a/test/test_compiler.txt
+++ b/test/test_compiler.txt
@@ -11621,20 +11621,20 @@ ontimer(date=[set_time(new Date(2021, 0, 1), new Time(10, 30, 0))]) => @org.thin
         _t_29 = _iter_tmp.value;
         _t_30 = _t_29[0];
         _t_31 = _t_29[1];
-        _t_32 = _t_31.first.__response;
-        _t_33 = _t_31.first.id;
-        _t_34 = _t_31.first.artists;
-        _t_35 = _t_31.first.album;
-        _t_36 = _t_31.first.genres;
-        _t_37 = _t_31.first.release_date;
-        _t_38 = _t_31.first.popularity;
-        _t_39 = _t_31.first.energy;
-        _t_40 = _t_31.first.danceability;
-        _t_41 = _t_31.second.__response;
-        _t_42 = _t_31.second.id;
-        _t_43 = _t_31.second.artists;
-        _t_44 = _t_31.second.release_date;
-        _t_45 = _t_31.second.popularity;
+        _t_32 = _t_31["first.__response"];
+        _t_33 = _t_31["first.id"];
+        _t_34 = _t_31["first.artists"];
+        _t_35 = _t_31["first.album"];
+        _t_36 = _t_31["first.genres"];
+        _t_37 = _t_31["first.release_date"];
+        _t_38 = _t_31["first.popularity"];
+        _t_39 = _t_31["first.energy"];
+        _t_40 = _t_31["first.danceability"];
+        _t_41 = _t_31["second.__response"];
+        _t_42 = _t_31["second.id"];
+        _t_43 = _t_31["second.artists"];
+        _t_44 = _t_31["second.release_date"];
+        _t_45 = _t_31["second.popularity"];
         _t_46 = __builtin.equality(_t_35, _t_42);
         if (_t_46) {
           try {

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -2076,3 +2076,13 @@ $dialogue @org.thingpedia.dialogue.transaction;
 // ** expect TypeError **
 // wrong projection over join
 [id] of (@org.wikidata.city() join @org.wikidata.city()) filter in_array(first.id, second.twinned_administrative_body);
+
+
+====
+
+// result of join
+$dialogue @org.thingpedia.dialogue.transaction.execute;
+@org.wikidata.city() join @org.wikidata.city()
+#[results=[
+  { first.id="..."^^org.wikidata:city, second.id="..."^^org.wikidata:city }
+]];

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -2025,54 +2025,54 @@ $dialogue @org.thingpedia.dialogue.transaction;
 ====
 
 // join with condition 1
-@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body);
+(@org.wikidata.city() join @org.wikidata.city()) filter in_array(first.id, second.twinned_administrative_body);
 
 
 ====
 
 // join with condition 2
-@org.wikidata.city() join @org.wikidata.city() on (in_array(first.id, second.twinned_administrative_body) && !(first.id == second.id)) ;
+(@org.wikidata.city() join @org.wikidata.city()) filter (in_array(first.id, second.twinned_administrative_body) && !(first.id == second.id)) ;
 
 ====
 
 // projection over join
-[first.id, second.id] of (@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body));
+[first.id, second.id] of ((@org.wikidata.city() join @org.wikidata.city()) filter in_array(first.id, second.twinned_administrative_body));
 
 ====
 
 // projection inside join
-([id] of @org.wikidata.city()) join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body);
+(([id] of @org.wikidata.city()) join @org.wikidata.city()) filter in_array(first.id, second.twinned_administrative_body);
 
 ====
 
 // filter over join
-(@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body)) filter first.population <= 10000;
+((@org.wikidata.city() join @org.wikidata.city()) filter in_array(first.id, second.twinned_administrative_body)) filter first.population <= 10000;
 
 ====
 
 // filter inside join
-@org.wikidata.city() filter population <= 10000 join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body);
+(@org.wikidata.city() filter population <= 10000 join @org.wikidata.city()) filter in_array(first.id, second.twinned_administrative_body);
 
 ====
 
 // multiple joins
-[first.first.id, first.second.id, second.id] of ((@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body)) join @org.wikidata.city() on in_array(first.second.id, second.twinned_administrative_body));
+[first.first.id, first.second.id, second.id] of (((@org.wikidata.city() join @org.wikidata.city()) filter in_array(first.id, second.twinned_administrative_body)) join @org.wikidata.city()) filter in_array(first.second.id, second.twinned_administrative_body);
 
 ====
 
 // ** expect TypeError **
 // Join with invalid condition 1
-@org.wikidata.city() join @org.wikidata.city() on in_array(first.xyz, second.twinned_administrative_body);
+(@org.wikidata.city() join @org.wikidata.city()) filter in_array(first.xyz, second.twinned_administrative_body);
 
 
 ====
 
 // ** expect TypeError **
 // Join with invalid condition 2
-@org.wikidata.city() join @org.wikidata.city() on first.id =~ "xyz";
+(@org.wikidata.city() join @org.wikidata.city()) filter id =~ "xyz";
 
 ====
 
 // ** expect TypeError **
 // wrong projection over join
-[id] of (@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body));
+[id] of (@org.wikidata.city() join @org.wikidata.city()) filter in_array(first.id, second.twinned_administrative_body);

--- a/test/test_syntax.tt
+++ b/test/test_syntax.tt
@@ -2015,3 +2015,64 @@ $dialogue @org.thingpedia.dialogue.transaction;
 // bad relative time
 // ** expect TypeError **
 @org.thingpedia.builtin.thingengine.builtin.get_time(), time == $time.foo;
+
+====
+
+// join
+@org.wikidata.city() join @org.wikidata.city();
+
+
+====
+
+// join with condition 1
+@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body);
+
+
+====
+
+// join with condition 2
+@org.wikidata.city() join @org.wikidata.city() on (in_array(first.id, second.twinned_administrative_body) && !(first.id == second.id)) ;
+
+====
+
+// projection over join
+[first.id, second.id] of (@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body));
+
+====
+
+// projection inside join
+([id] of @org.wikidata.city()) join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body);
+
+====
+
+// filter over join
+(@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body)) filter first.population <= 10000;
+
+====
+
+// filter inside join
+@org.wikidata.city() filter population <= 10000 join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body);
+
+====
+
+// multiple joins
+[first.first.id, first.second.id, second.id] of ((@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body)) join @org.wikidata.city() on in_array(first.second.id, second.twinned_administrative_body));
+
+====
+
+// ** expect TypeError **
+// Join with invalid condition 1
+@org.wikidata.city() join @org.wikidata.city() on in_array(first.xyz, second.twinned_administrative_body);
+
+
+====
+
+// ** expect TypeError **
+// Join with invalid condition 2
+@org.wikidata.city() join @org.wikidata.city() on first.id =~ "xyz";
+
+====
+
+// ** expect TypeError **
+// wrong projection over join
+[id] of (@org.wikidata.city() join @org.wikidata.city() on in_array(first.id, second.twinned_administrative_body));


### PR DESCRIPTION
The new `join` returns a pair of results for each side of the join. The returned result is flattened, where the fields from the left-hand side are prefixed with `first.` and the fields from the right-hand side are prefixed with `second.` 
The syntax allows projection/filter over joins, however, in practice, they should all be pushed down to either the left-hand side or the right-hand side. This is not currently enforced. Not sure if we want to enforce it in typechecking or optimization, or simply leave it to genie. 