### PR TITLE
Fix prettyprinting of enum types that are keywords

### DIFF
--- a/lib/new-syntax/pretty.ts
+++ b/lib/new-syntax/pretty.ts
@@ -267,7 +267,7 @@ export function prettyprint(tokens : TokenStream) : string {
         case 'extends':
         case 'join':
         case 'on':
-            if (buffer.endsWith('enum '))
+            if (buffer.endsWith('enum ') || buffer.endsWith('Enum('))
                 buffer += token;
             else
                 buffer += ' ' + token + ' ';

--- a/test/test_prettyprint.js
+++ b/test/test_prettyprint.js
@@ -101,7 +101,12 @@ const TEST_CASES = [
 // entity inheritance
 `class @com.example {
   entity a extends b, c;
-}`
+}`,
+
+// enums that are keywords
+`dataset @foo {
+  action (p : Enum(on, off)) = @light-bulb.set_power(power=p);
+}`,
 ];
 
 export default function main() {


### PR DESCRIPTION
Avoid an extra space

---

This is quite important because it is triggered by the Thingpedia API tests in almond-cloud, and I don't wish to update all of them.