### PR TITLE
Make ThingTalk timezone-aware

### DIFF
--- a/lib/compiler/index.ts
+++ b/lib/compiler/index.ts
@@ -69,8 +69,8 @@ export default class AppCompiler {
         this._astVars = [];
     }
 
-    compileCode(code : string) : Promise<CompiledProgram> {
-        const parsed = Grammar.parse(code);
+    compileCode(code : string, options : Grammar.ParseOptions = { timezone: undefined }) : Promise<CompiledProgram> {
+        const parsed = Grammar.parse(code, Grammar.SyntaxType.Normal, options);
         if (!(parsed instanceof Ast.Program))
             throw new Error(`Not an executable program`);
         return this.compileProgram(parsed);

--- a/lib/compiler/jsir.ts
+++ b/lib/compiler/jsir.ts
@@ -375,15 +375,20 @@ class FunctionOp {
     private _fn : string;
     private _into : Register;
     private _args : Register[];
+    private _passEnv : boolean;
 
-    constructor(fn : string, into : Register, ...args : Register[]) {
+    constructor(fn : string, passEnv : boolean, into : Register, ...args : Register[]) {
         this._fn = fn;
         this._into = into;
         this._args = args;
+        this._passEnv = passEnv;
     }
 
     codegen(prefix : string) : string {
-        return `${prefix}_t_${this._into} = __builtin.${this._fn}(${this._args.map((a) => '_t_' + a).join(', ')});`;
+        if (this._passEnv)
+            return `${prefix}_t_${this._into} = __builtin.${this._fn}(__env, ${this._args.map((a) => '_t_' + a).join(', ')});`;
+        else
+            return `${prefix}_t_${this._into} = __builtin.${this._fn}(${this._args.map((a) => '_t_' + a).join(', ')});`;
     }
 }
 

--- a/lib/compiler/ops-to-jsir.ts
+++ b/lib/compiler/ops-to-jsir.ts
@@ -179,7 +179,7 @@ export default class OpCompiler {
         if (opimpl.op)
             this._irBuilder.add(new JSIr.BinaryOp(args[0], args[1], opimpl.op, result));
         else
-            this._irBuilder.add(new JSIr.FunctionOp(opimpl.fn as string, result, ...args));
+            this._irBuilder.add(new JSIr.FunctionOp(opimpl.fn as string, opimpl.env ?? false, result, ...args));
         return result;
     }
 
@@ -1284,7 +1284,7 @@ export default class OpCompiler {
             this._compileTableMap(tableop);
         else if (tableop instanceof TableOp.Reduce)
             this._compileTableReduce(tableop);
-        else if (tableop instanceof TableOp.Join) 
+        else if (tableop instanceof TableOp.Join)
             this._compileTableJoin(tableop);
         else if (tableop instanceof TableOp.CrossJoin)
             this._compileTableCrossJoin(tableop);

--- a/lib/compiler/reduceop.ts
+++ b/lib/compiler/reduceop.ts
@@ -661,7 +661,7 @@ export class ComplexIndex extends ArrayReduceOp<ComplexIndexState> {
     _doFinish(irBuilder : JSIr.IRBuilder,
               { indices, array } : ComplexIndexState) : JSIr.Register {
         const newArray = irBuilder.allocRegister();
-        irBuilder.add(new JSIr.FunctionOp('indexArray', newArray, array, indices));
+        irBuilder.add(new JSIr.FunctionOp('indexArray', false, newArray, array, indices));
         return newArray;
     }
 }
@@ -698,7 +698,7 @@ export class Slice extends ArrayReduceOp<SliceState> {
     _doFinish(irBuilder : JSIr.IRBuilder,
               { base, limit, array } : SliceState) : JSIr.Register {
         const newArray = irBuilder.allocRegister();
-        irBuilder.add(new JSIr.FunctionOp('sliceArray', newArray, array, base, limit));
+        irBuilder.add(new JSIr.FunctionOp('sliceArray', false, newArray, array, base, limit));
         return newArray;
     }
 }

--- a/lib/entity-retriever.ts
+++ b/lib/entity-retriever.ts
@@ -112,11 +112,9 @@ export abstract class AbstractEntityRetriever {
     protected _timezone : string;
 
     constructor(options : {
-        timezone ?: string
+        timezone : string|undefined
     }) {
-        if (!options.timezone)
-            console.log('Serializing ThingTalk without a timezone is deprecated');
-        this._timezone = options.timezone || Temporal.Now.timeZone().id;
+        this._timezone = options.timezone ?? Temporal.Now.timeZone().id;
         this._syntaxType = SyntaxType.LegacyNN;
     }
 
@@ -151,8 +149,8 @@ export class EntityRetriever extends AbstractEntityRetriever {
     entities : EntityMap;
 
     constructor(sentence : string|string[], entities : EntityMap, options : {
-        timezone ?: string
-    } = {}) {
+        timezone : string|undefined
+    }) {
         super(options);
         if (typeof sentence === 'string')
             sentence = sentence.split(' ');
@@ -363,9 +361,9 @@ export class SequentialEntityAllocator extends AbstractEntityRetriever {
     explicitStrings : boolean;
 
     constructor(entities : EntityMap, options : {
-        timezone ?: string,
+        timezone : string|undefined,
         explicitStrings ?: boolean
-    } = {}) {
+    }) {
         super(options);
         this.offsets = {};
         this.entities = entities;

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -19,6 +19,7 @@
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 
 {
+import { Temporal } from '@js-temporal/polyfill';
 import assert from 'assert';
 import * as Ast from '../ast';
 import Type, { TypeMap } from '../type';
@@ -26,6 +27,11 @@ import { KEYWORDS, FORBIDDEN_KEYWORDS } from './keywords';
 import { TypeOfToken } from './token';
 
 import { parseDate } from '../utils/date_utils';
+
+type ParserOptions = {
+    locale ?: string;
+    timezone ?: string;
+};
 
 type DialogueHistoryAnnotation =
       { key : 'results', value : Ast.DialogueHistoryResultItem[], type : 'impl' }
@@ -35,7 +41,7 @@ type DialogueHistoryAnnotation =
     | { key : string, value : Ast.Value, type : 'impl' }
     | { key : string, value : Ast.Value, type : 'nl' };
 
-function makeInput($ : $runtime.ParserInterface, statements : Ast.TopLevelStatement[], annotations : Ast.AnnotationSpec) {
+function makeInput($ : $runtime.ParserInterface<ParserOptions>, statements : Ast.TopLevelStatement[], annotations : Ast.AnnotationSpec) {
     const classes : Ast.ClassDef[] = [];
     const datasets : Ast.Dataset[] = [];
     const declarations : Ast.FunctionDeclaration[] = [];
@@ -65,7 +71,7 @@ function makeInput($ : $runtime.ParserInterface, statements : Ast.TopLevelStatem
     return new Ast.Program($.location, classes, declarations, executable, annotations);
 }
 
-function makeClassDef($ : $runtime.ParserInterface,
+function makeClassDef($ : $runtime.ParserInterface<ParserOptions>,
                       name : string,
                       _extends : string[]|null,
                       members : Ast.ClassMember[],
@@ -120,7 +126,7 @@ interface AnnotationEntry {
     value : Ast.Value;
 }
 
-function checkExampleAnnotations($ : $runtime.ParserInterface, annotations : AnnotationEntry[]) : [number, string[], string[], Ast.AnnotationMap] {
+function checkExampleAnnotations($ : $runtime.ParserInterface<ParserOptions>, annotations : AnnotationEntry[]) : [number, string[], string[], Ast.AnnotationMap] {
     let id = -1;
     const utterances : string[] = [];
     const preprocessed : string[] = [];
@@ -173,7 +179,7 @@ function splitAnnotations(annotations : AnnotationEntry[]) {
     return { nl: nl_annotations, impl: impl_annotations };
 }
 
-function parseIncompleteDate($ : $runtime.ParserInterface,
+function parseIncompleteDate($ : $runtime.ParserInterface<ParserOptions>,
                              params : Array<number|','>,
                              time : Ast.AbsoluteTime|null) : Ast.DateValue {
     const parts : Array<number|null> = [];
@@ -211,7 +217,11 @@ function parseIncompleteDate($ : $runtime.ParserInterface,
         // (these are exactly equivalent because the incomplete bits are
         // set to 1 or 0)
 
-        const d = new Date;
+        let d = Temporal.Now.zonedDateTime('iso8601', $.timezone).with({
+            // remove excess precision
+            microsecond: 0,
+            nanosecond: 0
+        });
         if (parts.length === 1 && !time) {
             let unix_or_year = parts[0];
 
@@ -227,11 +237,13 @@ function parseIncompleteDate($ : $runtime.ParserInterface,
                         unix_or_year += 2000;
                 }
 
-                d.setFullYear(unix_or_year);
-                d.setMonth(0, 1);
-                d.setHours(0, 0, 0, 0);
+                d = d.with({ year: unix_or_year, month: 1, day: 1,
+                    hour: 0, minute: 0, second: 0, millisecond: 0 });
             } else {
-                d.setTime(unix_or_year);
+                d = Temporal.Instant.fromEpochMilliseconds(unix_or_year).toZonedDateTime({
+                    timeZone: $.timezone!,
+                    calendar: 'iso8601'
+                });
             }
         } else {
             let year = parts[0];
@@ -242,18 +254,17 @@ function parseIncompleteDate($ : $runtime.ParserInterface,
                     year += 2000;
             }
 
-            d.setFullYear(year);
-            // set both the month and the date at the same time
-            // otherwise when today's date is the 31st and the chosen
-            // month has 30 days, the Date will be adjusted to the
-            // first day of the subsequent month, which is wrong
-            d.setMonth((parts[1] || 1) - 1, parts[2] || 1);
+            d = d.with({
+                year: year,
+                month: (parts[1] || 1),
+                day: parts[2] || 1,
+            });
             if (time)
-                d.setHours(time.hour, time.minute, time.second, 0);
+                d = d.withPlainTime(time);
             else
-                d.setHours(parts[3] || 0, parts[4] || 0, parts[5] || 0, 0);
+                d = d.withPlainTime({ hour: parts[3] || 0, minute: parts[4] || 0, second: parts[5] || 0, millisecond: 0 });
         }
-        return new Ast.Value.Date(d);
+        return new Ast.Value.Date(new Date(d.epochMilliseconds));
     } else {
         const year = parts[0]||null;
         const month = parts[1]||null;
@@ -265,7 +276,7 @@ function parseIncompleteDate($ : $runtime.ParserInterface,
     }
 }
 
-function checkDialogueHistoryAnnotationSpec($ : $runtime.ParserInterface,
+function checkDialogueHistoryAnnotationSpec($ : $runtime.ParserInterface<ParserOptions>,
                                             spec : Ast.AnnotationSpec) {
     if (!spec.impl)
         return spec;
@@ -277,6 +288,8 @@ function checkDialogueHistoryAnnotationSpec($ : $runtime.ParserInterface,
 }
 
 }
+
+$options = ParserOptions;
 
 terminal CLASS_OR_FUNCTION_REF : TypeOfToken<'CLASS_OR_FUNCTION_REF'>;
 terminal SLOT : TypeOfToken<'SLOT'>;
@@ -920,7 +933,7 @@ toplevel_chain_expression : Ast.ChainExpression = {
 
 chain_expression_list : Ast.Expression[] = {
     expr:join_expression => [expr];
-    
+
     list:chain_expression_list '=>' expr:join_expression => {
         list.push(expr);
         return list;
@@ -929,7 +942,7 @@ chain_expression_list : Ast.Expression[] = {
 
 join_expression : Ast.Expression = {
     projection_expression;
-    
+
     lhs:join_expression 'join' rhs:projection_expression => {
         return new Ast.JoinExpression($.location, lhs, rhs, null);
     };
@@ -1548,7 +1561,7 @@ date_param_list : Array<number|','> = {
 }
 
 absolute_or_edge_date : Ast.DateValue = {
-    abs:DATE => new Ast.Value.Date(parseDate(abs.value));
+    abs:DATE => new Ast.Value.Date(parseDate(abs.value, $.timezone));
     'new' 'Date' '(' iso:any_string ')' => {
         return new Ast.Value.Date(new Date(iso));
     };

--- a/lib/nn-syntax/index.ts
+++ b/lib/nn-syntax/index.ts
@@ -54,14 +54,17 @@ import applyCompatibility from './compat';
  * @param {Object<string, any>} entities - concrete values of the entities referred in the program.
  * @return {Ast.Input} - the parsed program
  */
-function fromNN(input : string|string[], entities : EntityMap|EntityResolver) : Ast.Input {
+function fromNN(input : string|string[], entities : EntityMap|EntityResolver, options : {
+    locale ?: string,
+    timezone ?: string
+} = {}) : Ast.Input {
     let sequence : string[];
     if (typeof input === 'string')
         sequence = input.split(' ');
     else
         sequence = input;
 
-    const parser = new Parser();
+    const parser = new Parser(options);
     return parser.parse({
         [Symbol.iterator]() {
             return new Lexer(sequence, entities);

--- a/lib/nn-syntax/parser.lr
+++ b/lib/nn-syntax/parser.lr
@@ -28,7 +28,15 @@ type DialogueHistoryAnnotation =
     | { key : 'error', value : Ast.Value }
     | { key : 'count', value : Ast.Value }
     | { key : 'more', value : true };
+
+type ParserOptions = {
+    locale ?: string;
+    timezone ?: string;
+};
+
 }
+
+$options = ParserOptions;
 
 /**
  * Missing features, compared with full TT:
@@ -803,7 +811,7 @@ absolute_or_edge_date : Ast.DateValue = {
         return new Ast.Value.Date(new Date(iso));
     };
 
-    abs:DATE => new Ast.Value.Date(parseDate(abs.value));
+    abs:DATE => new Ast.Value.Date(parseDate(abs.value, $.timezone));
 
     'new' 'Date' '(' year:constant_Number ',' ',' ',' ')' => {
         return new Ast.Value.Date(new Ast.DatePiece(year.value, null, null, null));

--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -47,6 +47,11 @@ export interface OpImplementation {
      * Invert the arguments of the JS function/operator compared to the ThingTalk operator.
      */
     flip ?: boolean;
+
+    /**
+     * Pass the ExecEnvironment as the first argument to the function.
+     */
+    env ?: boolean;
 }
 
 export type OverloadResolver = (...types : Type[]) => OpImplementation;
@@ -318,7 +323,8 @@ export const ScalarExpressionOps : { [op : string] : OpDefinition } = {
     },
     'set_time': {
         types: [[Type.Date, Type.Time, Type.Date]],
-        fn: 'setTime'
+        fn: 'setTime',
+        env: true
     }
 };
 

--- a/lib/runtime/exec_environment.ts
+++ b/lib/runtime/exec_environment.ts
@@ -76,6 +76,16 @@ export abstract class ExecEnvironment {
         throw new Error('Must be overridden');
     }
 
+    /* istanbul ignore next */
+    get locale() : string {
+        throw new Error('Must be overridden');
+    }
+
+    /* istanbul ignore next */
+    get timezone() : string {
+        throw new Error('Must be overridden');
+    }
+
     /**
      * Returns a unique id of the current stack frame.
      *

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -96,6 +96,8 @@ interface EntityTypeRecord {
  * implemented by the Thingpedia SDK.
  */
 export interface AbstractThingpediaClient {
+    get locale() : string;
+
     /**
      * Retrieve the full code of a Thingpedia class.
      *
@@ -255,7 +257,7 @@ export default class SchemaRetriever {
 
     private async _getManifestRequest(kind : string) {
         const code = await this._thingpediaClient.getDeviceCode(kind);
-        const parsed = await Grammar.parse(code).typecheck(this);
+        const parsed = await Grammar.parse(code, Grammar.SyntaxType.Normal, { locale: this._thingpediaClient.locale, timezone: undefined }).typecheck(this);
         assert(parsed instanceof Library && parsed.classes.length > 0);
         return parsed.classes[0];
     }
@@ -305,7 +307,7 @@ export default class SchemaRetriever {
             return {};
         }
 
-        const parsed = Grammar.parse(code) as Library;
+        const parsed = Grammar.parse(code, Grammar.SyntaxType.Normal, { locale: this._thingpediaClient.locale, timezone: undefined }) as Library;
         const result : ClassMap = {};
         const missing = new Set<string>(pending);
 
@@ -534,7 +536,7 @@ export default class SchemaRetriever {
             for (const kind of pending)
                 this._classCache.dataset.set(kind, result[kind] = new Dataset(null, kind, []));
         } else {
-            const parsed = Grammar.parse(code) as Library;
+            const parsed = Grammar.parse(code, Grammar.SyntaxType.Normal, { locale: this._thingpediaClient.locale, timezone: undefined }) as Library;
 
             const examples = new Map<string, Example[]>();
 

--- a/lib/syntax_api.ts
+++ b/lib/syntax_api.ts
@@ -66,23 +66,28 @@ export enum SyntaxType {
     Tokenized,
 }
 
+export interface ParseOptions {
+    locale ?: string,
+    timezone ?: string
+}
+
 /**
  * Parse a string into a ThingTalk {@link Ast}
  *
  * @param {string} code - the ThingTalk code to parse
  * @return {Ast.Input} the parsed program, library or permission rule
  */
-export function parse(code : string|string[], syntaxType : SyntaxType.Tokenized|SyntaxType.LegacyNN, entities : EntityMap|EntityResolver) : Ast.Input;
-export function parse(code : string, syntaxType ?: SyntaxType.Normal|SyntaxType.Legacy) : Ast.Input;
-export function parse(code : string|string[], syntaxType : SyntaxType = SyntaxType.Normal, entities ?: EntityMap|EntityResolver) : Ast.Input {
+export function parse(code : string|string[], syntaxType : SyntaxType.Tokenized|SyntaxType.LegacyNN, entities : EntityMap|EntityResolver, options ?: ParseOptions) : Ast.Input;
+export function parse(code : string, syntaxType ?: SyntaxType.Normal|SyntaxType.Legacy, options ?: ParseOptions) : Ast.Input;
+export function parse(code : string|string[], syntaxType : SyntaxType = SyntaxType.Normal, entities ?: EntityMap|EntityResolver|ParseOptions, options ?: ParseOptions) : Ast.Input {
     let input : Ast.Input;
     if (syntaxType === SyntaxType.Tokenized) {
-        input = new Parser().parse(nnLexer(code, entities!));
+        input = new Parser(options ?? {}).parse(nnLexer(code, entities as EntityMap|EntityResolver));
     } else if (syntaxType === SyntaxType.LegacyNN) {
-        input = LegacyNNSyntax.fromNN(code, entities!);
+        input = LegacyNNSyntax.fromNN(code, entities as EntityMap|EntityResolver);
     } else if (syntaxType === SyntaxType.Normal) {
         assert(typeof code === 'string');
-        input = new Parser().parse(surfaceLexer(code as string));
+        input = new Parser((entities as ParseOptions) ?? {}).parse(surfaceLexer(code as string));
     } else {
         // workaround grammar bug with // comments at the end of input
         input = Grammar.parse(code + '\n') as any;

--- a/lib/syntax_api.ts
+++ b/lib/syntax_api.ts
@@ -68,7 +68,7 @@ export enum SyntaxType {
 
 export interface ParseOptions {
     locale ?: string,
-    timezone ?: string
+    timezone : string|undefined
 }
 
 /**
@@ -77,8 +77,8 @@ export interface ParseOptions {
  * @param {string} code - the ThingTalk code to parse
  * @return {Ast.Input} the parsed program, library or permission rule
  */
-export function parse(code : string|string[], syntaxType : SyntaxType.Tokenized|SyntaxType.LegacyNN, entities : EntityMap|EntityResolver, options ?: ParseOptions) : Ast.Input;
-export function parse(code : string, syntaxType ?: SyntaxType.Normal|SyntaxType.Legacy, options ?: ParseOptions) : Ast.Input;
+export function parse(code : string|string[], syntaxType : SyntaxType.Tokenized|SyntaxType.LegacyNN, entities : EntityMap|EntityResolver, options : ParseOptions) : Ast.Input;
+export function parse(code : string, syntaxType : SyntaxType.Normal|SyntaxType.Legacy, options : ParseOptions) : Ast.Input;
 export function parse(code : string|string[], syntaxType : SyntaxType = SyntaxType.Normal, entities ?: EntityMap|EntityResolver|ParseOptions, options ?: ParseOptions) : Ast.Input {
     let input : Ast.Input;
     if (syntaxType === SyntaxType.Tokenized) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,6 +410,15 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@js-temporal/polyfill": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.2.0.tgz",
+      "integrity": "sha512-GyjuWEUpK2i+hGIfFOEdA8iVS4xPNLupwCgU9CiQFbMH+QW8De/4egT1MSod3ZmPDLyuxvFJ1285Cg3QuZOVBQ==",
+      "requires": {
+        "big-integer": "^1.6.48",
+        "es-abstract": "^1.18.3"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -723,6 +732,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -782,7 +796,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1046,7 +1059,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1116,7 +1128,6 @@
       "version": "1.18.5",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
       "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -1157,7 +1168,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -1506,8 +1516,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1531,7 +1540,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -1646,7 +1654,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1654,8 +1661,7 @@
     "has-bigints": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-      "dev": true
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -1666,14 +1672,12 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -1761,7 +1765,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -1782,7 +1785,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -1791,7 +1793,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -1800,14 +1801,12 @@
     "is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
     },
     "is-date-object": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -1842,8 +1841,7 @@
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-      "dev": true
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
     },
     "is-number": {
       "version": "7.0.0",
@@ -1855,7 +1853,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
       "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -1864,7 +1861,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -1886,7 +1882,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -1895,7 +1890,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -2364,8 +2358,7 @@
     "object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -2380,14 +2373,12 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -2757,7 +2748,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -2898,7 +2888,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
       "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -2908,7 +2897,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
       "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -3146,7 +3134,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -3205,7 +3192,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
+    "@js-temporal/polyfill": "^0.2.0",
     "@types/semver": "^7.3.7",
     "byline": "^5.0.0",
     "consumer-queue": "^1.0.0",

--- a/test/test_builtin_values.js
+++ b/test/test_builtin_values.js
@@ -125,7 +125,7 @@ export default function main() {
     assert(equality(new Date('2019-04-30T15:00:00.000Z'), new Date('2019-04-30T15:00:00.000Z')));
     assert(equality(new Date('2019-04-30T15:00:00.000Z'), 1556636400000));
     assert(equality(1556636400000, new Date('2019-04-30T15:00:00.000Z')));
-    assert(equality(setTime(new Date(2019, 4, 30), new __builtin.Time(9, 30)), new Date(2019, 4, 30, 9, 30, 0)));
+    assert(equality(setTime({ timezone: 'America/Los_Angeles' }, new Date(2019, 4, 30), new __builtin.Time(9, 30)), new Date(2019, 4, 30, 9, 30, 0)));
 
     assert(equality([1, 2], [1, 2]));
     assert(equality([], []));

--- a/test/test_compiler.txt
+++ b/test/test_compiler.txt
@@ -11422,7 +11422,7 @@ ontimer(date=[set_time(new Date(2021, 0, 1), new Time(10, 30, 0))]) => @org.thin
     _t_1 = new Array(1);
     _t_2 = new Date(XNOWX);
     _t_3 = new __builtin.Time(10, 30, 0);
-    _t_4 = __builtin.setTime(_t_2, _t_3);
+    _t_4 = __builtin.setTime(__env, _t_2, _t_3);
     _t_1[0] = _t_4;
     _t_0 = await __env.invokeOnTimer(_t_1);
     _t_5 = null;

--- a/test/test_legacy_nn_syntax.js
+++ b/test/test_legacy_nn_syntax.js
@@ -656,7 +656,9 @@ async function testCase(test, i) {
             return;
         await program.typecheck(schemaRetriever);
 
-        let entityRetriever = new Grammar.EntityRetriever(sentence, entities);
+        let entityRetriever = new Grammar.EntityRetriever(sentence, entities, {
+            timezone: 'America/Los_Angeles'
+        });
         let reconstructed = Grammar.serialize(program, Grammar.SyntaxType.LegacyNN, entityRetriever).join(' ');
         if (reconstructed !== test[0]) {
             console.error('Test Case #' + (i+1) + ' failed (wrong NN syntax)');

--- a/test/test_legacy_nn_syntax.js
+++ b/test/test_legacy_nn_syntax.js
@@ -641,7 +641,9 @@ async function testCase(test, i) {
     console.log('Test Case #' + (i+1));
     try {
         sequence = sequence.split(' ');
-        let program = Grammar.parse(sequence, Grammar.SyntaxType.LegacyNN, entities);
+        let program = Grammar.parse(sequence, Grammar.SyntaxType.LegacyNN, entities, {
+            timezone: 'America/Los_Angeles'
+        });
         let generated = program.prettyprint();
 
         if (generated !== expected) {
@@ -668,7 +670,9 @@ async function testCase(test, i) {
                 throw new Error(`testNNSyntax ${i+1} FAILED`);
         }
 
-        entityRetriever = new Grammar.EntityRetriever(sentence, entities);
+        entityRetriever = new Grammar.EntityRetriever(sentence, entities, {
+            timezone: 'America/Los_Angeles'
+        });
         let withoutTypeAnnotations = Grammar.serialize(program, Grammar.SyntaxType.LegacyNN, entityRetriever, { typeAnnotations: false }).join(' ');
         if (withoutTypeAnnotations !== stripTypeAnnotations(test[0])) {
             console.error('Test Case #' + (i+1) + ' failed (wrong NN syntax without type annotations)');

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -684,7 +684,9 @@ async function testCase(test, i) {
             return;
         await program.typecheck(schemaRetriever);
 
-        let entityRetriever = new Grammar.EntityRetriever(sentence, entities);
+        let entityRetriever = new Grammar.EntityRetriever(sentence, entities, {
+            timezone: 'America/Los_Angeles'
+        });
         let reconstructed = Grammar.serialize(program, Grammar.SyntaxType.Tokenized, entityRetriever).join(' ');
         if (reconstructed !== test[0]) {
             console.error('Test Case #' + (i+1) + ' failed (wrong NN syntax)');

--- a/test/test_nn_syntax_allocator.js
+++ b/test/test_nn_syntax_allocator.js
@@ -139,7 +139,9 @@ async function testCase(test, i) {
         await program.typecheck(schemaRetriever);
 
         const into = {};
-        const allocator = new Grammar.SequentialEntityAllocator(into);
+        const allocator = new Grammar.SequentialEntityAllocator(into, {
+            timezone: 'America/Los_Angeles'
+        });
         let reconstructed = Grammar.serialize(program, Grammar.SyntaxType.Tokenized, allocator).join(' ');
         if (reconstructed !== test[0]) {
             console.error('Test Case #' + (i+1) + ' failed (wrong NN syntax)');

--- a/test/test_nn_syntax_allocator.js
+++ b/test/test_nn_syntax_allocator.js
@@ -135,7 +135,9 @@ async function testCase(test, i) {
     console.log('Test Case #' + (i+1));
     try {
         sequence = sequence.split(' ');
-        let program = Grammar.parse(sequence, Grammar.SyntaxType.Tokenized, entities);
+        let program = Grammar.parse(sequence, Grammar.SyntaxType.Tokenized, entities, {
+            timezone: 'America/Los_Angeles'
+        });
         await program.typecheck(schemaRetriever);
 
         const into = {};

--- a/test/test_nn_syntax_allocator_2.js
+++ b/test/test_nn_syntax_allocator_2.js
@@ -97,7 +97,9 @@ async function testCase(test, i) {
 
     console.log('Test Case #' + (i+1));
     try {
-        let program1 = Grammar.parse(sequence1.split(' '), Grammar.SyntaxType.Tokenized, {});
+        let program1 = Grammar.parse(sequence1.split(' '), Grammar.SyntaxType.Tokenized, {}, {
+            timezone: 'America/Los_Angeles'
+        });
         await program1.typecheck(schemaRetriever);
 
         const into = {};

--- a/test/test_nn_syntax_allocator_2.js
+++ b/test/test_nn_syntax_allocator_2.js
@@ -101,11 +101,15 @@ async function testCase(test, i) {
         await program1.typecheck(schemaRetriever);
 
         const into = {};
-        const allocator1 = new Grammar.SequentialEntityAllocator(into);
+        const allocator1 = new Grammar.SequentialEntityAllocator(into, {
+            timezone: 'America/Los_Angeles'
+        });
         Grammar.serialize(program1, Grammar.SyntaxType.Tokenized, allocator1).join(' ');
         assert.deepStrictEqual(into, entities1);
 
-        const allocator2 = new Grammar.SequentialEntityAllocator(into);
+        const allocator2 = new Grammar.SequentialEntityAllocator(into, {
+            timezone: 'America/Los_Angeles'
+        });
         const program2 = Grammar.parse(sequence2.split(' '), Grammar.SyntaxType.Tokenized, {});
         await program2.typecheck(schemaRetriever);
         Grammar.serialize(program2, Grammar.SyntaxType.Tokenized, allocator2).join(' ');

--- a/test/test_runtime.js
+++ b/test/test_runtime.js
@@ -81,6 +81,12 @@ class MockExecEnvironment extends ExecEnvironment {
     get program_id() {
         return 'uuid-XXXXXXXXXXXX';
     }
+    get locale() {
+        return 'en-US';
+    }
+    get timezone() {
+        return 'America/Los_Angeles';
+    }
 
     _getFn(kind, attrs, fname) {
         return `${kind}:${fname}`;

--- a/tools/generate-parser/grammar.pegjs
+++ b/tools/generate-parser/grammar.pegjs
@@ -65,12 +65,18 @@ InitialCodeBlock = '{' code:Code '}' { return code; }
 
 Statement
   = TerminalDeclaration
+  / OptionDeclaration
   / NonTerminalDeclaration
 
 TerminalDeclaration
   = TerminalToken __ name:Identifier __ ':' __ type:CodeNoSemicolon __ ';' {
     return new Ast.TerminalStmt(name, type);
   }
+
+OptionDeclaration
+  = '$options' __ '=' __ type:CodeNoSemicolon __ ';' {
+    return new Ast.TerminalStmt('$options', type);
+}
 
 NonTerminalDeclaration
   = name:Identifier __ type:(':' __ CodeNoEqual)? '=' __ block:RuleBlock {

--- a/tools/generate-parser/index.ts
+++ b/tools/generate-parser/index.ts
@@ -40,7 +40,7 @@ function handleRule(rule : Ast.Rule,
                     typeMap : TypeMap) : ProcessedRule {
     const head = rule.head.map((h) => h.getGeneratorInput());
 
-    const bodyArgs = ['$ : $runtime.ParserInterface'];
+    const bodyArgs = [`$ : $runtime.ParserInterface<${typeMap.$options ?? 'any'}>`];
     let i = 0;
     for (const headPart of rule.head) {
         if (headPart instanceof Ast.RuleHeadPart.Terminal) {
@@ -132,8 +132,9 @@ async function main() {
     if (output === '--wsn') {
         wsnDump(grammar);
     } else {
-        const generator = new SLRParserGenerator(grammar, 'input', typeMap['input'] || 'any');
-        await writeout(firstFile.preamble, generator, fs.createWriteStream(output), output, typeMap['input'] || 'any');
+        const generator = new SLRParserGenerator(grammar, 'input', typeMap['input'] || 'any', typeMap['$options'] || 'any');
+        await writeout(firstFile.preamble, generator, fs.createWriteStream(output), output, typeMap['input'] || 'any',
+            typeMap['$options'] || 'any');
     }
 }
 main();

--- a/tools/generate-parser/javascript.ts
+++ b/tools/generate-parser/javascript.ts
@@ -34,7 +34,8 @@ export default function writeout(preamble : string,
                                  generator : slr.SLRParserGenerator,
                                  output : stream.Writable,
                                  outputPath : string,
-                                 rootType : string) {
+                                 rootType : string,
+                                 optionType : string) {
     const runtimePath = require.resolve('../../lib/utils/sr_parser_runtime');
     const runtimedir = path.relative(path.dirname(outputPath),
                                      path.dirname(runtimePath));
@@ -95,7 +96,7 @@ export default function writeout(preamble : string,
         output.write(`(${action}),\n`);
     output.write(`];\n`);
     output.write(`import * as $runtime from '${relativeruntimepath}';\n`);
-    output.write(`export default $runtime.createParser<${rootType}>({ TERMINAL_IDS, RULE_NON_TERMINALS, ARITY, GOTO, PARSER_ACTION, SEMANTIC_ACTION });\n`);
+    output.write(`export default $runtime.createParser<${rootType}, ${optionType}>({ TERMINAL_IDS, RULE_NON_TERMINALS, ARITY, GOTO, PARSER_ACTION, SEMANTIC_ACTION });\n`);
     output.end();
 
     return new Promise((resolve, reject) => {

--- a/tools/generate-parser/slr_generator.ts
+++ b/tools/generate-parser/slr_generator.ts
@@ -315,10 +315,11 @@ export class SLRParserGenerator {
     private _followSets ! : Map<string, Set<string>>;
     private _stateTransitionMatrix ! : Array<Map<string, number>>;
 
-    constructor(grammar : ProcessedGrammar, startSymbol : string, rootType : string) {
+    constructor(grammar : ProcessedGrammar, startSymbol : string, rootType : string, optionType : string) {
         // optimizations first
         this._startSymbol = startSymbol;
-        grammar[ROOT_NT.symbol] = [[[new NonTerminal(startSymbol), EOF_TOKEN], `($ : $runtime.ParserInterface, $0 : ${rootType}) : ${rootType} => $0`]];
+        grammar[ROOT_NT.symbol] = [[[new NonTerminal(startSymbol), EOF_TOKEN],
+            `($ : $runtime.ParserInterface<${optionType}>, $0 : ${rootType}) : ${rootType} => $0`]];
         this._numberRules(grammar);
         this._extractTerminalsNonTerminals();
         this._buildFirstSets();


### PR DESCRIPTION
This is part 2 of a series of fixes to decouple dates from the system timezone, which is necessary to handle dates & times correctly in the cloud. Part 1 is at https://github.com/stanford-oval/genie-toolkit/pull/783

This implements a subset of #366 containing the minimal set of changes to make alarms and reminders work. 
In both ASTs and runtime, we're still using (non-timezone-aware) legacy JS Date objects.  Use of the Temporal library is limited in specific places where we go from year-month-day-hour-minute-second of some sort to a Unix timestamp, or where we need to read/change fields on a date. 

This PR is not enough to handle relative dates correctly, but it's a start.
A later PR should get rid of JS Date entirely, and switch over completely to Temporal objects. Changing the ASTs and entity representations will be a significant change that will require a flag day in Genie, and some sort of compatibility code for existing skills.